### PR TITLE
MiddyMorphy: Fix gui init

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,18 @@ This project is a reboot of the legendary [pizMidi plugins](https://web.archive.
 -   midiCurve: Help text is never shown
 -   midiIn: Channel selector combobox only shows channel when expanded
 -   midiKeyboard: Toggle mode is not working
+-   midiLooper
 -   midiOut: Channel selector combobox only shows channel when expanded
 -   midiPads
 -   midiPBCurve: Help text is never shown
 -   midiPCGUI
 -   midiStep
--   midiLooper
 
 ### Serious problems are known
 
--   Middy Morphy: sends nothing, UI looks very weird
+-   Middy Morphy:
+    - crashes on controller delete
+    - crashes on delete of last scene (probably with auto or audit enabled)
 -   midiMonitor:
     -   serious performance problems when receiving a large amount of data in short time
     -   text of checkboxes is truncated

--- a/pizjuce/MiddyMorphy/D3CKLook.h
+++ b/pizjuce/MiddyMorphy/D3CKLook.h
@@ -6,10 +6,10 @@
 
 using namespace juce;
 
-class D3CKLook : public juce::LookAndFeel_V4
+class D3CKLook : public juce::LookAndFeel_V1
 {
 public:
-    D3CKLook() : juce::LookAndFeel_V4() {}
+    D3CKLook() : juce::LookAndFeel_V1() {}
 
     int getDefaultScrollbarWidth() override;
 

--- a/pizjuce/MiddyMorphy/MidiMorph.cpp
+++ b/pizjuce/MiddyMorphy/MidiMorph.cpp
@@ -448,8 +448,8 @@ void MidiMorph::setFromXml (juce::XmlElement* xmlData)
         this->refreshRate = options->getIntAttribute ("refreshrate", this->refreshRate);
     }
 
-    this->sendSynchronousChangeMessage();
-    this->sendSynchronousChangeMessage();
+    sendChangeMessage(&controllers);
+    sendChangeMessage(&scenes);
 
     // Bouml preserved body end 0004048D
 }
@@ -555,6 +555,7 @@ void MidiMorph::sendChangeMessage (void* ptr)
         MessageManagerLock lock;
         dispatchPendingMessages();
     }
+    currentChangeBroadcastRecipient = ptr;
     ChangeBroadcaster::sendChangeMessage();
     this->lastRecipant = ptr;
     // Bouml preserved body end 00048D0D

--- a/pizjuce/MiddyMorphy/MidiMorph.h
+++ b/pizjuce/MiddyMorphy/MidiMorph.h
@@ -136,6 +136,8 @@ public:
 
     bool needsOneRefresh();
 
+    void* currentChangeBroadcastRecipient;
+
 private:
     OwnedArray<Controller> controllers;
     Array<Scene*> selectedScenes;

--- a/pizjuce/MiddyMorphy/MidiMorphGUI.cpp
+++ b/pizjuce/MiddyMorphy/MidiMorphGUI.cpp
@@ -113,20 +113,19 @@ void MidiMorphGUI::changeListenerCallback (ChangeBroadcaster* source)
 {
     // Bouml preserved body begin 0003350D
     void* objectThatHasChanged = source;
-    OwnedArray<Scene>* scenes  = core->getScenes();
-    if (objectThatHasChanged == core->getSelectedScenes())
+    if (core->currentChangeBroadcastRecipient == core->getSelectedScenes())
     {
         this->controllerListModel->scenesSelected();
         //morphPane->setSelectedScenes(
     }
-    else if (objectThatHasChanged == core->getCursor())
+    else if (core->currentChangeBroadcastRecipient == core->getCursor())
     {
         controllerListModel->distancesChanged();
         core->saveGUIState (morphPane->getXml ("morphpanestate"));
         //    	ownerFilter->setParameterNotifyingHost(0,core->getCursorXRatio());
         //    	ownerFilter->setParameterNotifyingHost(1,core->getCursorYRatio());
     }
-    else if (objectThatHasChanged == core->getScenes())
+    else if (core->currentChangeBroadcastRecipient == core->getScenes())
     {
         morphPane->updateContent();
         if (core->scenes.size() > 0)
@@ -134,14 +133,10 @@ void MidiMorphGUI::changeListenerCallback (ChangeBroadcaster* source)
             morphPane->selectModule (core->scenes.size() - 1, true);
         }
     }
-    else if (objectThatHasChanged == core->getControllers())
+    else if (core->currentChangeBroadcastRecipient == core->getControllers())
     {
         controllerList->updateContent();
     }
-    //	else
-    //	{
-    //		repaint();
-    //	}
     else if (objectThatHasChanged == morphPaneModel)
     {
         this->resized();


### PR DESCRIPTION
Fix the initial gui:
- Quick (and probably ugly) workaround to restore the change event source in the relevant listener callback
- Also rollback of the LookAndFeel version for now

Discovered crashes on delete of controller and delete of last scene with some of the auto and audit context menu entries enabled. But at least some CC values seem to be spawned.