### PR TITLE
Fix builds without Ccache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
     pull_request:
     push:
         branches:
+            # Release branches
             - main
 
 jobs:
@@ -19,14 +20,28 @@ jobs:
             - name: Checkout pizmidi
               uses: actions/checkout@v2
             - name: Ccache
-              # Builds on the main branch shall always build everything from scratch:
+              # Builds on release branches shall always build everything from scratch:
               if: ${{ github.event_name == 'pull_request' }}
               uses: hendrikmuhs/ccache-action@5801e95cf1e42288c5778844eff2a1f8e56f24cd
               with:
                   key: ${{ env.PRESET }}
                   max-size: 2048M
+            - name: Set additional options for configure step
+              run: |
+                  ADDITIONAL_CONFIGURE_OPTIONS=""
+
+                  if [ ${{ github.event_name == 'pull_request' }} = true ]; then
+                    # Use Ccache
+                    ADDITIONAL_CONFIGURE_OPTIONS="${ADDITIONAL_CONFIGURE_OPTIONS} -D CMAKE_C_COMPILER_LAUNCHER=ccache"
+                    ADDITIONAL_CONFIGURE_OPTIONS="${ADDITIONAL_CONFIGURE_OPTIONS} -D CMAKE_CXX_COMPILER_LAUNCHER=ccache"
+                  fi
+
+                  echo "Additional options for CMake are: \"${ADDITIONAL_CONFIGURE_OPTIONS}\""
+
+                  # Persist for the next steps
+                  echo "ADDITIONAL_CONFIGURE_OPTIONS=${ADDITIONAL_CONFIGURE_OPTIONS}" >> $GITHUB_ENV
             - name: Configure pizmidi
-              run: cmake -S . --preset=$PRESET -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
+              run: cmake -S . --preset=$PRESET $ADDITIONAL_CONFIGURE_OPTIONS
             - name: Build pizmidi plugins
               run: cmake --build --preset=$PRESET --parallel
             - name: Build pizmidi packages
@@ -65,8 +80,22 @@ jobs:
               with:
                   key: ${{ env.PRESET }}
                   max-size: 2048M
+            - name: Set additional options for configure step
+              run: |
+                  ADDITIONAL_CONFIGURE_OPTIONS=""
+
+                  if [ ${{ github.event_name == 'pull_request' }} = true ]; then
+                    # Use Ccache
+                    ADDITIONAL_CONFIGURE_OPTIONS="${ADDITIONAL_CONFIGURE_OPTIONS} -D CMAKE_C_COMPILER_LAUNCHER=ccache"
+                    ADDITIONAL_CONFIGURE_OPTIONS="${ADDITIONAL_CONFIGURE_OPTIONS} -D CMAKE_CXX_COMPILER_LAUNCHER=ccache"
+                  fi
+
+                  echo "Additional options for CMake are: \"${ADDITIONAL_CONFIGURE_OPTIONS}\""
+
+                  # Persist for the next steps
+                  echo "ADDITIONAL_CONFIGURE_OPTIONS=${ADDITIONAL_CONFIGURE_OPTIONS}" >> $GITHUB_ENV
             - name: Configure pizmidi
-              run: cmake -S . --preset=$PRESET -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
+              run: cmake -S . --preset=$PRESET $ADDITIONAL_CONFIGURE_OPTIONS
             - name: Build pizmidi plugins
               run: cmake --build --preset=$PRESET --parallel
             - name: Build pizmidi packages


### PR DESCRIPTION
When the Ccache step is omitted, Ccache is not available on the system
and thus must not be used as a compiler launcher.

Signed-off-by: Simon Leiner <simon@leiner.me>