### PR TITLE
MidiLooper: Fix piano roll settings init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ build/
 
 # Visual Studio
 .vs/
+
+# CLion
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
     -   some minor bugs are still present
     -   currently non-functional:
         -   MiddyMorphy
-        -   midiLooper
 -   The plugins build under macOS, Windows and Linux (tested: Ubuntu 20.04).
     -   Exceptions:
         -   "CPU and RAM" is only available for Windows

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ This project is a reboot of the legendary [pizMidi plugins](https://web.archive.
 -   midiPBCurve: Help text is never shown
 -   midiPCGUI
 -   midiStep
+-   midiLooper
 
 ### Serious problems are known
 
 -   Middy Morphy: sends nothing, UI looks very weird
--   midiLooper: Does not play back anything
 -   midiMonitor:
     -   serious performance problems when receiving a large amount of data in short time
     -   text of checkboxes is truncated

--- a/pizjuce/midiLooper/PizLooper.h
+++ b/pizjuce/midiLooper/PizLooper.h
@@ -107,6 +107,7 @@ public:
     {
         ValueTree tree ("PRSettings");
         values_.addChild (tree, 0, undo_manager_);
+        loadDefaults();
     }
 
     ValueTree& set (const Identifier& name, const var& newValue)


### PR DESCRIPTION
Add loadDefaults() call to fix piano roll initialization.
Quick test in Bitwig created midi events with play enabled and the host playing.
Beforehand the piano roll component wouldn't show up and no notes could be added.