### PR TITLE
PizJuce + MiddyMorphy: Cleanup

### DIFF
--- a/pizjuce/AudioToCC/AudioToCC.cpp
+++ b/pizjuce/AudioToCC/AudioToCC.cpp
@@ -2,6 +2,9 @@
 #include "../_common/midistuff.h"
 #include "AudioToCCEditor.h"
 
+using juce::jlimit;
+using juce::roundToInt;
+
 EnvelopeFollower::EnvelopeFollower()
 {
     envelope = 0;
@@ -82,8 +85,8 @@ AudioToCC::AudioToCC() : envL (0),
 {
     programs = new JuceProgram[getNumPrograms()];
 
-    devices     = MidiOutput::getAvailableDevices();
-    midiOutput  = NULL;
+    devices     = juce::MidiOutput::getAvailableDevices();
+    midiOutput  = nullptr;
     lastCCL     = 0;
     lastCCR     = 0;
     oldenv[0]   = 0;
@@ -116,7 +119,7 @@ AudioToCC::AudioToCC() : envL (0),
     {
         for (int i = 0; i < getNumPrograms(); i++)
         {
-            programs[i].name = String ("Program ") + String (i + 1);
+            programs[i].name = juce::String ("Program ") + juce::String (i + 1);
         }
     }
     setCurrentProgram (0);
@@ -192,12 +195,12 @@ void AudioToCC::setParameter (int index, float newValue)
     sendChangeMessage();
 }
 
-void AudioToCC::setActiveDevice (String name)
+void AudioToCC::setActiveDevice (juce::String name)
 {
     setActiveDevice (getDeviceByName (name));
 }
 
-void AudioToCC::setActiveDevice (MidiDeviceInfo const& device)
+void AudioToCC::setActiveDevice (juce::MidiDeviceInfo const& device)
 {
     activeDevice                = device;
     programs[curProgram].device = device;
@@ -215,18 +218,18 @@ void AudioToCC::setActiveDevice (MidiDeviceInfo const& device)
         param[kDevice] = programs[curProgram].param[kDevice] = (float) index / (float) (devices.size() - 1);
         if (midiOutput)
             midiOutput->stopBackgroundThread();
-        midiOutput = MidiOutput::openDevice (device.identifier);
+        midiOutput = juce::MidiOutput::openDevice (device.identifier);
         midiOutput->startBackgroundThread();
     }
 }
 
-MidiDeviceInfo AudioToCC::getDeviceByName (String name) const
+juce::MidiDeviceInfo AudioToCC::getDeviceByName (juce::String name) const
 {
     return devices.findIf ([&] (auto const& device)
                            { return name == device.name; });
 }
 
-const String AudioToCC::getParameterName (int index)
+const juce::String AudioToCC::getParameterName (int index)
 {
     if (index == kGain)
         return "RMSGain";
@@ -282,96 +285,96 @@ const String AudioToCC::getParameterName (int index)
         return "L Gate Reset";
     else if (index == kGateResetR)
         return "R Gate Reset";
-    return String();
+    return juce::String();
 }
 
-const String AudioToCC::getParameterText (int index)
+const juce::String AudioToCC::getParameterText (int index)
 {
     if (index == kGain || index == kPeakGain)
-        return param[index] == 0.f ? String ("-inf") : String (20.f * log10 (param[index] * maxGain), 1) + " dB";
+        return param[index] == 0.f ? juce::String ("-inf") : juce::String (20.f * log10 (param[index] * maxGain), 1) + " dB";
     else if (index == kAttack)
-        return String (roundToInt (param[kAttack] * 100.f));
+        return juce::String (roundToInt (param[kAttack] * 100.f));
     else if (index == kRelease)
-        return String (roundToInt (param[kRelease] * 100.f));
+        return juce::String (roundToInt (param[kRelease] * 100.f));
     else if (index == kDevice)
     {
         if (param[kDevice] > 0.0)
             return devices[roundToInt (param[kDevice] * (devices.size() - 1))].name;
         else
-            return String ("--");
+            return juce::String ("--");
     }
     else if (index == kCCL || index == kCCR)
     {
         const int v = floatToMidi (param[index]);
-        return v < 0 ? "Off" : String (floatToMidi (param[index]));
+        return v < 0 ? "Off" : juce::String (floatToMidi (param[index]));
     }
     else if (index == kStereo)
     {
         if (param[kStereo] < 0.5f)
-            return String ("Mono (L+R)");
+            return juce::String ("Mono (L+R)");
         else
-            return String ("Stereo");
+            return juce::String ("Stereo");
     }
     else if (index == kChannel)
-        return String (roundToInt (param[index] * 15.0) + 1);
+        return juce::String (roundToInt (param[index] * 15.0) + 1);
     else if (index == kAutomateHost)
     {
         if (param[kAutomateHost] < 0.5f)
-            return String ("Off");
+            return juce::String ("Off");
         else
-            return String ("On");
+            return juce::String ("On");
     }
     else if (index == kMode)
     {
         if (param[kMode] >= 0.5f)
-            return String ("Logarithmic");
+            return juce::String ("Logarithmic");
         else
-            return String ("Linear");
+            return juce::String ("Linear");
     }
     else if (index == kMidiToHost)
     {
         if (param[kMidiToHost] < 0.5f)
-            return String ("Off");
+            return juce::String ("Off");
         else
-            return String ("On");
+            return juce::String ("On");
     }
     else if (index == kGateThreshold)
     {
         if (param[index] == 0.f)
             return "Off";
-        return String (20.f * log10 (param[index]), 1) + " dB";
+        return juce::String (20.f * log10 (param[index]), 1) + " dB";
     }
     else if (index == kGateCCL || index == kGateCCR)
     {
         const int v = floatToMidi (param[index]);
-        return v < 0 ? "Off" : String (floatToMidi (param[index]));
+        return v < 0 ? "Off" : juce::String (floatToMidi (param[index]));
     }
     else if (index == kGateOnValueCCL || index == kGateOnValueCCR)
     {
         const int v = floatToMidi (param[index]);
-        return v < 0 ? "Off" : String (floatToMidi (param[index]));
+        return v < 0 ? "Off" : juce::String (floatToMidi (param[index]));
     }
     else if (index == kGateOffValueCCL || index == kGateOffValueCCR)
     {
         const int v = floatToMidi (param[index]);
-        return v < 0 ? "Off" : String (floatToMidi (param[index]));
+        return v < 0 ? "Off" : juce::String (floatToMidi (param[index]));
     }
     else if (index == kRate)
     {
-        return String ((param[index] == 1.f ? 1.0 / getSampleRate() : (1.0f - param[index]) * 0.0025f + 0.001f) * 1000, 1) + " ms";
+        return juce::String ((param[index] == 1.f ? 1.0 / getSampleRate() : (1.0f - param[index]) * 0.0025f + 0.001f) * 1000, 1) + " ms";
     }
     else
-        return String (roundToInt (param[index] * 100.f));
+        return juce::String (roundToInt (param[index] * 100.f));
 }
 
-const String AudioToCC::getInputChannelName (const int channelIndex) const
+const juce::String AudioToCC::getInputChannelName (const int channelIndex) const
 {
-    return String (channelIndex + 1);
+    return juce::String (channelIndex + 1);
 }
 
-const String AudioToCC::getOutputChannelName (const int channelIndex) const
+const juce::String AudioToCC::getOutputChannelName (const int channelIndex) const
 {
-    return String (channelIndex + 1);
+    return juce::String (channelIndex + 1);
 }
 
 bool AudioToCC::isInputChannelStereoPair (int index) const
@@ -399,12 +402,12 @@ void AudioToCC::setCurrentProgram (int index)
     sendChangeMessage();
 }
 
-void AudioToCC::changeProgramName (int index, const String& newName)
+void AudioToCC::changeProgramName (int index, const juce::String& newName)
 {
     programs[curProgram].name = newName;
 }
 
-const String AudioToCC::getProgramName (int index)
+const juce::String AudioToCC::getProgramName (int index)
 {
     return programs[index].name;
 }
@@ -452,8 +455,8 @@ int AudioToCC::smooth (int data, int old, int older, float inertia)
     return data;
 }
 
-void AudioToCC::processBlock (AudioSampleBuffer& buffer,
-                              MidiBuffer& midiMessages)
+void AudioToCC::processBlock (juce::AudioSampleBuffer& buffer,
+                              juce::MidiBuffer& midiMessages)
 {
     for (int i = getNumInputChannels(); i < getNumOutputChannels(); ++i)
     {
@@ -488,7 +491,7 @@ void AudioToCC::processBlock (AudioSampleBuffer& buffer,
     {
         if (gateccL >= 0 && gateOffValueL >= 0)
         {
-            MidiMessage cc = MidiMessage::controllerEvent (Ch + 1, gateccL, gateOffValueL);
+            juce::MidiMessage cc = juce::MidiMessage::controllerEvent (Ch + 1, gateccL, gateOffValueL);
             if (midiOutput)
                 midiOutput->sendMessageNow (cc);
             if (param[kMidiToHost] >= 0.5f)
@@ -504,7 +507,7 @@ void AudioToCC::processBlock (AudioSampleBuffer& buffer,
     {
         if (gateccR >= 0 && gateOffValueR >= 0)
         {
-            MidiMessage cc = MidiMessage::controllerEvent (Ch + 1, gateccR, gateOffValueR);
+            juce::MidiMessage cc = juce::MidiMessage::controllerEvent (Ch + 1, gateccR, gateOffValueR);
             if (midiOutput)
                 midiOutput->sendMessageNow (cc);
             if (param[kMidiToHost] >= 0.5f)
@@ -534,7 +537,7 @@ void AudioToCC::processBlock (AudioSampleBuffer& buffer,
             {
                 if (gateOnValueL >= 0)
                 {
-                    MidiMessage cc = MidiMessage::controllerEvent (Ch + 1, gateccL, gateOnValueL);
+                    juce::MidiMessage cc = juce::MidiMessage::controllerEvent (Ch + 1, gateccL, gateOnValueL);
                     if (midiOutput)
                         midiOutput->sendMessageNow (cc);
                     if (param[kMidiToHost] >= 0.5f)
@@ -548,7 +551,7 @@ void AudioToCC::processBlock (AudioSampleBuffer& buffer,
             {
                 if (gateOffValueL >= 0)
                 {
-                    MidiMessage cc = MidiMessage::controllerEvent (Ch + 1, gateccL, gateOffValueL);
+                    juce::MidiMessage cc = juce::MidiMessage::controllerEvent (Ch + 1, gateccL, gateOffValueL);
                     if (midiOutput)
                         midiOutput->sendMessageNow (cc);
                     if (param[kMidiToHost] >= 0.5f)
@@ -601,7 +604,7 @@ void AudioToCC::processBlock (AudioSampleBuffer& buffer,
             {
                 if (ccL >= 0)
                 {
-                    MidiMessage cc (0xB0 | Ch, ccL, data2);
+                    juce::MidiMessage cc (0xB0 | Ch, ccL, data2);
                     if (midiOutput)
                         midiOutput->sendMessageNow (cc);
                     if (param[kMidiToHost] >= 0.5f)
@@ -630,7 +633,7 @@ void AudioToCC::processBlock (AudioSampleBuffer& buffer,
                 {
                     if (gateOnValueR >= 0)
                     {
-                        MidiMessage cc = MidiMessage::controllerEvent (Ch + 1, gateccR, gateOnValueR);
+                        juce::MidiMessage cc = juce::MidiMessage::controllerEvent (Ch + 1, gateccR, gateOnValueR);
                         if (midiOutput)
                             midiOutput->sendMessageNow (cc);
                         if (param[kMidiToHost] >= 0.5f)
@@ -644,7 +647,7 @@ void AudioToCC::processBlock (AudioSampleBuffer& buffer,
                 {
                     if (gateOffValueR >= 0)
                     {
-                        MidiMessage cc = MidiMessage::controllerEvent (Ch + 1, gateccR, gateOffValueR);
+                        juce::MidiMessage cc = juce::MidiMessage::controllerEvent (Ch + 1, gateccR, gateOffValueR);
                         if (midiOutput)
                             midiOutput->sendMessageNow (cc);
                         if (param[kMidiToHost] >= 0.5f)
@@ -693,7 +696,7 @@ void AudioToCC::processBlock (AudioSampleBuffer& buffer,
                 {
                     if (ccR >= 0)
                     {
-                        MidiMessage cc (0xB0 | Ch, ccR, data2);
+                        juce::MidiMessage cc (0xB0 | Ch, ccR, data2);
                         if (midiOutput)
                             midiOutput->sendMessageNow (cc);
                         if (param[kMidiToHost] >= 0.5f)
@@ -713,20 +716,20 @@ void AudioToCC::processBlock (AudioSampleBuffer& buffer,
 }
 
 //==============================================================================
-AudioProcessorEditor* AudioToCC::createEditor()
+juce::AudioProcessorEditor* AudioToCC::createEditor()
 {
     return new AudioToCCEditor (this);
 }
 
 //==============================================================================
-void AudioToCC::getStateInformation (MemoryBlock& destData)
+void AudioToCC::getStateInformation (juce::MemoryBlock& destData)
 {
-    XmlElement xmlState ("PizAudioToCCSettings");
+    juce::XmlElement xmlState ("PizAudioToCCSettings");
     xmlState.setAttribute ("pluginVersion", 3);
     xmlState.setAttribute ("program", getCurrentProgram());
     for (int p = 0; p < getNumPrograms(); p++)
     {
-        XmlElement* prog = new XmlElement ("Program");
+        auto* prog = new juce::XmlElement ("Program");
         prog->setAttribute ("index", p);
         JuceProgram* program = &programs[p];
         for (int i = 0; i < (numParams - 2); i++)

--- a/pizjuce/AudioToCC/AudioToCC.h
+++ b/pizjuce/AudioToCC/AudioToCC.h
@@ -34,11 +34,11 @@
 
 #include <memory>
 
+#include <juce_audio_devices/juce_audio_devices.h>
+#include <juce_core/juce_core.h>
+
 #include "../_common/PizArray.h"
 #include "../_common/PizAudioProcessor.h"
-
-#include "juce_audio_devices/juce_audio_devices.h"
-#include "juce_core/juce_core.h"
 
 #define goodXmlChars "abcdefghijklmnopqrstuvwxyz0123456789"
 
@@ -103,13 +103,13 @@ public:
 
 private:
     float param[numParams];
-    String name;
-    MidiDeviceInfo device;
+    juce::String name;
+    juce::MidiDeviceInfo device;
 };
 
 //==============================================================================
 class AudioToCC : public PizAudioProcessor,
-                  public ChangeBroadcaster
+                  public juce::ChangeBroadcaster
 {
 public:
     //==============================================================================
@@ -120,14 +120,14 @@ public:
     void prepareToPlay (double sampleRate, int samplesPerBlock) override;
     void releaseResources() override;
 
-    void processBlock (AudioSampleBuffer& buffer,
-                       MidiBuffer& midiMessages) override;
+    void processBlock (juce::AudioSampleBuffer& buffer,
+                       juce::MidiBuffer& midiMessages) override;
 
     //==============================================================================
-    AudioProcessorEditor* createEditor() override;
+    juce::AudioProcessorEditor* createEditor() override;
 
     //==============================================================================
-    const String getName() const override { return JucePlugin_Name; }
+    const juce::String getName() const override { return JucePlugin_Name; }
     bool hasEditor() const override { return true; }
     bool acceptsMidi() const override
     {
@@ -151,11 +151,11 @@ public:
     float getParameter (int index) override;
     void setParameter (int index, float newValue) override;
 
-    const String getParameterName (int index) override;
-    const String getParameterText (int index) override;
+    const juce::String getParameterName (int index) override;
+    const juce::String getParameterText (int index) override;
 
-    const String getInputChannelName (int channelIndex) const override;
-    const String getOutputChannelName (int channelIndex) const override;
+    const juce::String getInputChannelName (int channelIndex) const override;
+    const juce::String getOutputChannelName (int channelIndex) const override;
     bool isInputChannelStereoPair (int index) const override;
     bool isOutputChannelStereoPair (int index) const override;
     double getTailLengthSeconds() const override { return 0; }
@@ -164,27 +164,25 @@ public:
     int getNumPrograms() override { return 16; }
     int getCurrentProgram() override;
     void setCurrentProgram (int index) override;
-    const String getProgramName (int index) override;
-    void changeProgramName (int index, const String& newName) override;
+    const juce::String getProgramName (int index) override;
+    void changeProgramName (int index, const juce::String& newName) override;
 
     //==============================================================================
-    void getStateInformation (MemoryBlock& destData) override;
+    void getStateInformation (juce::MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
 
-    void setActiveDevice (String name);
-    void setActiveDevice (MidiDeviceInfo const& device);
-    MidiDeviceInfo getActiveDevice() { return activeDevice; }
-    MidiDeviceInfo getDeviceByName (String name) const;
+    void setActiveDevice (juce::String name);
+    void setActiveDevice (juce::MidiDeviceInfo const& device);
+    juce::MidiDeviceInfo getActiveDevice() { return activeDevice; }
+    juce::MidiDeviceInfo getDeviceByName (juce::String name) const;
 
-    PizArray<MidiDeviceInfo> devices;
+    PizArray<juce::MidiDeviceInfo> devices;
     int lastCCL, lastCCR;
     float lastInL, lastInR;
     bool lastGateCCL, lastGateCCR;
 
-    //==============================================================================
-    juce_UseDebuggingNewOperator
-
-        private : float param[numParams];
+private:
+    float param[numParams];
 
     unsigned int rateCounter;
     double continualRMS[numChannels];
@@ -202,12 +200,14 @@ public:
     JuceProgram* programs;
     int curProgram;
 
-    std::unique_ptr<MidiOutput> midiOutput;
-    MidiDeviceInfo activeDevice;
+    std::unique_ptr<juce::MidiOutput> midiOutput;
+    juce::MidiDeviceInfo activeDevice;
 
     float maxAttack, maxRelease;
 
     bool resetGateL, resetGateR;
+
+    JUCE_LEAK_DETECTOR (AudioToCC)
 };
 
 #endif

--- a/pizjuce/AudioToCC/AudioToCCEditor.cpp
+++ b/pizjuce/AudioToCC/AudioToCCEditor.cpp
@@ -1014,7 +1014,7 @@ void AudioToCCEditor::comboBoxChanged (juce::ComboBox* comboBoxThatHasChanged)
 }
 
 //[MiscUserCode] You can add your own definitions of your custom methods or any other code here...
-void AudioToCCEditor::changeListenerCallback (ChangeBroadcaster* source)
+void AudioToCCEditor::changeListenerCallback (juce::ChangeBroadcaster* source)
 {
     if (source == getFilter())
         updateParametersFromFilter();
@@ -1050,12 +1050,12 @@ void AudioToCCEditor::updateParametersFromFilter()
     s_OffValueR->setVSTSlider (p[kGateOffValueCCR]);
     s_Thresh->setValue (p[kGateThreshold]);
 
-    comboBox->setSelectedItemIndex (newDevice + 1, dontSendNotification);
-    toggleButton->setToggleState (p[kAutomateHost] >= 0.5f, dontSendNotification);
-    toggleButton2->setToggleState (p[kMidiToHost] >= 0.5f, dontSendNotification);
-    b_Stereo->setToggleState (p[kStereo] >= 0.5f, dontSendNotification);
+    comboBox->setSelectedItemIndex (newDevice + 1, juce::dontSendNotification);
+    toggleButton->setToggleState (p[kAutomateHost] >= 0.5f, juce::dontSendNotification);
+    toggleButton2->setToggleState (p[kMidiToHost] >= 0.5f, juce::dontSendNotification);
+    b_Stereo->setToggleState (p[kStereo] >= 0.5f, juce::dontSendNotification);
     b_Stereo->setButtonText (p[kStereo] >= 0.5f ? "Stereo" : "Mono (L+R)");
-    b_Mode->setToggleState (p[kMode] >= 0.5f, dontSendNotification);
+    b_Mode->setToggleState (p[kMode] >= 0.5f, juce::dontSendNotification);
     b_Mode->setButtonText (p[kMode] >= 0.5f ? "Logarithmic" : "Linear");
 }
 
@@ -1070,23 +1070,23 @@ void AudioToCCEditor::timerCallback()
     const bool gateR = getFilter()->lastGateCCR;
     getFilter()->getCallbackLock().exit();
 
-    s_IndicatorL->setValue (ccL, dontSendNotification);
-    s_IndicatorR->setValue (ccR, dontSendNotification);
-    s_IndicatorLIn->setValue (inL, dontSendNotification);
-    s_IndicatorRIn->setValue (inR, dontSendNotification);
+    s_IndicatorL->setValue (ccL, juce::dontSendNotification);
+    s_IndicatorR->setValue (ccR, juce::dontSendNotification);
+    s_IndicatorLIn->setValue (inL, juce::dontSendNotification);
+    s_IndicatorRIn->setValue (inR, juce::dontSendNotification);
     ++peakcounter;
     if (peakcounter == 2)
     {
         peakcounter = 0;
-        clipL->setToggleState (gateL, dontSendNotification);
-        clipR->setToggleState (gateR, dontSendNotification);
+        clipL->setToggleState (gateL, juce::dontSendNotification);
+        clipR->setToggleState (gateR, juce::dontSendNotification);
     }
     else
     {
         if (gateL)
-            clipL->setToggleState (true, dontSendNotification);
+            clipL->setToggleState (true, juce::dontSendNotification);
         if (gateR)
-            clipR->setToggleState (true, dontSendNotification);
+            clipR->setToggleState (true, juce::dontSendNotification);
     }
 }
 //[/MiscUserCode]

--- a/pizjuce/AudioToCC/AudioToCCEditor.h
+++ b/pizjuce/AudioToCC/AudioToCCEditor.h
@@ -20,42 +20,42 @@
 #pragma once
 
 //[Headers]     -- You can add your own extra header files here --
-#include "juce_core/juce_core.h"
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_core/juce_core.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
 #include "../_common/VSTSlider.h"
 #include "AudioToCC.h"
 
-class DecibelMeter : public Slider
+class DecibelMeter : public juce::Slider
 {
 public:
-    DecibelMeter (const String& name) : Slider (name)
+    DecibelMeter (const juce::String& name) : Slider (name)
     {
         this->setMouseClickGrabsKeyboardFocus (false);
         this->setInterceptsMouseClicks (false, false);
     }
     ~DecibelMeter() override {}
 
-    String getTextFromValue (double value) override
+    juce::String getTextFromValue (double value) override
     {
-        return value == 0.0 ? " " : String (20.0 * log10 (value), 1) + " dB";
+        return value == 0.0 ? " " : juce::String (20.0 * log10 (value), 1) + " dB";
     }
 };
 
-class DecibelSlider : public Slider
+class DecibelSlider : public juce::Slider
 {
 public:
-    DecibelSlider (const String& name) : Slider (name)
+    DecibelSlider (const juce::String& name) : juce::Slider (name)
     {
         this->setMouseClickGrabsKeyboardFocus (false);
     }
     ~DecibelSlider() override {}
 
-    String getTextFromValue (double value) override
+    juce::String getTextFromValue (double value) override
     {
-        return value == 0.0 ? "-inf" : String (20.0 * log10 (value), 1) + " dB";
+        return value == 0.0 ? "-inf" : juce::String (20.0 * log10 (value), 1) + " dB";
     }
-    double getValueFromText (const String& text) override
+    double getValueFromText (const juce::String& text) override
     {
         if (text.equalsIgnoreCase ("-inf"))
             return 0.0;
@@ -87,7 +87,7 @@ public:
 
     //==============================================================================
     //[UserMethods]     -- You can add your own custom methods in this section.
-    void changeListenerCallback (ChangeBroadcaster* source) override;
+    void changeListenerCallback (juce::ChangeBroadcaster* source) override;
     void timerCallback() override;
     //[/UserMethods]
 

--- a/pizjuce/BigClock/BigClock.cpp
+++ b/pizjuce/BigClock/BigClock.cpp
@@ -1,6 +1,8 @@
 #include "BigClock.h"
 #include "BigClockEditor.h"
 
+using juce::roundToInt;
+
 //==============================================================================
 /**
     This function must be implemented to create the actual plugin object that
@@ -18,7 +20,7 @@ BigClockFilter::BigClockFilter()
     runwatch     = false;
     rectime      = 0;
     watchtime    = 0;
-    plugintime   = Time::getMillisecondCounter();
+    plugintime   = juce::Time::getMillisecondCounter();
     mode         = 0;
     barsbeats    = 1.0f;
     look         = 1.0f;
@@ -33,7 +35,7 @@ BigClockFilter::BigClockFilter()
 
     sampleRate = getSampleRate();
 
-    bgcolor = Colour (0xffb8bcc0);
+    bgcolor = juce::Colour (0xffb8bcc0);
 
     zeromem (&lastPosInfo, sizeof (lastPosInfo));
     lastPosInfo.timeSigNumerator   = 4;
@@ -42,7 +44,7 @@ BigClockFilter::BigClockFilter()
 
     loadDefaultFxp();
 
-    lastTimerTime = Time::getMillisecondCounter();
+    lastTimerTime = juce::Time::getMillisecondCounter();
     startTimer (10);
 }
 
@@ -177,7 +179,7 @@ void BigClockFilter::setParameter (int index, float newValue)
     }
 }
 
-const String BigClockFilter::getParameterName (int index)
+const juce::String BigClockFilter::getParameterName (int index)
 {
     if (index == 0)
         return L"mode";
@@ -200,102 +202,102 @@ const String BigClockFilter::getParameterName (int index)
     if (index == 9)
         return L"runwatch";
     else
-        return String();
+        return juce::String();
 }
 
-const String BigClockFilter::getParameterText (int index)
+const juce::String BigClockFilter::getParameterText (int index)
 {
     if (index == 0)
     {
         if (barsbeats >= 0.5f)
-            return String (L"bar/beat/tick");
+            return juce::String (L"bar/beat/tick");
         else
-            return String (L"hour/min/sec");
+            return juce::String (L"hour/min/sec");
     }
     else if (index == 1)
-        return String (look, 2);
+        return juce::String (look, 2);
     else if (index == 2)
     {
         if (showms >= 0.5f)
-            return String (L"yes");
+            return juce::String (L"yes");
         else
-            return String (L"no");
+            return juce::String (L"no");
     }
     else if (index == 3)
     {
         if (showhrs >= 0.5f)
-            return String (L"yes");
+            return juce::String (L"yes");
         else
-            return String (L"no");
+            return juce::String (L"no");
     }
     else if (index == 4)
     {
         if (ticks == 0.0)
-            return String (L"960");
+            return juce::String (L"960");
         else if (ticks < 0.1)
-            return String (L"768");
+            return juce::String (L"768");
         else if (ticks < 0.2)
-            return String (L"480");
+            return juce::String (L"480");
         else if (ticks < 0.3)
-            return String (L"384");
+            return juce::String (L"384");
         else if (ticks < 0.4)
-            return String (L"240");
+            return juce::String (L"240");
         else if (ticks < 0.5)
-            return String (L"192");
+            return juce::String (L"192");
         else if (ticks < 0.6)
-            return String (L"120");
+            return juce::String (L"120");
         else if (ticks < 0.65)
-            return String (L"100");
+            return juce::String (L"100");
         else if (ticks < 0.7)
-            return String (L"96");
+            return juce::String (L"96");
         else if (ticks < 0.8)
-            return String (L"48");
+            return juce::String (L"48");
         else if (ticks < 0.9)
-            return String (L"16");
+            return juce::String (L"16");
         else if (ticks < 1.0)
-            return String (L"4");
+            return juce::String (L"4");
         else
-            return String (L"hide ticks");
+            return juce::String (L"hide ticks");
     }
     else if (index == 5)
     {
         if (frames == 0.0)
-            return String (L"ms (1000)");
+            return juce::String (L"ms (1000)");
         else if (frames < 0.1)
-            return String (L"10");
+            return juce::String (L"10");
         else if (frames < 0.2)
-            return String (L"15");
+            return juce::String (L"15");
         else if (frames < 0.3)
-            return String (L"24");
+            return juce::String (L"24");
         else if (frames < 0.4)
-            return String (L"25");
+            return juce::String (L"25");
         else if (frames < 0.5)
-            return String (L"29.97 Drop");
+            return juce::String (L"29.97 Drop");
         else if (frames < 0.6)
-            return String (L"30");
+            return juce::String (L"30");
         else if (frames < 0.7)
-            return String (L"50");
+            return juce::String (L"50");
         else if (frames < 0.8)
-            return String (L"60");
+            return juce::String (L"60");
         else if (frames < 0.9)
-            return String (L"75");
+            return juce::String (L"75");
         else if (frames < 1.0)
-            return String (L"100");
+            return juce::String (L"100");
         else
-            return String (L"120");
+            return juce::String (L"120");
     }
     else
-        return String();
+        return juce::String();
 }
 
-const String BigClockFilter::getInputChannelName (const int channelIndex) const
+const juce::String BigClockFilter::getInputChannelName (const int channelIndex) const
 {
-    return String (channelIndex + 1);
+    return juce::String (channelIndex + 1);
 }
 
-const String BigClockFilter::getOutputChannelName (const int channelIndex) const
+const juce::String BigClockFilter::getOutputChannelName (const int channelIndex) const
 {
-    return String (channelIndex + 1);
+    return juce::String (channelIndex + 1);
 }
 
 bool BigClockFilter::isInputChannelStereoPair (int index) const
@@ -311,7 +313,6 @@ bool BigClockFilter::isOutputChannelStereoPair (int index) const
 //==============================================================================
 void BigClockFilter::prepareToPlay (double sampleRate, int samplesPerBlock)
 {
-    // do your pre-playback setup stuff here..
     this->sampleRate = sampleRate;
 }
 
@@ -321,8 +322,8 @@ void BigClockFilter::releaseResources()
     // spare memory, etc.
 }
 
-void BigClockFilter::processBlock (AudioSampleBuffer& buffer,
-                                   MidiBuffer& midiMessages)
+void BigClockFilter::processBlock (juce::AudioSampleBuffer& buffer,
+                                   juce::MidiBuffer& midiMessages)
 {
     for (int i = getNumInputChannels(); i < getNumOutputChannels(); ++i)
     {
@@ -330,9 +331,9 @@ void BigClockFilter::processBlock (AudioSampleBuffer& buffer,
     }
 
     //sampleRate=getSampleRate();
-    AudioPlayHead::CurrentPositionInfo pos;
+    juce::AudioPlayHead::CurrentPositionInfo pos;
 
-    if (getPlayHead() != 0 && getPlayHead()->getCurrentPosition (pos))
+    if (getPlayHead() != nullptr && getPlayHead()->getCurrentPosition (pos))
     {
         if (memcmp (&pos, &lastPosInfo, sizeof (pos)) != 0)
         {
@@ -361,15 +362,15 @@ void BigClockFilter::processBlock (AudioSampleBuffer& buffer,
 }
 
 //==============================================================================
-AudioProcessorEditor* BigClockFilter::createEditor()
+juce::AudioProcessorEditor* BigClockFilter::createEditor()
 {
     return new BigClockEditor (this);
 }
 
 //==============================================================================
-void BigClockFilter::getStateInformation (MemoryBlock& destData)
+void BigClockFilter::getStateInformation (juce::MemoryBlock& destData)
 {
-    XmlElement xmlState ("MYPLUGINSETTINGS");
+    juce::XmlElement xmlState ("MYPLUGINSETTINGS");
 
     xmlState.setAttribute ("pluginVersion", 1);
     xmlState.setAttribute ("barsbeats", barsbeats);
@@ -391,7 +392,7 @@ void BigClockFilter::getStateInformation (MemoryBlock& destData)
 
     for (int i = 0; i < cues.size(); i++)
     {
-        XmlElement* xmlCue = new XmlElement ("Cue");
+        auto* xmlCue = new juce::XmlElement ("Cue");
         xmlCue->setAttribute ("time", cues[i]->time);
         xmlCue->setAttribute ("ppq", cues[i]->ppq);
         xmlCue->setAttribute ("text", cues[i]->text);
@@ -405,15 +406,15 @@ void BigClockFilter::getStateInformation (MemoryBlock& destData)
 void BigClockFilter::setStateInformation (const void* data, int sizeInBytes)
 {
     cues.clear();
-    // use this helper function to get the XML from this binary blob..
+    // use this helper function to get the XML from this binary blob
     auto const xmlState = getXmlFromBinary (data, sizeInBytes);
 
     if (xmlState != 0)
     {
-        // check that it's the right type of xml..
+        // check that it's the right type of xml
         if (xmlState->hasTagName ("MYPLUGINSETTINGS"))
         {
-            // ok, now pull out our parameters..
+            // ok, now pull out our parameters
             barsbeats  = (float) xmlState->getDoubleAttribute ("gainLeve", barsbeats);
             barsbeats  = (float) xmlState->getDoubleAttribute ("barsbeats", barsbeats);
             look       = (float) xmlState->getDoubleAttribute ("contrast", look);
@@ -431,7 +432,7 @@ void BigClockFilter::setStateInformation (const void* data, int sizeInBytes)
 
             lastUIWidth  = xmlState->getIntAttribute ("uiWidth", lastUIWidth);
             lastUIHeight = xmlState->getIntAttribute ("uiHeight", lastUIHeight);
-            bgcolor      = Colour (xmlState->getIntAttribute ("bgcolor", bgcolor.getARGB()));
+            bgcolor      = juce::Colour (xmlState->getIntAttribute ("bgcolor", bgcolor.getARGB()));
 
             for (auto* e : xmlState->getChildIterator())
             {
@@ -451,9 +452,9 @@ void BigClockFilter::setStateInformation (const void* data, int sizeInBytes)
     }
 }
 
-void BigClockFilter::saveCues (File cuefile)
+void BigClockFilter::saveCues (juce::File cuefile)
 {
-    XmlElement xmlState ("BigClockCues");
+    juce::XmlElement xmlState ("BigClockCues");
 
     double fps;
     if (getParameter (kFrames) == 0.0)
@@ -482,7 +483,7 @@ void BigClockFilter::saveCues (File cuefile)
         fps = 120.0;
     for (int i = 0; i < cues.size(); i++)
     {
-        XmlElement* xmlCue = new XmlElement ("Cue");
+        auto* xmlCue = new juce::XmlElement ("Cue");
         if (getParameter (kBarsBeats) < 0.5f)
             xmlCue->setAttribute ("time", secondsToSmpteString (cues[i]->time, fps));
         else
@@ -493,13 +494,13 @@ void BigClockFilter::saveCues (File cuefile)
     }
     if (getParameter (kBarsBeats) < 0.5f)
     {
-        XmlElement* fr = new XmlElement ("FrameRate");
+        auto* fr = new juce::XmlElement ("FrameRate");
         fr->setAttribute ("rate", fps);
         xmlState.addChildElement (fr);
     }
     else
     {
-        XmlElement* ts = new XmlElement ("TimeSig");
+        auto* ts = new juce::XmlElement ("TimeSig");
         ts->setAttribute ("numerator", lastPosInfo.timeSigNumerator);
         ts->setAttribute ("denominator", lastPosInfo.timeSigDenominator);
         xmlState.addChildElement (ts);
@@ -531,7 +532,7 @@ void BigClockFilter::saveCues (File cuefile)
             tpb = 4.0;
         else
             tpb = 0.0;
-        XmlElement* ticks = new XmlElement ("TicksPerBeat");
+        auto* ticks = new juce::XmlElement ("TicksPerBeat");
         ticks->setAttribute ("value", tpb);
         xmlState.addChildElement (ticks);
     }
@@ -539,10 +540,10 @@ void BigClockFilter::saveCues (File cuefile)
     xmlState.writeTo (cuefile);
 }
 
-void BigClockFilter::loadCues (File cuefile)
+void BigClockFilter::loadCues (juce::File cuefile)
 {
-    String xml = cuefile.loadFileAsString();
-    XmlDocument xmldoc (xml);
+    juce::String xml = cuefile.loadFileAsString();
+    juce::XmlDocument xmldoc (xml);
     auto const xmlState = xmldoc.getDocumentElement();
     if (xmlState != 0)
     {
@@ -633,7 +634,7 @@ void BigClockFilter::loadCues (File cuefile)
     }
 }
 
-void BigClockFilter::addCue (double time, double ppq, String text)
+void BigClockFilter::addCue (double time, double ppq, juce::String text)
 {
     cue* newcue = new cue (time, ppq, text);
     cues.addSorted (c, newcue);
@@ -645,7 +646,7 @@ void BigClockFilter::setCueEnabled (int index, bool state)
     cues[index]->enabled = state;
 }
 
-String BigClockFilter::getCue (double ppq, bool barsbeats)
+juce::String BigClockFilter::getCue (double ppq, bool barsbeats)
 {
     for (int i = cues.size() - 1; i >= 0; i--)
     {
@@ -678,7 +679,7 @@ String BigClockFilter::getCue (double ppq, bool barsbeats)
             }
         }
     }
-    return String();
+    return juce::String();
 }
 
 const double BigClockFilter::secondsToPpq (const double seconds, const double bpm)
@@ -687,11 +688,11 @@ const double BigClockFilter::secondsToPpq (const double seconds, const double bp
 }
 
 //==============================================================================
-const String BigClockFilter::ppqToString (const double sppq,
-                                          const int numerator,
-                                          const int denominator,
-                                          const double bpm,
-                                          const bool mode)
+const juce::String BigClockFilter::ppqToString (const double sppq,
+                                                const int numerator,
+                                                const int denominator,
+                                                const double bpm,
+                                                const bool mode)
 {
     if (numerator == 0 || denominator == 0)
         return L"1|1|0";
@@ -770,15 +771,15 @@ const String BigClockFilter::ppqToString (const double sppq,
         ticks = (int) tpb - ticks - 1;
     }
 
-    long double seconds = (long double) (sppq * 60.0 / bpm);
+    auto seconds = (long double) (sppq * 60.0 / bpm);
     //if (playing) seconds = sec;
     //else seconds =
 
-    const long double absSecs = fabs (seconds);
-    const uint64 samples      = roundToInt (sampleRate * absSecs);
+    const long double absSecs  = fabs (seconds);
+    const juce::uint64 samples = roundToInt (sampleRate * absSecs);
 
     if (getParameter (kSamples))
-        return sign + String (samples);
+        return sign + juce::String (samples);
     else
     {
         int hours;
@@ -795,68 +796,68 @@ const String BigClockFilter::ppqToString (const double sppq,
             mins = (int) (absSecs / 60.0);
         const int secs = ((int) absSecs) % 60;
 
-        String s1;
+        juce::String s1;
         if (showhrs)
         {
             if (showms)
             {
                 if (fps == 1000.0)
-                    s1 = String::formatted (L"%s%02d:%02d:%02d.%03d",
-                                            sign,
-                                            hours,
-                                            mins,
-                                            secs,
-                                            int64 (absSecs * 1000) % 1000);
+                    s1 = juce::String::formatted (L"%s%02d:%02d:%02d.%03d",
+                                                  sign,
+                                                  hours,
+                                                  mins,
+                                                  secs,
+                                                  juce::int64 (absSecs * 1000) % 1000);
                 else if (fps <= 10.0)
-                    s1 = String::formatted (L"%s%02d:%02d:%02d:%.1d",
-                                            sign,
-                                            hours,
-                                            mins,
-                                            secs,
-                                            int64 (absSecs * fps) % (int) fps);
+                    s1 = juce::String::formatted (L"%s%02d:%02d:%02d:%.1d",
+                                                  sign,
+                                                  hours,
+                                                  mins,
+                                                  secs,
+                                                  juce::int64 (absSecs * fps) % (int) fps);
                 else if (fps <= 100.0)
                 {
                     if (dropframe)
                     {
-                        int64 frameNumber = int64 (absSecs * 29.97);
+                        auto frameNumber = juce::int64 (absSecs * 29.97);
                         frameNumber += 18 * (frameNumber / 17982) + 2 * (((frameNumber % 17982) - 2) / 1798);
                         int frames   = int (frameNumber % 30);
                         int dseconds = int ((frameNumber / 30) % 60);
                         int dminutes = int (((frameNumber / 30) / 60) % 60);
                         int dhours   = int ((((frameNumber / 30) / 60) / 60) % 24);
 
-                        s1 = String::formatted (L"%s%02d;%02d;%02d;%.2d",
-                                                sign,
-                                                dhours,
-                                                dminutes,
-                                                dseconds,
-                                                frames);
+                        s1 = juce::String::formatted (L"%s%02d;%02d;%02d;%.2d",
+                                                      sign,
+                                                      dhours,
+                                                      dminutes,
+                                                      dseconds,
+                                                      frames);
                     }
                     else
-                        s1 = String::formatted (L"%s%02d:%02d:%02d:%.2d",
-                                                sign,
-                                                hours,
-                                                mins,
-                                                secs,
-                                                int64 (absSecs * fps) % (int) fps);
+                        s1 = juce::String::formatted (L"%s%02d:%02d:%02d:%.2d",
+                                                      sign,
+                                                      hours,
+                                                      mins,
+                                                      secs,
+                                                      juce::int64 (absSecs * fps) % (int) fps);
                 }
                 else
-                    s1 = String::formatted (L"%s%02d:%02d:%02d:%03d",
-                                            sign,
-                                            hours,
-                                            mins,
-                                            secs,
-                                            int64 (absSecs * fps) % (int) fps);
+                    s1 = juce::String::formatted (L"%s%02d:%02d:%02d:%03d",
+                                                  sign,
+                                                  hours,
+                                                  mins,
+                                                  secs,
+                                                  juce::int64 (absSecs * fps) % (int) fps);
                 if (showsubfr >= 0.5f)
-                    s1 += String (L"::") + String::formatted (L"%02d", (int64 (absSecs * fps * 100.0) % 100));
+                    s1 += juce::String (L"::") + juce::String::formatted (L"%02d", (juce::int64 (absSecs * fps * 100.0) % 100));
             }
             else
             {
-                s1 = String::formatted (L"%s%02d:%02d:%02d",
-                                        sign,
-                                        hours,
-                                        mins,
-                                        secs);
+                s1 = juce::String::formatted (L"%s%02d:%02d:%02d",
+                                              sign,
+                                              hours,
+                                              mins,
+                                              secs);
             }
         }
         else
@@ -864,59 +865,59 @@ const String BigClockFilter::ppqToString (const double sppq,
             if (showms)
             {
                 if (fps == 1000.0)
-                    s1 = String::formatted (L"%s%d:%02d.%03d",
-                                            sign,
-                                            mins,
-                                            secs,
-                                            int64 (absSecs * 1000) % 1000);
+                    s1 = juce::String::formatted (L"%s%d:%02d.%03d",
+                                                  sign,
+                                                  mins,
+                                                  secs,
+                                                  juce::int64 (absSecs * 1000) % 1000);
                 else if (fps <= 10.0)
-                    s1 = String::formatted (L"%s%d:%02d:%.1d",
-                                            sign,
-                                            mins,
-                                            secs,
-                                            int64 (absSecs * fps) % (int) fps);
+                    s1 = juce::String::formatted (L"%s%d:%02d:%.1d",
+                                                  sign,
+                                                  mins,
+                                                  secs,
+                                                  juce::int64 (absSecs * fps) % (int) fps);
                 else if (fps <= 100.0)
                 {
                     if (dropframe)
                     {
-                        int64 frameNumber = int64 (absSecs * 29.97);
+                        auto frameNumber = juce::int64 (absSecs * 29.97);
                         frameNumber += 18 * (frameNumber / 17982) + 2 * (((frameNumber % 17982) - 2) / 1798);
                         int frames   = int (frameNumber % 30);
                         int dseconds = int ((frameNumber / 30) % 60);
                         int dminutes = int (((frameNumber / 30) / 60) % 60);
 
-                        s1 = String::formatted (L"%s%d:%02d;%.2d",
-                                                sign,
-                                                dminutes,
-                                                dseconds,
-                                                frames);
+                        s1 = juce::String::formatted (L"%s%d:%02d;%.2d",
+                                                      sign,
+                                                      dminutes,
+                                                      dseconds,
+                                                      frames);
                     }
                     else
-                        s1 = String::formatted (L"%s%d:%02d:%.2d",
-                                                sign,
-                                                mins,
-                                                secs,
-                                                int64 (absSecs * fps) % (int) fps);
+                        s1 = juce::String::formatted (L"%s%d:%02d:%.2d",
+                                                      sign,
+                                                      mins,
+                                                      secs,
+                                                      juce::int64 (absSecs * fps) % (int) fps);
                 }
                 else
-                    s1 = String::formatted (L"%s%d:%02d:%03d",
-                                            sign,
-                                            mins,
-                                            secs,
-                                            int64 (absSecs * fps) % (int) fps);
+                    s1 = juce::String::formatted (L"%s%d:%02d:%03d",
+                                                  sign,
+                                                  mins,
+                                                  secs,
+                                                  juce::int64 (absSecs * fps) % (int) fps);
                 if (showsubfr >= 0.5f)
-                    s1 += String (L"::") + String::formatted (L"%02d", (int64 (absSecs * fps * 100.0) % 100));
+                    s1 += juce::String (L"::") + juce::String::formatted (L"%02d", (juce::int64 (absSecs * fps * 100.0) % 100));
             }
             else
             {
-                s1 = String::formatted (L"%s%d:%02d",
-                                        sign,
-                                        mins,
-                                        secs);
+                s1 = juce::String::formatted (L"%s%d:%02d",
+                                              sign,
+                                              mins,
+                                              secs);
             }
         }
 
-        String padding = String();
+        juce::String padding = juce::String();
         if (ticks < 10 && tpb > 100.0)
             padding = L"00";
         else if (ticks < 100 && tpb > 100.0)
@@ -924,7 +925,7 @@ const String BigClockFilter::ppqToString (const double sppq,
         else if (ticks < 10 && tpb >= 10.0)
             padding = L"0";
 
-        String s;
+        juce::String s;
         if (tpb > 0.0)
             s << (bar == 0 ? L"" : sign) << bar << L"|" << beat << L"|" << padding << ticks;
         else
@@ -936,9 +937,9 @@ const String BigClockFilter::ppqToString (const double sppq,
     }
 }
 
-double BigClockFilter::smpteStringToSeconds (String smpte, double fps)
+double BigClockFilter::smpteStringToSeconds (juce::String smpte, double fps)
 {
-    StringArray smpteArray;
+    juce::StringArray smpteArray;
     smpteArray.addTokens (smpte, ":;", "");
     return smpteArray[0].getDoubleValue() * 60 * 60 //hours
          + smpteArray[1].getDoubleValue() * 60      //minutes
@@ -946,7 +947,7 @@ double BigClockFilter::smpteStringToSeconds (String smpte, double fps)
          + smpteArray[3].getDoubleValue() / fps;    //frames
 }
 
-String BigClockFilter::secondsToSmpteString (double seconds, double fps)
+juce::String BigClockFilter::secondsToSmpteString (double seconds, double fps)
 {
     if (fps < 0)
     {
@@ -988,38 +989,38 @@ String BigClockFilter::secondsToSmpteString (double seconds, double fps)
     {
         if (fps == 29.97)
         {
-            int64 frameNumber = int64 (seconds * 29.97);
+            auto frameNumber = juce::int64 (seconds * 29.97);
             frameNumber += 18 * (frameNumber / 17982) + 2 * (((frameNumber % 17982) - 2) / 1798);
             int frames   = int (frameNumber % 30);
             int dseconds = int ((frameNumber / 30) % 60);
             int dminutes = int (((frameNumber / 30) / 60) % 60);
             int dhours   = int ((((frameNumber / 30) / 60) / 60) % 24);
 
-            return String::formatted (L"%s%02d;%02d;%02d;%.2d",
-                                      sign,
-                                      dhours,
-                                      dminutes,
-                                      dseconds,
-                                      frames);
+            return juce::String::formatted (L"%s%02d;%02d;%02d;%.2d",
+                                            sign,
+                                            dhours,
+                                            dminutes,
+                                            dseconds,
+                                            frames);
         }
         else
-            return String::formatted (L"%s%02d:%02d:%02d:%.2d",
-                                      sign,
-                                      hours,
-                                      mins,
-                                      secs,
-                                      int64 (absSecs * fps) % (int) fps);
+            return juce::String::formatted (L"%s%02d:%02d:%02d:%.2d",
+                                            sign,
+                                            hours,
+                                            mins,
+                                            secs,
+                                            juce::int64 (absSecs * fps) % (int) fps);
     }
     else
-        return String::formatted (L"%s%02d:%02d:%02d:%03d",
-                                  sign,
-                                  hours,
-                                  mins,
-                                  secs,
-                                  int64 (absSecs * fps) % (int) fps);
+        return juce::String::formatted (L"%s%02d:%02d:%02d:%03d",
+                                        sign,
+                                        hours,
+                                        mins,
+                                        secs,
+                                        juce::int64 (absSecs * fps) % (int) fps);
 }
 
-double BigClockFilter::barsbeatsStringToPpq (String barsbeats, int n, int d)
+double BigClockFilter::barsbeatsStringToPpq (juce::String barsbeats, int n, int d)
 {
     float tpb;
     if (getParameter (kTicks) == 0.0)
@@ -1049,14 +1050,14 @@ double BigClockFilter::barsbeatsStringToPpq (String barsbeats, int n, int d)
     else
         tpb = 0.0;
 
-    StringArray smpteArray;
+    juce::StringArray smpteArray;
     smpteArray.addTokens (barsbeats, ":", "");
     const double ppqPerBar  = ((double) n * 4.0 / (double) d);
     const double ppqPerBeat = 4.0 / (double) d;
     return (smpteArray[0].getIntValue() - 1) * ppqPerBar + (smpteArray[1].getIntValue() - 1) * ppqPerBeat + smpteArray[2].getDoubleValue() / tpb;
 }
 
-String BigClockFilter::ppqToBarsbeatsString (double ppq, int n, int d)
+juce::String BigClockFilter::ppqToBarsbeatsString (double ppq, int n, int d)
 {
     const double ppqPerBar = ((double) n * 4.0 / (double) d);
     double beats           = (fmod (ppq, ppqPerBar) / ppqPerBar) * n;
@@ -1093,7 +1094,7 @@ String BigClockFilter::ppqToBarsbeatsString (double ppq, int n, int d)
     const int beat  = ((int) beats) + 1;
     const int ticks = ((int) (fmod (beats, 1.0) * tpb));
 
-    String padding = String();
+    juce::String padding = juce::String();
     if (ticks < 10 && tpb > 100.0)
         padding = L"00";
     else if (ticks < 100 && tpb > 100.0)
@@ -1101,7 +1102,7 @@ String BigClockFilter::ppqToBarsbeatsString (double ppq, int n, int d)
     else if (ticks < 10 && tpb >= 10.0)
         padding = L"0";
 
-    String s;
+    juce::String s;
     if (tpb > 0.0)
         s << bar << L":" << beat << L":" << padding << ticks;
     else
@@ -1112,6 +1113,6 @@ String BigClockFilter::ppqToBarsbeatsString (double ppq, int n, int d)
 void BigClockFilter::timerCallback()
 {
     if (runwatch)
-        watchtime += Time::getMillisecondCounter() - lastTimerTime;
-    lastTimerTime = Time::getMillisecondCounter();
+        watchtime += juce::Time::getMillisecondCounter() - lastTimerTime;
+    lastTimerTime = juce::Time::getMillisecondCounter();
 }

--- a/pizjuce/BigClock/BigClock.h
+++ b/pizjuce/BigClock/BigClock.h
@@ -1,8 +1,9 @@
 #ifndef BIGCLOCK_PLUGINFILTER_H
 #define BIGCLOCK_PLUGINFILTER_H
 
+#include <juce_events/juce_events.h>
+
 #include "../_common/PizAudioProcessor.h"
-#include "juce_events/juce_events.h"
 
 enum parameters
 {
@@ -57,15 +58,15 @@ public:
         }
         return 3600.0 * (long double) hr + 60.0 * (long double) mn + (long double) sc + (long double) (fr / rate);
     }
-    int64 getCurrentFrame()
+    juce::int64 getCurrentFrame()
     {
         if (rate == 29.97)
         {
-            int64 frameNumber = int64 (this->getTimeInSeconds() * rate);
+            auto frameNumber = juce::int64 (this->getTimeInSeconds() * rate);
             frameNumber += 18 * (frameNumber / 17982) + 2 * (((frameNumber % 17982) - 2) / 1798);
             return frameNumber;
         }
-        return int64 (this->getTimeInSeconds() * rate);
+        return juce::int64 (this->getTimeInSeconds() * rate);
     }
     int getSubFrames()
     {
@@ -85,16 +86,16 @@ class cue
 public:
     double time;
     double ppq;
-    String text;
+    juce::String text;
     bool enabled;
     cue()
     {
         time    = 0.0;
-        text    = String();
+        text    = juce::String();
         ppq     = 0.0;
         enabled = true;
     }
-    cue (double t, double p, String s, bool e = true)
+    cue (double t, double p, juce::String s, bool e = true)
     {
         time    = t;
         text    = s;
@@ -120,8 +121,8 @@ public:
 
 */
 class BigClockFilter : public PizAudioProcessor,
-                       public ChangeBroadcaster,
-                       public Timer
+                       public juce::ChangeBroadcaster,
+                       public juce::Timer
 {
 public:
     //==============================================================================
@@ -132,14 +133,14 @@ public:
     void prepareToPlay (double sampleRate, int samplesPerBlock) override;
     void releaseResources() override;
 
-    void processBlock (AudioSampleBuffer& buffer,
-                       MidiBuffer& midiMessages) override;
+    void processBlock (juce::AudioSampleBuffer& buffer,
+                       juce::MidiBuffer& midiMessages) override;
 
     //==============================================================================
-    AudioProcessorEditor* createEditor() override;
+    juce::AudioProcessorEditor* createEditor() override;
 
     //==============================================================================
-    const String getName() const override { return JucePlugin_Name; }
+    const juce::String getName() const override { return JucePlugin_Name; }
     double getTailLengthSeconds() const override { return 0; }
     bool hasEditor() const override { return true; }
     bool acceptsMidi() const override
@@ -164,11 +165,11 @@ public:
     float getParameter (int index) override;
     void setParameter (int index, float newValue) override;
 
-    const String getParameterName (int index) override;
-    const String getParameterText (int index) override;
+    const juce::String getParameterName (int index) override;
+    const juce::String getParameterText (int index) override;
 
-    const String getInputChannelName (int channelIndex) const override;
-    const String getOutputChannelName (int channelIndex) const override;
+    const juce::String getInputChannelName (int channelIndex) const override;
+    const juce::String getOutputChannelName (int channelIndex) const override;
     bool isInputChannelStereoPair (int index) const override;
     bool isOutputChannelStereoPair (int index) const override;
 
@@ -176,11 +177,11 @@ public:
     int getNumPrograms() override { return 1; }
     int getCurrentProgram() override { return 0; }
     void setCurrentProgram (int index) override {}
-    const String getProgramName (int index) override { return String(); }
-    void changeProgramName (int index, const String& newName) override {}
+    const juce::String getProgramName (int index) override { return juce::String(); }
+    void changeProgramName (int index, const juce::String& newName) override {}
 
     //==============================================================================
-    void getStateInformation (MemoryBlock& destData) override;
+    void getStateInformation (juce::MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
 
     void timerCallback() override;
@@ -189,11 +190,11 @@ public:
     // These properties are public so that our editor component can access them
     //  - a bit of a hacky way to do it, but it's only a demo!
 
-    Colour bgcolor;
+    juce::Colour bgcolor;
 
     // this keeps a copy of the last set of time info that was acquired during an audio
     // callback - the UI component will read this and display it.
-    AudioPlayHead::CurrentPositionInfo lastPosInfo;
+    juce::AudioPlayHead::CurrentPositionInfo lastPosInfo;
 
     // these are used to persist the UI's size - the values are stored along with the
     // filter's other parameters, and the UI component will update them when it gets
@@ -201,34 +202,32 @@ public:
     int lastUIWidth, lastUIHeight;
     double sampleRate;
     double rectime;
-    uint32 plugintime;
-    uint32 watchtime; //stopwatch start time
+    juce::uint32 plugintime;
+    juce::uint32 watchtime; //stopwatch start time
     int mode;
 
-    OwnedArray<cue> cues;
+    juce::OwnedArray<cue> cues;
     //cue cues[128];
     bool showcues;
-    void addCue (double time, double ppq, String text);
-    String getCue (double ppq, bool barsbeats);
+    void addCue (double time, double ppq, juce::String text);
+    juce::String getCue (double ppq, bool barsbeats);
     void setCueEnabled (int index, bool state);
     const double secondsToPpq (const double seconds, const double bpm);
-    const String ppqToString (const double sppq,
-                              const int numerator,
-                              const int denominator,
-                              const double bpm,
-                              const bool mode);
-    void saveCues (File cuefile);
-    void loadCues (File cuefile);
+    const juce::String ppqToString (const double sppq,
+                                    const int numerator,
+                                    const int denominator,
+                                    const double bpm,
+                                    const bool mode);
+    void saveCues (juce::File cuefile);
+    void loadCues (juce::File cuefile);
 
-    double smpteStringToSeconds (String smpte, double fps);
-    String secondsToSmpteString (double seconds, double fps);
-    double barsbeatsStringToPpq (String barsbeats, int n = 4, int d = 4);
-    String ppqToBarsbeatsString (double ppq, int n = 4, int d = 4);
+    double smpteStringToSeconds (juce::String smpte, double fps);
+    juce::String secondsToSmpteString (double seconds, double fps);
+    double barsbeatsStringToPpq (juce::String barsbeats, int n = 4, int d = 4);
+    juce::String ppqToBarsbeatsString (double ppq, int n = 4, int d = 4);
 
-    //==============================================================================
-    juce_UseDebuggingNewOperator
-
-        private : float barsbeats;
+private:
+    float barsbeats;
     float look;
     float showms;
     float showhrs;
@@ -239,9 +238,11 @@ public:
     bool runwatch;
 
     bool recording;
-    uint32 lastTimerTime;
+    juce::uint32 lastTimerTime;
 
     compareCues c;
+
+    JUCE_LEAK_DETECTOR (BigClockFilter)
 };
 
 #endif

--- a/pizjuce/BigClock/BigClockEditor.cpp
+++ b/pizjuce/BigClock/BigClockEditor.cpp
@@ -1,10 +1,13 @@
 #include "BigClockEditor.h"
 
+using juce::jmin;
+using juce::roundToInt;
+
 TimeDisplay::TimeDisplay()
-    : Button (String())
+    : Button (juce::String())
 {
     setSize (600, 400);
-    textcolor = Colour (0xff000000);
+    textcolor = juce::Colour (0xff000000);
     setMouseClickGrabsKeyboardFocus (false);
 }
 
@@ -13,16 +16,16 @@ TimeDisplay::~TimeDisplay()
 }
 
 //==============================================================================
-void TimeDisplay::paintButton (Graphics& g, bool isMouseOverButton, bool isButtonDown)
+void TimeDisplay::paintButton (juce::Graphics& g, bool isMouseOverButton, bool isButtonDown)
 {
     g.setColour (textcolor);
-    g.setFont (Font (jmin ((float) getHeight() * .95f, (float) getWidth() * .16f), Font::bold));
+    g.setFont (juce::Font (jmin ((float) getHeight() * .95f, (float) getWidth() * .16f), juce::Font::bold));
     g.drawFittedText (time,
                       0,
                       0,
                       getWidth(),
                       getHeight(),
-                      Justification::centred,
+                      juce::Justification::centred,
                       true);
 }
 
@@ -36,45 +39,45 @@ BigClockEditor::BigClockEditor (BigClockFilter* const ownerFilter)
     : AudioProcessorEditor (ownerFilter),
       showtextbox (ownerFilter->showcues)
 {
-    addChildComponent (modeLabel = new Label ("Mode Label", String()));
+    addChildComponent (modeLabel = new juce::Label ("Mode Label", juce::String()));
     modeLabel->setMouseClickGrabsKeyboardFocus (false);
-    modeLabel->setFont (Font (12.f, Font::bold));
-    modeLabel->setJustificationType (Justification::topRight);
+    modeLabel->setFont (juce::Font (12.f, juce::Font::bold));
+    modeLabel->setJustificationType (juce::Justification::topRight);
 
     addAndMakeVisible (infoLabel = new TimeDisplay());
     infoLabel->addListener (this);
     infoLabel->addMouseListener (this, false);
 
-    colourSelector = new ColourSelector (ColourSelector::showColourAtTop | ColourSelector::showSliders | ColourSelector::showColourspace);
-    colourSelector->setName (String (L"color"));
+    colourSelector = new juce::ColourSelector (juce::ColourSelector::showColourAtTop | juce::ColourSelector::showSliders | juce::ColourSelector::showColourspace);
+    colourSelector->setName (juce::String (L"color"));
     colourSelector->setCurrentColour (getFilter()->bgcolor);
     colourSelector->addChangeListener (this);
 
-    addAndMakeVisible (textBox = new TextEditor());
+    addAndMakeVisible (textBox = new juce::TextEditor());
     textBox->setMultiLine (false);
     textBox->setReturnKeyStartsNewLine (false);
     textBox->setReadOnly (false);
     textBox->setScrollbarsShown (false);
     textBox->setCaretVisible (true);
     textBox->setPopupMenuEnabled (true);
-    textBox->setText (String());
+    textBox->setText (juce::String());
     textBox->addListener (this);
 
-    addAndMakeVisible (cueLabel = new Label ("Cue Label", String()));
+    addAndMakeVisible (cueLabel = new juce::Label ("Cue Label", juce::String()));
 
-    addAndMakeVisible (runButton = new TextButton ("Run"));
+    addAndMakeVisible (runButton = new juce::TextButton ("Run"));
     runButton->setMouseClickGrabsKeyboardFocus (false);
     runButton->setButtonText (">");
-    runButton->setConnectedEdges (Button::ConnectedOnLeft | Button::ConnectedOnRight);
+    runButton->setConnectedEdges (juce::Button::ConnectedOnLeft | juce::Button::ConnectedOnRight);
     runButton->addListener (this);
 
-    addAndMakeVisible (resetButton = new TextButton ("Reset"));
+    addAndMakeVisible (resetButton = new juce::TextButton ("Reset"));
     resetButton->setMouseClickGrabsKeyboardFocus (false);
     resetButton->setButtonText ("0");
-    resetButton->setConnectedEdges (Button::ConnectedOnLeft | Button::ConnectedOnRight);
+    resetButton->setConnectedEdges (juce::Button::ConnectedOnLeft | juce::Button::ConnectedOnRight);
     resetButton->addListener (this);
 
-    addAndMakeVisible (resizer = new ResizableCornerComponent (this, &resizeLimits));
+    addAndMakeVisible (resizer = new juce::ResizableCornerComponent (this, &resizeLimits));
     resizer->setMouseClickGrabsKeyboardFocus (false);
     resizeLimits.setSizeLimits (10, 10, 1200, 200);
 
@@ -92,7 +95,7 @@ BigClockEditor::~BigClockEditor()
 }
 
 //==============================================================================
-void BigClockEditor::paint (Graphics& g)
+void BigClockEditor::paint (juce::Graphics& g)
 {
     g.fillAll (getFilter()->bgcolor);
 }
@@ -125,15 +128,15 @@ void BigClockEditor::resized()
     getFilter()->lastUIHeight = getHeight();
 }
 
-void BigClockEditor::buttonStateChanged (Button* buttonThatWasClicked)
+void BigClockEditor::buttonStateChanged (juce::Button* buttonThatWasClicked)
 {
     if (buttonThatWasClicked->isDown())
     {
-        ModifierKeys mousebutton = ModifierKeys::getCurrentModifiers();
+        juce::ModifierKeys mousebutton = juce::ModifierKeys::getCurrentModifiers();
         if (mousebutton.isPopupMenu())
         {
             bool samplemode = getFilter()->getParameter (kSamples) >= 0.5f;
-            PopupMenu m, sub1, sub2, sub3, sub4, clockmode;
+            juce::PopupMenu m, sub1, sub2, sub3, sub4, clockmode;
             sub1.addCustomItem (-1, *colourSelector, 300, 300, false);
             m.addSubMenu (L"Color", sub1);
             m.addSeparator();
@@ -332,7 +335,7 @@ void BigClockEditor::buttonStateChanged (Button* buttonThatWasClicked)
                     else if (getFilter()->mode == RecTimeMode)
                         getFilter()->rectime = 0;
                     else if (getFilter()->mode == PluginTimeMode)
-                        getFilter()->plugintime = Time::getMillisecondCounter();
+                        getFilter()->plugintime = juce::Time::getMillisecondCounter();
                 }
 
                 else if (result == 998)
@@ -344,24 +347,24 @@ void BigClockEditor::buttonStateChanged (Button* buttonThatWasClicked)
                 }
                 else if (result == 996)
                 {
-                    FileChooser myChooser ("Import cue file...",
-                                           File (getFilter()->getCurrentPath()),
-                                           "*.xml");
+                    juce::FileChooser myChooser ("Import cue file...",
+                                                 juce::File (getFilter()->getCurrentPath()),
+                                                 "*.xml");
 
                     if (myChooser.browseForFileToOpen())
                     {
-                        File file (myChooser.getResult());
+                        juce::File file (myChooser.getResult());
                         getFilter()->loadCues (file);
                     }
                 }
                 else if (result == 997)
                 {
-                    FileChooser myChooser ("Export cue file...",
-                                           File (getFilter()->getCurrentPath() + File::getSeparatorString() + "cues.xml"));
+                    juce::FileChooser myChooser ("Export cue file...",
+                                                 juce::File (getFilter()->getCurrentPath() + juce::File::getSeparatorString() + "cues.xml"));
 
                     if (myChooser.browseForFileToSave (true))
                     {
-                        File cuefile (myChooser.getResult());
+                        juce::File cuefile (myChooser.getResult());
                         if (! cuefile.hasFileExtension ("xml"))
                             cuefile = cuefile.withFileExtension ("xml");
 
@@ -371,7 +374,7 @@ void BigClockEditor::buttonStateChanged (Button* buttonThatWasClicked)
                 else if (result == 999)
                 {
                     getFilter()->cues.clear();
-                    cueLabel->setText (String(), dontSendNotification);
+                    cueLabel->setText (juce::String(), juce::dontSendNotification);
                 }
                 else if (result >= 1000)
                 {
@@ -382,9 +385,9 @@ void BigClockEditor::buttonStateChanged (Button* buttonThatWasClicked)
         }
     }
 }
-void BigClockEditor::buttonClicked (Button* buttonThatWasClicked)
+void BigClockEditor::buttonClicked (juce::Button* buttonThatWasClicked)
 {
-    ModifierKeys mousebutton = ModifierKeys::getCurrentModifiers();
+    juce::ModifierKeys mousebutton = juce::ModifierKeys::getCurrentModifiers();
     if (! mousebutton.isPopupMenu())
     {
         if (buttonThatWasClicked == runButton)
@@ -419,7 +422,7 @@ void BigClockEditor::buttonClicked (Button* buttonThatWasClicked)
     }
 }
 
-void BigClockEditor::textEditorReturnKeyPressed (TextEditor& editor)
+void BigClockEditor::textEditorReturnKeyPressed (juce::TextEditor& editor)
 {
     if (textBox->getText().isNotEmpty())
     {
@@ -436,17 +439,17 @@ void BigClockEditor::timerCallback()
         updateParametersFromFilter();
 }
 
-void BigClockEditor::mouseEnter (const MouseEvent& e)
+void BigClockEditor::mouseEnter (const juce::MouseEvent& e)
 {
     modeLabel->setVisible (true);
 }
 
-void BigClockEditor::mouseExit (const MouseEvent& e)
+void BigClockEditor::mouseExit (const juce::MouseEvent& e)
 {
     modeLabel->setVisible (false);
 }
 
-void BigClockEditor::changeListenerCallback (ChangeBroadcaster* source)
+void BigClockEditor::changeListenerCallback (juce::ChangeBroadcaster* source)
 {
     if (source == getFilter())
     {
@@ -454,7 +457,7 @@ void BigClockEditor::changeListenerCallback (ChangeBroadcaster* source)
     }
     else
     {
-        ColourSelector* cs = (ColourSelector*) source;
+        auto* cs = (juce::ColourSelector*) source;
         if (cs)
         {
             getFilter()->bgcolor = (cs->getCurrentColour());
@@ -470,7 +473,7 @@ void BigClockEditor::updateParametersFromFilter()
     BigClockFilter* const filter = getFilter();
 
     filter->getCallbackLock().enter();
-    const AudioPlayHead::CurrentPositionInfo positionInfo (filter->lastPosInfo);
+    const juce::AudioPlayHead::CurrentPositionInfo positionInfo (filter->lastPosInfo);
     barsbeats               = filter->getParameter (kBarsBeats) >= 0.5f;
     const float clockmode   = filter->getParameter (kClockMode);
     const bool watchrunning = filter->getParameter (kRunWatch) >= 0.5f;
@@ -483,7 +486,7 @@ void BigClockEditor::updateParametersFromFilter()
     {
         case HostTimeMode:
             hosttime = true;
-            modeLabel->setText ("Host Timeline", dontSendNotification);
+            modeLabel->setText ("Host Timeline", juce::dontSendNotification);
             infoLabel->time = filter->ppqToString (positionInfo.ppqPosition,
                                                    positionInfo.timeSigNumerator,
                                                    positionInfo.timeSigDenominator,
@@ -492,7 +495,7 @@ void BigClockEditor::updateParametersFromFilter()
             break;
         case RecTimeMode:
             hosttime = false;
-            modeLabel->setText ("Recording Time", dontSendNotification);
+            modeLabel->setText ("Recording Time", juce::dontSendNotification);
             infoLabel->time = filter->ppqToString (filter->secondsToPpq (filter->rectime, positionInfo.bpm),
                                                    positionInfo.timeSigNumerator,
                                                    positionInfo.timeSigDenominator,
@@ -501,7 +504,7 @@ void BigClockEditor::updateParametersFromFilter()
             break;
         case StopwatchMode:
             hosttime = false;
-            modeLabel->setText ("Stopwatch", dontSendNotification);
+            modeLabel->setText ("Stopwatch", juce::dontSendNotification);
             infoLabel->time = filter->ppqToString (filter->secondsToPpq ((double) (filter->watchtime) * 0.001, positionInfo.bpm),
                                                    positionInfo.timeSigNumerator,
                                                    positionInfo.timeSigDenominator,
@@ -510,8 +513,8 @@ void BigClockEditor::updateParametersFromFilter()
             break;
         case PluginTimeMode:
             hosttime = false;
-            modeLabel->setText ("Plugin Time", dontSendNotification);
-            infoLabel->time = filter->ppqToString (filter->secondsToPpq ((double) (Time::getMillisecondCounter() - filter->plugintime) * 0.001, positionInfo.bpm),
+            modeLabel->setText ("Plugin Time", juce::dontSendNotification);
+            infoLabel->time = filter->ppqToString (filter->secondsToPpq ((double) (juce::Time::getMillisecondCounter() - filter->plugintime) * 0.001, positionInfo.bpm),
                                                    positionInfo.timeSigNumerator,
                                                    positionInfo.timeSigDenominator,
                                                    positionInfo.bpm,
@@ -519,8 +522,8 @@ void BigClockEditor::updateParametersFromFilter()
             break;
         case ActualTimeMode:
             hosttime = false;
-            modeLabel->setText ("Actual Time", dontSendNotification);
-            infoLabel->time = Time::getCurrentTime().toString (false, true);
+            modeLabel->setText ("Actual Time", juce::dontSendNotification);
+            infoLabel->time = juce::Time::getCurrentTime().toString (false, true);
             break;
         default:
             break;
@@ -529,14 +532,14 @@ void BigClockEditor::updateParametersFromFilter()
     infoLabel->textcolor = filter->bgcolor.contrasting (filter->getParameter (kLook));
     infoLabel->repaint();
 
-    modeLabel->setColour (Label::textColourId, infoLabel->textcolor);
+    modeLabel->setColour (juce::Label::textColourId, infoLabel->textcolor);
 
     runButton->setButtonText (watchrunning ? "||" : ">");
 
     if (showtextbox)
     {
-        cueLabel->setColour (Label::textColourId, infoLabel->textcolor);
-        cueLabel->setText (filter->getCue (positionInfo.ppqPosition, barsbeats), sendNotification);
+        cueLabel->setColour (juce::Label::textColourId, infoLabel->textcolor);
+        cueLabel->setText (filter->getCue (positionInfo.ppqPosition, barsbeats), juce::sendNotification);
     }
 
     setSize (filter->lastUIWidth,

--- a/pizjuce/BigClock/BigClockEditor.h
+++ b/pizjuce/BigClock/BigClockEditor.h
@@ -1,12 +1,12 @@
 #ifndef BIGCLOCKPLUGINEDITOR_H
 #define BIGCLOCKPLUGINEDITOR_H
 
-#include "juce_gui_basics/juce_gui_basics.h"
-#include "juce_gui_extra/juce_gui_extra.h"
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <juce_gui_extra/juce_gui_extra.h>
 
 #include "BigClock.h"
 
-class TimeDisplay : public Button
+class TimeDisplay : public juce::Button
 {
 public:
     //==============================================================================
@@ -14,68 +14,68 @@ public:
     ~TimeDisplay() override;
 
     //==============================================================================
-    void paintButton (Graphics& g, bool isMouseOverButton, bool isButtonDown) override;
+    void paintButton (juce::Graphics& g, bool isMouseOverButton, bool isButtonDown) override;
     void resized() override;
-    String time;
-    Colour textcolor;
+    juce::String time;
+    juce::Colour textcolor;
 
-    //==============================================================================
-    juce_UseDebuggingNewOperator
-
-        private :
-
-        TimeDisplay (const TimeDisplay&);
+private:
+    TimeDisplay (const TimeDisplay&);
     const TimeDisplay& operator= (const TimeDisplay&);
+
+    JUCE_LEAK_DETECTOR (TimeDisplay)
 };
 
 //==============================================================================
-class BigClockEditor : public AudioProcessorEditor,
-                       public Button::Listener,
-                       public TextEditor::Listener,
-                       public ChangeListener,
-                       public Timer
+class BigClockEditor : public juce::AudioProcessorEditor,
+                       public juce::Button::Listener,
+                       public juce::TextEditor::Listener,
+                       public juce::ChangeListener,
+                       public juce::Timer
 {
 public:
     BigClockEditor (BigClockFilter* const ownerFilter);
     ~BigClockEditor() override;
 
-    void changeListenerCallback (ChangeBroadcaster* source) override;
-    void buttonClicked (Button* buttonThatWasClicked) override;
-    void buttonStateChanged (Button* buttonThatWasClicked) override;
-    void textEditorReturnKeyPressed (TextEditor& editor) override;
-    void textEditorEscapeKeyPressed (TextEditor& editor) override{};
-    void textEditorTextChanged (TextEditor& editor) override{};
-    void textEditorFocusLost (TextEditor& editor) override{};
+    void changeListenerCallback (juce::ChangeBroadcaster* source) override;
+    void buttonClicked (juce::Button* buttonThatWasClicked) override;
+    void buttonStateChanged (juce::Button* buttonThatWasClicked) override;
+    void textEditorReturnKeyPressed (juce::TextEditor& editor) override;
+    void textEditorEscapeKeyPressed (juce::TextEditor& editor) override{};
+    void textEditorTextChanged (juce::TextEditor& editor) override{};
+    void textEditorFocusLost (juce::TextEditor& editor) override{};
     void timerCallback() override;
-    void mouseEnter (const MouseEvent& e) override;
-    void mouseExit (const MouseEvent& e) override;
+    void mouseEnter (const juce::MouseEvent& e) override;
+    void mouseExit (const juce::MouseEvent& e) override;
 
     //==============================================================================
-    void paint (Graphics& g) override;
+    void paint (juce::Graphics& g) override;
     void resized() override;
 
 private:
     //==============================================================================
     TimeDisplay* infoLabel;
-    ColourSelector* colourSelector;
-    TooltipWindow tooltipWindow;
-    ResizableCornerComponent* resizer;
-    ComponentBoundsConstrainer resizeLimits;
-    TextEditor* textBox;
-    Label* cueLabel;
-    Label* modeLabel;
-    TextButton* runButton;
-    TextButton* resetButton;
+    juce::ColourSelector* colourSelector;
+    juce::TooltipWindow tooltipWindow;
+    juce::ResizableCornerComponent* resizer;
+    juce::ComponentBoundsConstrainer resizeLimits;
+    juce::TextEditor* textBox;
+    juce::Label* cueLabel;
+    juce::Label* modeLabel;
+    juce::TextButton* runButton;
+    juce::TextButton* resetButton;
 
     bool showtextbox;
     bool barsbeats;
     bool recording;
     bool hosttime;
-    uint32 watchTime;
+    juce::uint32 watchTime;
 
     void updateParametersFromFilter();
 
     BigClockFilter* getFilter() const throw() { return (BigClockFilter*) getAudioProcessor(); }
+
+    JUCE_LEAK_DETECTOR (BigClockEditor)
 };
 
 #endif

--- a/pizjuce/CpuRam/CpuRam.cpp
+++ b/pizjuce/CpuRam/CpuRam.cpp
@@ -25,7 +25,7 @@ void CpuRam::resetToDefaultSettings()
     showGraph    = true;
     lastUIWidth  = 230;
     lastUIHeight = 30;
-    bgcolor      = Colour (0xffb8bcc0);
+    bgcolor      = juce::Colour (0xffb8bcc0);
 }
 
 CpuRam::~CpuRam()
@@ -86,7 +86,7 @@ void CpuRam::setParameter (int index, float newValue)
     }
 }
 
-const String CpuRam::getParameterName (int index)
+const juce::String CpuRam::getParameterName (int index)
 {
     if (index == 0)
         return "interval";
@@ -95,37 +95,37 @@ const String CpuRam::getParameterName (int index)
     if (index == 2)
         return "show graph";
     else
-        return String();
+        return juce::String();
 }
 
-const String CpuRam::getParameterText (int index)
+const juce::String CpuRam::getParameterText (int index)
 {
     if (index == 0)
     {
-        return String ((int) (interval * 1700.0) + 300) + String (" ms");
+        return juce::String ((int) (interval * 1700.0) + 300) + juce::String (" ms");
     }
     if (index == 1)
     {
         if (minimize >= 0.5f)
-            return String ("yes");
+            return juce::String ("yes");
         else
-            return String ("no");
+            return juce::String ("no");
     }
     if (index == 2)
     {
-        return showGraph ? String ("yes") : String ("no");
+        return showGraph ? juce::String ("yes") : juce::String ("no");
     }
     else
-        return String();
+        return juce::String();
 }
-const String CpuRam::getInputChannelName (const int channelIndex) const
+const juce::String CpuRam::getInputChannelName (const int channelIndex) const
 {
-    return String (channelIndex + 1);
+    return juce::String (channelIndex + 1);
 }
 
-const String CpuRam::getOutputChannelName (const int channelIndex) const
+const juce::String CpuRam::getOutputChannelName (const int channelIndex) const
 {
-    return String (channelIndex + 1);
+    return juce::String (channelIndex + 1);
 }
 
 bool CpuRam::isInputChannelStereoPair (int index) const
@@ -150,8 +150,8 @@ void CpuRam::releaseResources()
     // spare memory, etc.
 }
 
-void CpuRam::processBlock (AudioSampleBuffer& buffer,
-                           MidiBuffer& midiMessages)
+void CpuRam::processBlock (juce::AudioSampleBuffer& buffer,
+                           juce::MidiBuffer& midiMessages)
 {
     for (int i = getNumInputChannels(); i < getNumOutputChannels(); ++i)
     {
@@ -162,23 +162,23 @@ void CpuRam::processBlock (AudioSampleBuffer& buffer,
 }
 
 //==============================================================================
-AudioProcessorEditor* CpuRam::createEditor()
+juce::AudioProcessorEditor* CpuRam::createEditor()
 {
     return new CpuRamEditor (this);
 }
 
 //==============================================================================
-void CpuRam::getStateInformation (JUCE_NAMESPACE::MemoryBlock& destData)
+void CpuRam::getStateInformation (juce::MemoryBlock& destData)
 {
     // you can store your parameters as binary data if you want to or if you've got
     // a load of binary to put in there, but if you're not doing anything too heavy,
     // XML is a much cleaner way of doing it - here's an example of how to store your
-    // params as XML..
+    // params as XML
 
-    // create an outer XML element..
-    XmlElement xmlState ("MYPLUGINSETTINGS");
+    // create an outer XML element
+    juce::XmlElement xmlState ("MYPLUGINSETTINGS");
 
-    // add some attributes to it..
+    // add some attributes to it
     xmlState.setAttribute ("pluginVersion", 1);
     xmlState.setAttribute ("intervalLevel", interval);
     xmlState.setAttribute ("showGraph", showGraph);
@@ -186,28 +186,28 @@ void CpuRam::getStateInformation (JUCE_NAMESPACE::MemoryBlock& destData)
     xmlState.setAttribute ("uiHeight", lastUIHeight);
     xmlState.setAttribute ("bgcolor", (int) (bgcolor.getARGB()));
 
-    // you could also add as many child elements as you need to here..
+    // you could also add as many child elements as you need to here
 
-    // then use this helper function to stuff it into the binary blob and return it..
+    // then use this helper function to stuff it into the binary blob and return it
     copyXmlToBinary (xmlState, destData);
 }
 
 void CpuRam::setStateInformation (const void* data, int sizeInBytes)
 {
-    // use this helper function to get the XML from this binary blob..
+    // use this helper function to get the XML from this binary blob
     auto const xmlState = getXmlFromBinary (data, sizeInBytes);
 
-    if (xmlState != 0)
+    if (xmlState != nullptr)
     {
-        // check that it's the right type of xml..
+        // check that it's the right type of xml
         if (xmlState->hasTagName ("MYPLUGINSETTINGS"))
         {
-            // ok, now pull out our parameters..
+            // ok, now pull out our parameters
             interval     = (float) xmlState->getDoubleAttribute ("intervalLevel", interval);
             showGraph    = xmlState->getBoolAttribute ("showGraph", showGraph);
             lastUIWidth  = xmlState->getIntAttribute ("uiWidth", lastUIWidth);
             lastUIHeight = xmlState->getIntAttribute ("uiHeight", lastUIHeight);
-            bgcolor      = Colour (xmlState->getIntAttribute ("bgcolor", bgcolor.getARGB()));
+            bgcolor      = juce::Colour (xmlState->getIntAttribute ("bgcolor", bgcolor.getARGB()));
             sendChangeMessage();
         }
     }

--- a/pizjuce/CpuRam/CpuRam.h
+++ b/pizjuce/CpuRam/CpuRam.h
@@ -2,13 +2,13 @@
 #define CPURAMPLUGINFILTER_H
 #define _WIN32_WINNT 0x0501
 
-#include "juce_events/juce_events.h"
+#include <juce_events/juce_events.h>
 
 #include "../_common/PizAudioProcessor.h"
 
 //==============================================================================
 class CpuRam : public PizAudioProcessor,
-               public ChangeBroadcaster
+               public juce::ChangeBroadcaster
 {
 public:
     //==============================================================================
@@ -19,15 +19,15 @@ public:
     void prepareToPlay (double sampleRate, int samplesPerBlock) override;
     void releaseResources() override;
 
-    void processBlock (AudioSampleBuffer& buffer,
-                       MidiBuffer& midiMessages) override;
+    void processBlock (juce::AudioSampleBuffer& buffer,
+                       juce::MidiBuffer& midiMessages) override;
 
     //==============================================================================
-    AudioProcessorEditor* createEditor() override;
+    juce::AudioProcessorEditor* createEditor() override;
 
     //==============================================================================
     double getTailLengthSeconds() const override { return 0; }
-    const String getName() const override { return JucePlugin_Name; }
+    const juce::String getName() const override { return JucePlugin_Name; }
     bool hasEditor() const override { return true; }
     bool acceptsMidi() const override
     {
@@ -51,11 +51,11 @@ public:
     float getParameter (int index) override;
     void setParameter (int index, float newValue) override;
 
-    const String getParameterName (int index) override;
-    const String getParameterText (int index) override;
+    const juce::String getParameterName (int index) override;
+    const juce::String getParameterText (int index) override;
 
-    const String getInputChannelName (int channelIndex) const override;
-    const String getOutputChannelName (int channelIndex) const override;
+    const juce::String getInputChannelName (int channelIndex) const override;
+    const juce::String getOutputChannelName (int channelIndex) const override;
     bool isInputChannelStereoPair (int index) const override;
     bool isOutputChannelStereoPair (int index) const override;
 
@@ -63,11 +63,11 @@ public:
     int getNumPrograms() override { return 1; }
     int getCurrentProgram() override { return 0; }
     void setCurrentProgram (int index) override {}
-    const String getProgramName (int index) override { return String(); }
-    void changeProgramName (int index, const String& newName) override {}
+    const juce::String getProgramName (int index) override { return juce::String(); }
+    void changeProgramName (int index, const juce::String& newName) override {}
 
     //==============================================================================
-    void getStateInformation (MemoryBlock& destData) override;
+    void getStateInformation (juce::MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
     void resetToDefaultSettings();
 
@@ -75,7 +75,7 @@ public:
     // These properties are public so that our editor component can access them
     //  - a bit of a hacky way to do it, but it's only a demo!
 
-    Colour bgcolor;
+    juce::Colour bgcolor;
     bool showGraph;
 
     // these are used to persist the UI's size - the values are stored along with the
@@ -83,14 +83,13 @@ public:
     // resized.
     int lastUIWidth, lastUIHeight;
 
-    //==============================================================================
-    juce_UseDebuggingNewOperator
-
-        private :
-        // this is our interval - the UI and the host can access this by getting/setting
-        // parameter 0.
-        float interval;
+private:
+    // this is our interval - the UI and the host can access this by getting/setting
+    // parameter 0.
+    float interval;
     float minimize;
+
+    JUCE_LEAK_DETECTOR (CpuRam)
 };
 
 #endif

--- a/pizjuce/CpuRam/CpuRamEditor.cpp
+++ b/pizjuce/CpuRam/CpuRamEditor.cpp
@@ -6,25 +6,25 @@ CpuRamEditor::CpuRamEditor (CpuRam* const ownerFilter)
 {
     setMouseClickGrabsKeyboardFocus (false);
 
-    addAndMakeVisible (infoLabel = new Label (String ("CPU"), String()));
+    addAndMakeVisible (infoLabel = new juce::Label (juce::String ("CPU"), juce::String()));
     infoLabel->setMouseClickGrabsKeyboardFocus (false);
     infoLabel->setInterceptsMouseClicks (false, false);
 
-    addAndMakeVisible (memLabel2 = new Label (String ("RAM"), String()));
+    addAndMakeVisible (memLabel2 = new juce::Label (juce::String ("RAM"), juce::String()));
     memLabel2->setMouseClickGrabsKeyboardFocus (false);
     memLabel2->setInterceptsMouseClicks (false, false);
 
-    addAndMakeVisible (slider = new Slider (String ("interval")));
+    addAndMakeVisible (slider = new juce::Slider (juce::String ("interval")));
     slider->setMouseClickGrabsKeyboardFocus (false);
-    slider->setSliderStyle (Slider::LinearBar);
+    slider->setSliderStyle (juce::Slider::LinearBar);
     slider->setRange (300, 2000, 1);
-    slider->setTextValueSuffix (String (" ms"));
+    slider->setTextValueSuffix (juce::String (" ms"));
     slider->addListener (this);
 
     addAndMakeVisible (graph = new CpuGraph());
 
-    colourSelector = new ColourSelector (ColourSelector::showColourAtTop | ColourSelector::showSliders | ColourSelector::showColourspace);
-    colourSelector->setName (String ("color"));
+    colourSelector = new juce::ColourSelector (juce::ColourSelector::showColourAtTop | juce::ColourSelector::showSliders | juce::ColourSelector::showColourspace);
+    colourSelector->setName (juce::String ("color"));
     colourSelector->setCurrentColour (getFilter()->bgcolor);
     colourSelector->addChangeListener (this);
 
@@ -59,7 +59,7 @@ CpuRamEditor::~CpuRamEditor()
 }
 
 //==============================================================================
-void CpuRamEditor::paint (Graphics& g)
+void CpuRamEditor::paint (juce::Graphics& g)
 {
     g.fillAll (getFilter()->bgcolor);
 }
@@ -89,7 +89,7 @@ void CpuRamEditor::resized()
     //getFilter()->lastUIHeight = h;
 }
 
-void CpuRamEditor::sliderValueChanged (Slider* sliderThatWasMoved)
+void CpuRamEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
 {
     getFilter()->setParameterNotifyingHost (0, (float) (sliderThatWasMoved->getValue() - 300) / 1700.0f);
 }
@@ -113,11 +113,11 @@ void CpuRamEditor::timerCallback()
     updateParametersFromFilter();
 }
 
-void CpuRamEditor::mouseUp (const MouseEvent& e)
+void CpuRamEditor::mouseUp (const juce::MouseEvent& e)
 {
     if (e.mods.isPopupMenu())
     {
-        PopupMenu m;
+        juce::PopupMenu m;
         colourSelector->setCurrentColour (getFilter()->bgcolor);
         m.addItem (3, "Show Graph", true, getFilter()->showGraph);
         m.addSectionHeader ("Interval");
@@ -133,7 +133,7 @@ void CpuRamEditor::mouseUp (const MouseEvent& e)
 }
 
 //==============================================================================
-void CpuRamEditor::changeListenerCallback (ChangeBroadcaster* source)
+void CpuRamEditor::changeListenerCallback (juce::ChangeBroadcaster* source)
 {
     if (source == getFilter())
     {
@@ -141,11 +141,11 @@ void CpuRamEditor::changeListenerCallback (ChangeBroadcaster* source)
     }
     else
     {
-        ColourSelector* cs   = (ColourSelector*) source;
+        auto* cs             = (juce::ColourSelector*) source;
         getFilter()->bgcolor = (cs->getCurrentColour());
-        infoLabel->setColour (Label::textColourId, getFilter()->bgcolor.contrasting (0.8f));
-        memLabel2->setColour (Label::textColourId, getFilter()->bgcolor.contrasting (0.8f));
-        slider->setColour (Slider::textBoxTextColourId, getFilter()->bgcolor.contrasting (0.8f));
+        infoLabel->setColour (juce::Label::textColourId, getFilter()->bgcolor.contrasting (0.8f));
+        memLabel2->setColour (juce::Label::textColourId, getFilter()->bgcolor.contrasting (0.8f));
+        slider->setColour (juce::Slider::textBoxTextColourId, getFilter()->bgcolor.contrasting (0.8f));
         repaint();
     }
 }
@@ -160,18 +160,18 @@ void CpuRamEditor::updateParametersFromFilter()
     float cpu = CPULoad();
     graph->addPoint (cpu * 0.01f);
     if (getFilter()->showGraph)
-        infoLabel->setText (String ("CPU Load: ") + String (cpu, 1) + String ("%"), dontSendNotification);
+        infoLabel->setText (juce::String ("CPU Load: ") + juce::String (cpu, 1) + juce::String ("%"), juce::dontSendNotification);
     else
-        infoLabel->setText (String ("CPU: ") + String (cpu, 1) + String ("%"), dontSendNotification);
+        infoLabel->setText (juce::String ("CPU: ") + juce::String (cpu, 1) + juce::String ("%"), juce::dontSendNotification);
 
-    memLabel2->setText (String ("Free RAM: ") + String ((int) RAMLoad().ullAvailPhys / 1048576) + String ("MB"), dontSendNotification);
+    memLabel2->setText (juce::String ("Free RAM: ") + juce::String ((int) RAMLoad().ullAvailPhys / 1048576) + juce::String ("MB"), juce::dontSendNotification);
 
-    infoLabel->setColour (Label::textColourId, filter->bgcolor.contrasting (0.8f));
-    memLabel2->setColour (Label::textColourId, filter->bgcolor.contrasting (0.8f));
-    slider->setColour (Slider::textBoxTextColourId, filter->bgcolor.contrasting (0.8f));
+    infoLabel->setColour (juce::Label::textColourId, filter->bgcolor.contrasting (0.8f));
+    memLabel2->setColour (juce::Label::textColourId, filter->bgcolor.contrasting (0.8f));
+    slider->setColour (juce::Slider::textBoxTextColourId, filter->bgcolor.contrasting (0.8f));
 
     float interval = filter->getParameter (0) * 1700.0f + 300.0f;
-    slider->setValue (interval, dontSendNotification);
+    slider->setValue (interval, juce::dontSendNotification);
     startTimer ((int) interval);
     pu.setInterval ((int) interval);
 

--- a/pizjuce/CpuRam/CpuRamEditor.h
+++ b/pizjuce/CpuRam/CpuRamEditor.h
@@ -1,13 +1,13 @@
 #ifndef DEMOJUCEPLUGINEDITOR_H
 #define DEMOJUCEPLUGINEDITOR_H
 
-#include "juce_gui_basics/juce_gui_basics.h"
-#include "juce_gui_extra/juce_gui_extra.h"
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <juce_gui_extra/juce_gui_extra.h>
 
 #include "CpuRam.h"
 #include "cputime.h"
 
-class CpuGraph : public Component
+class CpuGraph : public juce::Component
 {
 public:
     CpuGraph()
@@ -32,10 +32,10 @@ private:
         numPoints = 128
     };
     float points[numPoints];
-    void paint (Graphics& g) override
+    void paint (juce::Graphics& g) override
     {
-        g.fillAll (Colours::black);
-        g.setColour (Colours::green);
+        g.fillAll (juce::Colours::black);
+        g.setColour (juce::Colours::green);
         for (int i = 0; i < numPoints; i++)
         {
             float x = ((float) i / float (numPoints)) * getWidth();
@@ -57,10 +57,10 @@ private:
     when it's destroyed. When the filter's parameters are changed, it broadcasts
     a message and this editor responds by updating its display.
 */
-class CpuRamEditor : public AudioProcessorEditor,
-                     public ChangeListener,
-                     public Slider::Listener,
-                     public Timer
+class CpuRamEditor : public juce::AudioProcessorEditor,
+                     public juce::ChangeListener,
+                     public juce::Slider::Listener,
+                     public juce::Timer
 {
 public:
     /** Constructor.
@@ -77,25 +77,25 @@ public:
     /** Our demo filter is a ChangeBroadcaster, and will call us back when one of
         its parameters changes.
     */
-    void changeListenerCallback (ChangeBroadcaster* source) override;
+    void changeListenerCallback (juce::ChangeBroadcaster* source) override;
     void timerCallback() override;
-    void sliderValueChanged (Slider* sliderThatWasMoved) override;
-    void mouseUp (const MouseEvent&) override;
+    void sliderValueChanged (juce::Slider* sliderThatWasMoved) override;
+    void mouseUp (const juce::MouseEvent&) override;
 
     //==============================================================================
     /** Standard Juce paint callback. */
-    void paint (Graphics& g) override;
+    void paint (juce::Graphics& g) override;
 
     /** Standard Juce resize callback. */
     void resized() override;
 
 private:
     //==============================================================================
-    Label* infoLabel;
-    Label* memLabel2;
-    Slider* slider;
+    juce::Label* infoLabel;
+    juce::Label* memLabel2;
+    juce::Slider* slider;
     CpuGraph* graph;
-    ColourSelector* colourSelector;
+    juce::ColourSelector* colourSelector;
     //TooltipWindow tooltipWindow;
     //ResizableCornerComponent* resizer;
     //ComponentBoundsConstrainer resizeLimits;
@@ -110,7 +110,7 @@ private:
     void updateParametersFromFilter();
 
     // handy wrapper method to avoid having to cast the filter to a CpuRam
-    // every time we need it..
+    // every time we need it
     CpuRam* getFilter() const throw() { return (CpuRam*) getAudioProcessor(); }
 };
 

--- a/pizjuce/Image/MidiPad.cpp
+++ b/pizjuce/Image/MidiPad.cpp
@@ -1,23 +1,24 @@
 #include "MidiPad.h"
 
-#include "MidiPad.h"
+using juce::jmax;
+using juce::jmin;
 
 MidiPad::MidiPad()
     : Button ("MidiPad"),
       normalImage (nullptr),
       index (0),
-      text (0)
+      text (nullptr)
 
 {
-    bgColour   = Colours::white;
-    textColour = Colours::black;
+    bgColour   = juce::Colours::white;
+    textColour = juce::Colours::black;
 
     centeredText = false;
     imageSize    = 1.f;
     setMouseClickGrabsKeyboardFocus (true);
 
-    addAndMakeVisible (text = new Label ("label", ""));
-    text->setJustificationType (Justification::centredTop);
+    addAndMakeVisible (text = new juce::Label ("label", ""));
+    text->setJustificationType (juce::Justification::centredTop);
     text->setEditable (false, false, false);
     text->setInterceptsMouseClicks (false, false);
 
@@ -36,13 +37,13 @@ void MidiPad::deleteImages()
     normalImage.reset();
 }
 
-bool MidiPad::setImageFromFile (File file)
+bool MidiPad::setImageFromFile (juce::File file)
 {
     if (file.exists())
     {
         deleteImages();
 
-        normalImage = Drawable::createFromImageFile (file);
+        normalImage = juce::Drawable::createFromImageFile (file);
         if (normalImage != nullptr)
         {
             repaint();
@@ -54,7 +55,7 @@ bool MidiPad::setImageFromFile (File file)
     return false;
 }
 
-void MidiPad::setImages (const Drawable* normal)
+void MidiPad::setImages (const juce::Drawable* normal)
 {
     deleteImages();
     if (normal != nullptr)
@@ -64,12 +65,12 @@ void MidiPad::setImages (const Drawable* normal)
     repaint();
 }
 
-void MidiPad::setIconPath (String name)
+void MidiPad::setIconPath (juce::String name)
 {
     iconPath = name;
 }
 
-String MidiPad::getIconPath()
+juce::String MidiPad::getIconPath()
 {
     return iconPath;
 }
@@ -83,24 +84,24 @@ void MidiPad::setColour (const juce::Colour& colour)
 void MidiPad::setTextColour (const juce::Colour& colour)
 {
     textColour = colour;
-    text->setColour (Label::textColourId, colour);
+    text->setColour (juce::Label::textColourId, colour);
 }
 
-const Colour& MidiPad::getBackgroundColour() const throw()
+const juce::Colour& MidiPad::getBackgroundColour() const throw()
 {
     return bgColour;
 }
 
-void MidiPad::drawButtonBackground (Graphics& g,
+void MidiPad::drawButtonBackground (juce::Graphics& g,
                                     Button& button,
-                                    const Colour& backgroundColour,
+                                    const juce::Colour& backgroundColour,
                                     bool isMouseOverButton,
                                     bool isButtonDown)
 {
     g.fillAll (backgroundColour);
 }
 
-void MidiPad::paintButton (Graphics& g, bool isMouseOverButton, bool isButtonDown)
+void MidiPad::paintButton (juce::Graphics& g, bool isMouseOverButton, bool isButtonDown)
 {
     juce::Rectangle<float> imageSpace;
     const float insetX = getWidth() * (1.f - imageSize) * 0.5f;
@@ -108,53 +109,53 @@ void MidiPad::paintButton (Graphics& g, bool isMouseOverButton, bool isButtonDow
     imageSpace.setBounds (insetX, insetY, getWidth() - insetX * 2, getHeight() - insetY * 2);
     MidiPad::drawButtonBackground (g, *this, getBackgroundColour(), isMouseOverButton, isButtonDown);
 
-    g.setImageResamplingQuality (Graphics::highResamplingQuality);
+    g.setImageResamplingQuality (juce::Graphics::highResamplingQuality);
     g.setOpacity (1.0f);
 
-    const Drawable* imageToDraw = 0;
-    imageToDraw                 = getCurrentImage();
-    if (imageToDraw != 0)
+    const juce::Drawable* imageToDraw = nullptr;
+    imageToDraw                       = getCurrentImage();
+    if (imageToDraw != nullptr)
     {
         imageToDraw->drawWithin (g,
                                  imageSpace,
-                                 RectanglePlacement::centred,
+                                 juce::RectanglePlacement::centred,
                                  1.f);
     }
 }
 
 void MidiPad::setCenteredText (bool centered)
 {
-    text->setJustificationType (centered ? Justification::centred : Justification::centredTop);
+    text->setJustificationType (centered ? juce::Justification::centred : juce::Justification::centredTop);
 }
 
 void MidiPad::resized()
 {
     text->setBounds (4, 4, getWidth() - 8, getHeight() - 8);
     float fontsize = jmax (5.f, jmin ((float) (proportionOfWidth (0.2f)), (float) (proportionOfHeight (0.15f))));
-    text->setFont (Font (fontsize, Font::bold));
+    text->setFont (juce::Font (fontsize, juce::Font::bold));
 }
 
-const Drawable* MidiPad::getCurrentImage() const throw()
+const juce::Drawable* MidiPad::getCurrentImage() const throw()
 {
     return getNormalImage();
 }
 
-const Drawable* MidiPad::getNormalImage() const throw()
+const juce::Drawable* MidiPad::getNormalImage() const throw()
 {
     return normalImage.get();
 }
 
-void MidiPad::setText (const String& name)
+void MidiPad::setText (const juce::String& name)
 {
-    text->setText (name, dontSendNotification);
+    text->setText (name, juce::dontSendNotification);
 }
 
-void MidiPad::setButtonText (const String& newText)
+void MidiPad::setButtonText (const juce::String& newText)
 {
-    text->setText (newText, dontSendNotification);
+    text->setText (newText, juce::dontSendNotification);
 }
 
-String MidiPad::getText()
+juce::String MidiPad::getText()
 {
     return text->getText();
 }

--- a/pizjuce/Image/MidiPad.h
+++ b/pizjuce/Image/MidiPad.h
@@ -5,9 +5,7 @@
 
 #include "../_common/PizAudioProcessor.h"
 
-using namespace juce;
-
-class MidiPad : public Button
+class MidiPad : public juce::Button
 {
 public:
     //==============================================================================
@@ -15,54 +13,53 @@ public:
     ~MidiPad() override;
 
     void resized() override;
-    void buttonClicked (Button*);
-    void setColour (const Colour&);
-    void setTextColour (const Colour&);
+    void buttonClicked (juce::Button*);
+    void setColour (const juce::Colour&);
+    void setTextColour (const juce::Colour&);
     int getIndex() { return index; }
-    String getIconPath();
-    void setIconPath (String name);
-    void setText (const String& name);
-    void setButtonText (const String& newText);
-    String getText();
+    juce::String getIconPath();
+    void setIconPath (juce::String name);
+    void setText (const juce::String& name);
+    void setButtonText (const juce::String& newText);
+    juce::String getText();
 
     //==============================================================================
-    void setImages (const Drawable* normalImage);
-    bool setImageFromFile (File file);
+    void setImages (const juce::Drawable* normalImage);
+    bool setImageFromFile (juce::File file);
 
     //==============================================================================
-    const Drawable* getCurrentImage() const throw();
-    const Drawable* getNormalImage() const throw();
-    const Colour& getBackgroundColour() const throw();
+    const juce::Drawable* getCurrentImage() const throw();
+    const juce::Drawable* getNormalImage() const throw();
+    const juce::Colour& getBackgroundColour() const throw();
 
-    String Description;
+    juce::String Description;
     float imageSize;
     void setCenteredText (bool centered);
 
-    //==============================================================================
-    juce_UseDebuggingNewOperator
+protected:
+    void drawButtonBackground (juce::Graphics& g,
+                               Button& button,
+                               const juce::Colour& backgroundColour,
+                               bool isMouseOverButton,
+                               bool isButtonDown);
 
-        protected : void
-                    drawButtonBackground (Graphics& g,
-                                          Button& button,
-                                          const Colour& backgroundColour,
-                                          bool isMouseOverButton,
-                                          bool isButtonDown);
-
-    void paintButton (Graphics& g,
+    void paintButton (juce::Graphics& g,
                       bool isMouseOverButton,
                       bool isButtonDown) override;
 
 private:
     bool centeredText;
     int index;
-    std::unique_ptr<Drawable> normalImage;
-    Colour bgColour, textColour;
+    std::unique_ptr<juce::Drawable> normalImage;
+    juce::Colour bgColour, textColour;
     void deleteImages();
-    String iconPath;
-    Label* text;
+    juce::String iconPath;
+    juce::Label* text;
 
     MidiPad (const MidiPad&);
     const MidiPad& operator= (const MidiPad&);
+
+    JUCE_LEAK_DETECTOR (MidiPad)
 };
 
 #endif

--- a/pizjuce/Image/imagePlugin.cpp
+++ b/pizjuce/Image/imagePlugin.cpp
@@ -1,6 +1,8 @@
 #include "imagePlugin.h"
 #include "imagePluginEditor.h"
 
+using juce::roundToInt;
+
 //==============================================================================
 /*
     This function must be implemented to create the actual plugin object that
@@ -24,11 +26,11 @@ void ImageBank::loadDefaultValues()
         for (int p = 0; p < getNumPrograms(); p++)
         {
             set (b, p, "progIndex", p);
-            set (b, p, "name", "Bank " + String (b) + " Image " + String (p + 1));
-            set (b, p, "icon", String ("Images") + File::getSeparatorString() + "Bank " + String (b) + File::getSeparatorString() + String (p + 1) + ".svg");
-            set (b, p, "text", String());
-            set (b, p, "bgcolor", Colour (0xFFFFFFFF).toString());
-            set (b, p, "textcolor", Colour (0xFF000000).toString());
+            set (b, p, "name", "Bank " + juce::String (b) + " Image " + juce::String (p + 1));
+            set (b, p, "icon", juce::String ("Images") + juce::File::getSeparatorString() + "Bank " + juce::String (b) + juce::File::getSeparatorString() + juce::String (p + 1) + ".svg");
+            set (b, p, "text", juce::String());
+            set (b, p, "bgcolor", juce::Colour (0xFFFFFFFF).toString());
+            set (b, p, "textcolor", juce::Colour (0xFF000000).toString());
             set (b, p, "h", 400);
             set (b, p, "w", 400);
         }
@@ -44,7 +46,7 @@ void ImageBank::loadDefaultValues()
 //==============================================================================
 imagePluginFilter::imagePluginFilter()
 {
-    iconPath = getCurrentPath() + File::getSeparatorString() + "images";
+    iconPath = getCurrentPath() + juce::File::getSeparatorString() + "images";
 
     // create built-in programs
     programs = new ImageBank(); //new JuceProgram[16384];
@@ -95,33 +97,33 @@ void imagePluginFilter::setParameter (int index, float newValue)
     }
 }
 
-const String imagePluginFilter::getParameterName (int index)
+const juce::String imagePluginFilter::getParameterName (int index)
 {
     if (index == kChannel)
         return "Channel";
-    return String();
+    return juce::String();
 }
 
-const String imagePluginFilter::getParameterText (int index)
+const juce::String imagePluginFilter::getParameterText (int index)
 {
     if (index == kChannel)
     {
         if (roundToInt (param[kChannel] * 16.0f) == 0)
-            return String ("Any");
+            return juce::String ("Any");
         else
-            return String (roundToInt (param[kChannel] * 16.0f));
+            return juce::String (roundToInt (param[kChannel] * 16.0f));
     }
-    return String();
+    return juce::String();
 }
 
-const String imagePluginFilter::getInputChannelName (const int channelIndex) const
+const juce::String imagePluginFilter::getInputChannelName (const int channelIndex) const
 {
-    return String (channelIndex + 1);
+    return juce::String (channelIndex + 1);
 }
 
-const String imagePluginFilter::getOutputChannelName (const int channelIndex) const
+const juce::String imagePluginFilter::getOutputChannelName (const int channelIndex) const
 {
-    return String (channelIndex + 1);
+    return juce::String (channelIndex + 1);
 }
 
 bool imagePluginFilter::isInputChannelStereoPair (int index) const
@@ -156,8 +158,8 @@ void imagePluginFilter::setCurrentProgram (int index)
     lastUIWidth     = programs->get (curBank, curProgram, "w");
     icon            = programs->get (curBank, curProgram, "icon");
     text            = programs->get (curBank, curProgram, "text");
-    bgcolor         = Colour::fromString (programs->get (curBank, curProgram, "bgcolor").toString());
-    textcolor       = Colour::fromString (programs->get (curBank, curProgram, "textcolor").toString());
+    bgcolor         = juce::Colour::fromString (programs->get (curBank, curProgram, "bgcolor").toString());
+    textcolor       = juce::Colour::fromString (programs->get (curBank, curProgram, "textcolor").toString());
     noteInput       = programs->getGlobal ("noteInput");
     usePC           = programs->getGlobal ("usePC");
 
@@ -184,12 +186,12 @@ void imagePluginFilter::setCurrentBank (int index, int program)
     setCurrentProgram (program);
 }
 
-void imagePluginFilter::changeProgramName (int index, const String& newName)
+void imagePluginFilter::changeProgramName (int index, const juce::String& newName)
 {
     programs->set (curBank, index, "name", newName);
 }
 
-const String imagePluginFilter::getProgramName (int index)
+const juce::String imagePluginFilter::getProgramName (int index)
 {
     return programs->get (curBank, index, "name");
 }
@@ -211,8 +213,8 @@ void imagePluginFilter::releaseResources()
     // spare memory, etc.
 }
 
-void imagePluginFilter::processBlock (AudioSampleBuffer& buffer,
-                                      MidiBuffer& midiMessages)
+void imagePluginFilter::processBlock (juce::AudioSampleBuffer& buffer,
+                                      juce::MidiBuffer& midiMessages)
 {
     for (int i = getNumInputChannels(); i < getNumOutputChannels(); ++i)
     {
@@ -245,13 +247,13 @@ void imagePluginFilter::processBlock (AudioSampleBuffer& buffer,
     midiMessages.clear();
 }
 //==============================================================================
-AudioProcessorEditor* imagePluginFilter::createEditor()
+juce::AudioProcessorEditor* imagePluginFilter::createEditor()
 {
     return new imagePluginEditor (this);
 }
 
 //==============================================================================
-void imagePluginFilter::getCurrentProgramStateInformation (MemoryBlock& destData)
+void imagePluginFilter::getCurrentProgramStateInformation (juce::MemoryBlock& destData)
 {
     // make sure the non-parameter settings are copied to the current program
     programs->set (curBank, curProgram, "h", lastUIHeight);
@@ -263,12 +265,12 @@ void imagePluginFilter::getCurrentProgramStateInformation (MemoryBlock& destData
     // you can store your parameters as binary data if you want to or if you've got
     // a load of binary to put in there, but if you're not doing anything too heavy,
     // XML is a much cleaner way of doing it - here's an example of how to store your
-    // params as XML..
+    // params as XML
 
-    // create an outer XML element..
-    XmlElement xmlState ("MYPLUGINSETTINGS");
+    // create an outer XML element
+    juce::XmlElement xmlState ("MYPLUGINSETTINGS");
 
-    // add some attributes to it..
+    // add some attributes to it
     xmlState.setAttribute ("pluginVersion", 1);
 
     xmlState.setAttribute ("bank", getCurrentBank());
@@ -277,7 +279,7 @@ void imagePluginFilter::getCurrentProgramStateInformation (MemoryBlock& destData
 
     for (int i = 0; i < kNumParams; i++)
     {
-        xmlState.setAttribute (String (i), param[i]);
+        xmlState.setAttribute (juce::String (i), param[i]);
     }
 
     xmlState.setAttribute ("uiWidth", lastUIWidth);
@@ -292,7 +294,7 @@ void imagePluginFilter::getCurrentProgramStateInformation (MemoryBlock& destData
     // then use this helper function to stuff it into the binary blob and return it..
     copyXmlToBinary (xmlState, destData);
 }
-void imagePluginFilter::getStateInformation (MemoryBlock& destData)
+void imagePluginFilter::getStateInformation (juce::MemoryBlock& destData)
 {
     // make sure the non-parameter settings are copied to the current program
     programs->set (curBank, curProgram, "h", lastUIHeight);
@@ -323,14 +325,14 @@ void imagePluginFilter::setCurrentProgramStateInformation (const void* data, int
             changeProgramName (getCurrentProgram(), xmlState->getStringAttribute ("progname", "Default"));
             for (int i = 0; i < kNumParams; i++)
             {
-                param[i] = (float) xmlState->getDoubleAttribute (String (i), param[i]);
+                param[i] = (float) xmlState->getDoubleAttribute (juce::String (i), param[i]);
             }
             lastUIWidth  = xmlState->getIntAttribute ("uiWidth", lastUIWidth);
             lastUIHeight = xmlState->getIntAttribute ("uiHeight", lastUIHeight);
             icon         = xmlState->getStringAttribute ("icon", icon);
             text         = xmlState->getStringAttribute ("text", text);
-            bgcolor      = Colour (xmlState->getIntAttribute ("bgcolor", bgcolor.getARGB()) | 0x00000000);
-            textcolor    = Colour (xmlState->getIntAttribute ("textcolor", bgcolor.contrasting (0.8f).getARGB()) | 0x00000000);
+            bgcolor      = juce::Colour (xmlState->getIntAttribute ("bgcolor", bgcolor.getARGB()) | 0x00000000);
+            textcolor    = juce::Colour (xmlState->getIntAttribute ("textcolor", bgcolor.contrasting (0.8f).getARGB()) | 0x00000000);
             noteInput    = xmlState->getBoolAttribute ("noteInput", noteInput);
             usePC        = xmlState->getBoolAttribute ("usePC", usePC);
 
@@ -343,10 +345,10 @@ void imagePluginFilter::setStateInformation (const void* data, int sizeInBytes)
 {
     auto const xmlState = getXmlFromBinary (data, sizeInBytes);
 
-    if (xmlState == 0)
+    if (xmlState == nullptr)
     {
-        MemoryInputStream input (data, sizeInBytes, false);
-        ValueTree vt = ValueTree::readFromStream (input);
+        juce::MemoryInputStream input (data, sizeInBytes, false);
+        juce::ValueTree vt = juce::ValueTree::readFromStream (input);
         programs->loadFrom (vt);
         init = true;
         setCurrentBank (vt.getChild (128).getProperty ("lastBank", 0), vt.getChild (128).getProperty ("lastProgram", 0));
@@ -360,15 +362,15 @@ void imagePluginFilter::setStateInformation (const void* data, int sizeInBytes)
                 fullscreen = xmlState->getBoolAttribute ("fullscreen", false);
                 for (int p = 0; p < getNumPrograms(); p++)
                 {
-                    String prefix = "P" + String (p) + ".";
-                    programs->set (0, p, "channel", (float) xmlState->getDoubleAttribute (prefix + String (0), 0));
+                    juce::String prefix = "P" + juce::String (p) + ".";
+                    programs->set (0, p, "channel", (float) xmlState->getDoubleAttribute (prefix + juce::String (0), 0));
                     programs->set (0, p, "w", xmlState->getIntAttribute (prefix + "uiWidth", 400));
                     programs->set (0, p, "h", xmlState->getIntAttribute (prefix + "uiHeight", 400));
-                    programs->set (0, p, "icon", xmlState->getStringAttribute (prefix + "icon", String()));
-                    programs->set (0, p, "text", xmlState->getStringAttribute (prefix + "text", String()));
-                    programs->set (0, p, "bgcolor", Colour (xmlState->getIntAttribute (prefix + "bgcolor")).toString());
-                    programs->set (0, p, "textcolor", Colour (xmlState->getIntAttribute ("textcolor")).toString());
-                    programs->set (0, p, "name", xmlState->getStringAttribute (prefix + "progname", String()));
+                    programs->set (0, p, "icon", xmlState->getStringAttribute (prefix + "icon", juce::String()));
+                    programs->set (0, p, "text", xmlState->getStringAttribute (prefix + "text", juce::String()));
+                    programs->set (0, p, "bgcolor", juce::Colour (xmlState->getIntAttribute (prefix + "bgcolor")).toString());
+                    programs->set (0, p, "textcolor", juce::Colour (xmlState->getIntAttribute ("textcolor")).toString());
+                    programs->set (0, p, "name", xmlState->getStringAttribute (prefix + "progname", juce::String()));
                 }
                 init = true;
                 setCurrentBank (0, xmlState->getIntAttribute ("program", 0));
@@ -400,7 +402,7 @@ void imagePluginFilter::setStateInformation (const void* data, int sizeInBytes)
     }
 }
 
-void imagePluginFilter::setBankColours (Colour colour, Colour text)
+void imagePluginFilter::setBankColours (juce::Colour colour, juce::Colour text)
 {
     for (int i = 0; i < getNumPrograms(); i++)
     {
@@ -421,5 +423,5 @@ void imagePluginFilter::applySizeToBank (int h, int w)
 void imagePluginFilter::clearAllImages()
 {
     for (int i = 0; i < getNumPrograms(); i++)
-        programs->set (curBank, i, "icon", String (""));
+        programs->set (curBank, i, "icon", juce::String (""));
 }

--- a/pizjuce/Image/imagePlugin.h
+++ b/pizjuce/Image/imagePlugin.h
@@ -1,12 +1,10 @@
 #ifndef IMAGEPLUGINFILTER_H
 #define IMAGEPLUGINFILTER_H
 
-#include "juce_data_structures/juce_data_structures.h"
+#include <juce_data_structures/juce_data_structures.h>
 
 #include "../_common/BankStorage.h"
 #include "../_common/PizAudioProcessor.h"
-
-using namespace juce;
 
 enum parameters
 {
@@ -30,7 +28,7 @@ private:
 
 */
 class imagePluginFilter : public PizAudioProcessor,
-                          public ChangeBroadcaster
+                          public juce::ChangeBroadcaster
 {
 public:
     //==============================================================================
@@ -41,14 +39,14 @@ public:
     void prepareToPlay (double sampleRate, int samplesPerBlock) override;
     void releaseResources() override;
 
-    void processBlock (AudioSampleBuffer& buffer,
-                       MidiBuffer& midiMessages) override;
+    void processBlock (juce::AudioSampleBuffer& buffer,
+                       juce::MidiBuffer& midiMessages) override;
 
     //==============================================================================
-    AudioProcessorEditor* createEditor() override;
+    juce::AudioProcessorEditor* createEditor() override;
 
     //==============================================================================
-    const String getName() const override { return JucePlugin_Name; }
+    const juce::String getName() const override { return JucePlugin_Name; }
     bool acceptsMidi() const override
     {
 #if JucePlugin_WantsMidiInput
@@ -73,11 +71,11 @@ public:
     float getParameter (int index) override;
     void setParameter (int index, float newValue) override;
 
-    const String getParameterName (int index) override;
-    const String getParameterText (int index) override;
+    const juce::String getParameterName (int index) override;
+    const juce::String getParameterText (int index) override;
 
-    const String getInputChannelName (int channelIndex) const override;
-    const String getOutputChannelName (int channelIndex) const override;
+    const juce::String getInputChannelName (int channelIndex) const override;
+    const juce::String getOutputChannelName (int channelIndex) const override;
     bool isInputChannelStereoPair (int index) const override;
     bool isOutputChannelStereoPair (int index) const override;
 
@@ -86,16 +84,16 @@ public:
     int getNumPrograms() override { return 128; }
     int getCurrentProgram() override;
     void setCurrentProgram (int index) override;
-    const String getProgramName (int index) override;
-    void changeProgramName (int index, const String& newName) override;
+    const juce::String getProgramName (int index) override;
+    void changeProgramName (int index, const juce::String& newName) override;
 
     //==============================================================================
-    void getCurrentProgramStateInformation (MemoryBlock& destData) override;
+    void getCurrentProgramStateInformation (juce::MemoryBlock& destData) override;
     void setCurrentProgramStateInformation (const void* data, int sizeInBytes) override;
-    void getStateInformation (MemoryBlock& destData) override;
+    void getStateInformation (juce::MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
 
-    void setBankColours (Colour colour, Colour text);
+    void setBankColours (juce::Colour colour, juce::Colour text);
     void applySizeToBank (int h, int w);
     void clearAllImages();
 
@@ -125,17 +123,17 @@ public:
     // filter's other parameters, and the UI component will update them when it gets
     // resized.
     int lastUIWidth, lastUIHeight;
-    Colour bgcolor;
-    Colour textcolor;
-    String icon;
-    String text;
+    juce::Colour bgcolor;
+    juce::Colour textcolor;
+    juce::String icon;
+    juce::String text;
     bool fullscreen;
-    String iconPath;
+    juce::String iconPath;
 
     //==============================================================================
-    juce_UseDebuggingNewOperator
 
-        private : float param[kNumParams];
+private:
+    float param[kNumParams];
 
     //JuceProgram *programs;
     ImageBank* programs;
@@ -145,6 +143,8 @@ public:
     bool usePC;
 
     bool init;
+
+    JUCE_LEAK_DETECTOR (imagePluginFilter)
 };
 
 #endif

--- a/pizjuce/Image/imagePluginEditor.cpp
+++ b/pizjuce/Image/imagePluginEditor.cpp
@@ -1,10 +1,13 @@
 #include "imagePluginEditor.h"
 
+using juce::jmin;
+using juce::roundToInt;
+
 //==============================================================================
 imagePluginEditor::imagePluginEditor (imagePluginFilter* const ownerFilter)
     : AudioProcessorEditor (ownerFilter),
-      bankSlider (0),
-      progSlider (0),
+      bankSlider (nullptr),
+      progSlider (nullptr),
       textEditor (0)
 {
     setMouseClickGrabsKeyboardFocus (false);
@@ -17,7 +20,7 @@ imagePluginEditor::imagePluginEditor (imagePluginFilter* const ownerFilter)
     imagepad->addMouseListener (this, true);
     imagepad->addKeyListener (this);
 
-    textEditor = new TextEditor ("text editor");
+    textEditor = new juce::TextEditor ("text editor");
     textEditor->setMultiLine (true);
     textEditor->setReturnKeyStartsNewLine (true);
     textEditor->setReadOnly (false);
@@ -27,50 +30,50 @@ imagePluginEditor::imagePluginEditor (imagePluginFilter* const ownerFilter)
     textEditor->setSelectAllWhenFocused (true);
     textEditor->addListener (this);
     textEditor->setText (getFilter()->text);
-    textEditor->setColour (TextEditor::outlineColourId, Colours::black);
+    textEditor->setColour (juce::TextEditor::outlineColourId, juce::Colours::black);
 
-    bankSlider = new Slider ("bank");
+    bankSlider = new juce::Slider ("bank");
     bankSlider->setRange (0, 127, 1);
-    bankSlider->setSliderStyle (Slider::IncDecButtons);
-    bankSlider->setTextBoxStyle (Slider::TextBoxLeft, false, 40, 20);
+    bankSlider->setSliderStyle (juce::Slider::IncDecButtons);
+    bankSlider->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 40, 20);
     bankSlider->addListener (this);
 
-    progSlider = new Slider ("program");
+    progSlider = new juce::Slider ("program");
     progSlider->setRange (0, 127, 1);
-    progSlider->setSliderStyle (Slider::IncDecButtons);
-    progSlider->setTextBoxStyle (Slider::TextBoxLeft, false, 40, 20);
+    progSlider->setSliderStyle (juce::Slider::IncDecButtons);
+    progSlider->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 40, 20);
     progSlider->addListener (this);
 
     chanSlider = new ChannelSlider ("channel");
-    chanSlider->setTextBoxStyle (Slider::TextBoxLeft, false, 40, 20);
+    chanSlider->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 40, 20);
     chanSlider->addListener (this);
 
-    container->addAndMakeVisible (label = new Label ("new label",
-                                                     "Insert Piz Here->  image v" + String (JucePlugin_VersionString) + "\n\n- Double-click to toggle full-screen\n- Drag & drop to load images (png/jpg/gif/svg)\n- Supports MIDI Program Change"));
-    label->setFont (Font (15.0000f, Font::plain));
-    label->setJustificationType (Justification::centredLeft);
+    container->addAndMakeVisible (label = new juce::Label ("new label",
+                                                           "Insert Piz Here->  image v" + juce::String (JucePlugin_VersionString) + "\n\n- Double-click to toggle full-screen\n- Drag & drop to load images (png/jpg/gif/svg)\n- Supports MIDI Program Change"));
+    label->setFont (juce::Font (15.0000f, juce::Font::plain));
+    label->setJustificationType (juce::Justification::centredLeft);
     label->setEditable (false, false, false);
-    label->setColour (Label::backgroundColourId, Colour (0xc7f3ef9f));
-    label->setColour (Label::textColourId, Colours::black);
-    label->setColour (Label::outlineColourId, Colours::black);
-    label->setColour (TextEditor::textColourId, Colours::black);
-    label->setColour (TextEditor::backgroundColourId, Colour (0x0));
+    label->setColour (juce::Label::backgroundColourId, juce::Colour (0xc7f3ef9f));
+    label->setColour (juce::Label::textColourId, juce::Colours::black);
+    label->setColour (juce::Label::outlineColourId, juce::Colours::black);
+    label->setColour (juce::TextEditor::textColourId, juce::Colours::black);
+    label->setColour (juce::TextEditor::backgroundColourId, juce::Colour (0x0));
     label->setMouseClickGrabsKeyboardFocus (false);
     label->addMouseListener (this, false);
     label->setVisible (false);
 
-    colourSelector = new ColourSelector (ColourSelector::showColourAtTop | ColourSelector::showSliders | ColourSelector::showColourspace);
-    colourSelector->setName (String ("color"));
+    colourSelector = new juce::ColourSelector (juce::ColourSelector::showColourAtTop | juce::ColourSelector::showSliders | juce::ColourSelector::showColourspace);
+    colourSelector->setName (juce::String ("color"));
     colourSelector->setCurrentColour (getFilter()->bgcolor);
     colourSelector->addChangeListener (this);
 
-    textColourSelector = new ColourSelector (ColourSelector::showColourAtTop | ColourSelector::showSliders | ColourSelector::showColourspace);
-    textColourSelector->setName (String ("textcolor"));
+    textColourSelector = new juce::ColourSelector (juce::ColourSelector::showColourAtTop | juce::ColourSelector::showSliders | juce::ColourSelector::showColourspace);
+    textColourSelector->setName (juce::String ("textcolor"));
     textColourSelector->setCurrentColour (getFilter()->textcolor);
     textColourSelector->addChangeListener (this);
 
     // add the triangular resizer component for the bottom-right of the UI
-    container->addAndMakeVisible (resizer = new ResizableCornerComponent (this, &resizeLimits));
+    container->addAndMakeVisible (resizer = new juce::ResizableCornerComponent (this, &resizeLimits));
     resizer->setMouseClickGrabsKeyboardFocus (false);
     resizeLimits.setSizeLimits (50, 50, 1600, 1600);
 
@@ -119,9 +122,9 @@ imagePluginEditor::~imagePluginEditor()
 }
 
 //==============================================================================
-void imagePluginEditor::paint (Graphics& g)
+void imagePluginEditor::paint (juce::Graphics& g)
 {
-    g.fillAll (Colour (0x00000000));
+    g.fillAll (juce::Colour (0x00000000));
 }
 
 void imagePluginEditor::resized()
@@ -133,7 +136,7 @@ void imagePluginEditor::resized()
     }
     else
     {
-        auto* display = Desktop::getInstance().getDisplays().getDisplayForPoint (Point<int> (container->getScreenX(), container->getScreenY()), false);
+        auto* display = juce::Desktop::getInstance().getDisplays().getDisplayForPoint (juce::Point<int> (container->getScreenX(), container->getScreenY()), false);
         if (display != nullptr)
         {
             container->setBounds (display->userArea);
@@ -158,14 +161,14 @@ void imagePluginEditor::resized()
     getFilter()->lastUIHeight = getHeight();
 }
 
-void imagePluginEditor::buttonClicked (Button* buttonThatWasClicked)
+void imagePluginEditor::buttonClicked (juce::Button* buttonThatWasClicked)
 {
 }
 
-bool imagePluginEditor::keyPressed (const KeyPress& key, Component* originatingComponent)
+bool imagePluginEditor::keyPressed (const juce::KeyPress& key, Component* originatingComponent)
 {
     int prog = getFilter()->getCurrentProgram();
-    if (key.isKeyCode (KeyPress::pageUpKey))
+    if (key.isKeyCode (juce::KeyPress::pageUpKey))
     {
         prog++;
         if (prog == getFilter()->getNumPrograms())
@@ -174,7 +177,7 @@ bool imagePluginEditor::keyPressed (const KeyPress& key, Component* originatingC
         getFilter()->updateHostDisplay();
         return true;
     }
-    else if (key.isKeyCode (KeyPress::pageDownKey))
+    else if (key.isKeyCode (juce::KeyPress::pageDownKey))
     {
         if (prog == 0)
             prog = getFilter()->getNumPrograms();
@@ -186,15 +189,15 @@ bool imagePluginEditor::keyPressed (const KeyPress& key, Component* originatingC
     return false;
 }
 
-void imagePluginEditor::buttonStateChanged (Button* buttonThatWasClicked)
+void imagePluginEditor::buttonStateChanged (juce::Button* buttonThatWasClicked)
 {
     getFilter()->icon = imagepad->getIconPath();
     if (imagepad->isDown())
     {
-        ModifierKeys mousebutton = ModifierKeys::getCurrentModifiers();
+        juce::ModifierKeys mousebutton = juce::ModifierKeys::getCurrentModifiers();
         if (mousebutton.isPopupMenu())
         {
-            PopupMenu m, sub1, sub2, sub3, subB, subP, subC;
+            juce::PopupMenu m, sub1, sub2, sub3, subB, subP, subC;
             m.addSectionHeader ("Text:");
             m.addCustomItem (1234, *textEditor, 200, 72, false);
             m.addSeparator();
@@ -227,24 +230,24 @@ void imagePluginEditor::buttonStateChanged (Button* buttonThatWasClicked)
             {
                 if (result == 66)
                 {
-                    getFilter()->icon = String ("");
+                    getFilter()->icon = juce::String ("");
                     imagepad->setImages (0);
                     imagepad->setIconPath ("");
                     imagepad->repaint();
                 }
                 else if (result == 99999)
                 {
-                    FileChooser myChooser ("Load image...",
-                                           File (getFilter()->iconPath),
-                                           "*.png;*.gif;*.svg;*.jpg");
+                    juce::FileChooser myChooser ("Load image...",
+                                                 juce::File (getFilter()->iconPath),
+                                                 "*.png;*.gif;*.svg;*.jpg");
 
                     if (myChooser.browseForFileToOpen())
                     {
-                        File file (myChooser.getResult());
+                        juce::File file (myChooser.getResult());
                         if (imagepad->setImageFromFile (file))
                         {
                             //save the relative path
-                            imagepad->setIconPath (file.getRelativePathFrom (File (getFilter()->iconPath)));
+                            imagepad->setIconPath (file.getRelativePathFrom (juce::File (getFilter()->iconPath)));
                             getFilter()->icon = imagepad->getIconPath();
                         }
                     }
@@ -281,7 +284,7 @@ void imagePluginEditor::buttonStateChanged (Button* buttonThatWasClicked)
     }
 }
 
-void imagePluginEditor::sliderValueChanged (Slider* sliderThatWasMoved)
+void imagePluginEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
 {
     if (sliderThatWasMoved == bankSlider)
     {
@@ -300,18 +303,18 @@ void imagePluginEditor::sliderValueChanged (Slider* sliderThatWasMoved)
     }
 }
 
-void imagePluginEditor::mouseDown (const MouseEvent& e)
+void imagePluginEditor::mouseDown (const juce::MouseEvent& e)
 {
     if (e.eventComponent == label)
         label->setVisible (false);
 }
 
-void imagePluginEditor::mouseDoubleClick (const MouseEvent& e)
+void imagePluginEditor::mouseDoubleClick (const juce::MouseEvent& e)
 {
     if (! fullscreen)
     {
         container->addToDesktop (0);
-        Desktop::getInstance().setKioskModeComponent (container, false);
+        juce::Desktop::getInstance().setKioskModeComponent (container, false);
         container->enterModalState (false);
         fullscreen = true;
         resized();
@@ -319,7 +322,7 @@ void imagePluginEditor::mouseDoubleClick (const MouseEvent& e)
     else
     {
         container->exitModalState (0);
-        Desktop::getInstance().setKioskModeComponent (0);
+        juce::Desktop::getInstance().setKioskModeComponent (0);
         this->addChildComponent (container);
         fullscreen = false;
         resized();
@@ -327,7 +330,7 @@ void imagePluginEditor::mouseDoubleClick (const MouseEvent& e)
     getFilter()->fullscreen = fullscreen;
 }
 
-void imagePluginEditor::textEditorTextChanged (TextEditor& editor)
+void imagePluginEditor::textEditorTextChanged (juce::TextEditor& editor)
 {
     if (&editor == textEditor)
     {
@@ -337,7 +340,7 @@ void imagePluginEditor::textEditorTextChanged (TextEditor& editor)
     }
 }
 
-void imagePluginEditor::textEditorReturnKeyPressed (TextEditor& editor)
+void imagePluginEditor::textEditorReturnKeyPressed (juce::TextEditor& editor)
 {
     if (&editor == textEditor)
     {
@@ -345,25 +348,25 @@ void imagePluginEditor::textEditorReturnKeyPressed (TextEditor& editor)
         imagepad->setButtonText (textEditor->getText());
         imagepad->repaint();
         getFilter()->text = textEditor->getText();
-        PopupMenu::dismissAllActiveMenus();
+        juce::PopupMenu::dismissAllActiveMenus();
     }
 }
 
-void imagePluginEditor::textEditorEscapeKeyPressed (TextEditor& editor)
+void imagePluginEditor::textEditorEscapeKeyPressed (juce::TextEditor& editor)
 {
-    PopupMenu::dismissAllActiveMenus();
+    juce::PopupMenu::dismissAllActiveMenus();
     textEditor->setText (getFilter()->text);
     imagepad->repaint();
 }
 
-void imagePluginEditor::textEditorFocusLost (TextEditor& editor)
+void imagePluginEditor::textEditorFocusLost (juce::TextEditor& editor)
 {
     getFilter()->text = textEditor->getText();
 }
 
-bool imagePluginEditor::isInterestedInFileDrag (const StringArray& files)
+bool imagePluginEditor::isInterestedInFileDrag (const juce::StringArray& files)
 {
-    File file = File (files.joinIntoString (String(), 0, 1));
+    juce::File file = juce::File (files.joinIntoString (juce::String(), 0, 1));
     if (file.hasFileExtension ("png") || file.hasFileExtension ("gif") || file.hasFileExtension ("jpg") || file.hasFileExtension ("svg"))
         return true;
     return false;
@@ -373,19 +376,19 @@ void imagePluginEditor::filesDropped (const juce::StringArray& filenames, int mo
 {
     if (isInterestedInFileDrag (filenames))
     {
-        String filename = filenames.joinIntoString (String(), 0, 1);
-        File file       = File (filename);
+        juce::String filename = filenames.joinIntoString (juce::String(), 0, 1);
+        juce::File file       = juce::File (filename);
         if (imagepad->setImageFromFile (file))
         {
             //save the relative path
-            imagepad->setIconPath (file.getRelativePathFrom (File (getFilter()->iconPath)));
+            imagepad->setIconPath (file.getRelativePathFrom (juce::File (getFilter()->iconPath)));
             getFilter()->icon = imagepad->getIconPath();
         }
     }
 }
 
 //==============================================================================
-void imagePluginEditor::changeListenerCallback (ChangeBroadcaster* source)
+void imagePluginEditor::changeListenerCallback (juce::ChangeBroadcaster* source)
 {
     if (source == getFilter())
     {
@@ -393,13 +396,13 @@ void imagePluginEditor::changeListenerCallback (ChangeBroadcaster* source)
     }
     else if (source == colourSelector)
     {
-        ColourSelector* cs = (ColourSelector*) source;
+        auto* cs = (juce::ColourSelector*) source;
         imagepad->setColour (cs->getCurrentColour());
         getFilter()->bgcolor = cs->getCurrentColour();
     }
     else if (source == textColourSelector)
     {
-        ColourSelector* cs = (ColourSelector*) source;
+        auto* cs = (juce::ColourSelector*) source;
         imagepad->setTextColour (cs->getCurrentColour());
         getFilter()->textcolor = cs->getCurrentColour();
     }
@@ -416,19 +419,18 @@ void imagePluginEditor::updateParametersFromFilter()
     imagePluginFilter* const filter = getFilter();
     // we use this lock to make sure the processBlock() method isn't writing to the
     // lastMidiMessage variable while we're trying to read it, but be extra-careful to
-    // only hold the lock for a minimum amount of time..
+    // only hold the lock for a minimum amount of time
     filter->getCallbackLock().enter();
 
-    // take a local copy of the info we need while we've got the lock..
+    // take a local copy of the info we need while we've got the lock
 
-    const String t         = filter->text;
-    const String icon      = filter->icon;
-    const Colour bgcolor   = filter->bgcolor;
-    const Colour textcolor = filter->textcolor;
-    const int bank         = filter->getCurrentBank();
-    const int prog         = filter->getCurrentProgram();
-    const float chan       = filter->getParameter (kChannel);
-    //fullscreen = filter->fullscreen;
+    const juce::String t         = filter->text;
+    const juce::String icon      = filter->icon;
+    const juce::Colour bgcolor   = filter->bgcolor;
+    const juce::Colour textcolor = filter->textcolor;
+    const int bank               = filter->getCurrentBank();
+    const int prog               = filter->getCurrentProgram();
+    const float chan             = filter->getParameter (kChannel);
 
     // ..release the lock ASAP
     filter->getCallbackLock().exit();
@@ -437,16 +439,16 @@ void imagePluginEditor::updateParametersFromFilter()
 
     if (icon.isEmpty())
     {
-        imagepad->setImages (0);
-        imagepad->setIconPath (String());
+        imagepad->setImages (nullptr);
+        imagepad->setIconPath (juce::String());
     }
     else
     {
-        String fullpath = icon;
-        if (! File::getCurrentWorkingDirectory().getChildFile (fullpath).existsAsFile())
-            fullpath = getFilter()->iconPath + File::getSeparatorString() + icon;
-        if (! imagepad->setImageFromFile (File::getCurrentWorkingDirectory().getChildFile (fullpath)))
-            imagepad->setImages (0);
+        juce::String fullpath = icon;
+        if (! juce::File::getCurrentWorkingDirectory().getChildFile (fullpath).existsAsFile())
+            fullpath = getFilter()->iconPath + juce::File::getSeparatorString() + icon;
+        if (! imagepad->setImageFromFile (juce::File::getCurrentWorkingDirectory().getChildFile (fullpath)))
+            imagepad->setImages (nullptr);
         imagepad->setIconPath (icon);
     }
 
@@ -456,9 +458,9 @@ void imagePluginEditor::updateParametersFromFilter()
     imagepad->setTextColour (textcolor);
     colourSelector->setCurrentColour (bgcolor);
     textColourSelector->setCurrentColour (textcolor);
-    bankSlider->setValue (bank, dontSendNotification);
-    progSlider->setValue (prog, dontSendNotification);
-    chanSlider->setValue (chan * 16.0, dontSendNotification);
+    bankSlider->setValue (bank, juce::dontSendNotification);
+    progSlider->setValue (prog, juce::dontSendNotification);
+    chanSlider->setValue (chan * 16.0, juce::dontSendNotification);
 
     setSize (filter->lastUIWidth,
              filter->lastUIHeight);

--- a/pizjuce/Image/imagePluginEditor.h
+++ b/pizjuce/Image/imagePluginEditor.h
@@ -1,21 +1,21 @@
 #ifndef IMAGEPLUGINEDITOR_H
 #define IMAGEPLUGINEDITOR_H
 
-#include "juce_audio_processors/juce_audio_processors.h"
-#include "juce_gui_basics/juce_gui_basics.h"
-#include "juce_gui_extra/juce_gui_extra.h"
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <juce_gui_extra/juce_gui_extra.h>
 
 #include "../_common/ChannelSlider.h"
 #include "imagePlugin.h"
 #include "MidiPad.h"
 
-class imagePluginEditor : public AudioProcessorEditor,
-                          public Button::Listener,
-                          public Slider::Listener,
-                          public TextEditor::Listener,
-                          public ChangeListener,
-                          public KeyListener,
-                          public FileDragAndDropTarget
+class imagePluginEditor : public juce::AudioProcessorEditor,
+                          public juce::Button::Listener,
+                          public juce::Slider::Listener,
+                          public juce::TextEditor::Listener,
+                          public juce::ChangeListener,
+                          public juce::KeyListener,
+                          public juce::FileDragAndDropTarget
 
 {
 public:
@@ -33,46 +33,46 @@ public:
     /** Our demo filter is a ChangeBroadcaster, and will call us back when one of
         its parameters changes.
     */
-    void changeListenerCallback (ChangeBroadcaster* source) override;
-    void buttonClicked (Button*) override;
-    void buttonStateChanged (Button* buttonThatWasClicked) override;
-    bool keyPressed (const KeyPress& key, Component* originatingComponent) override;
-    void textEditorTextChanged (TextEditor& editor) override;
-    void textEditorReturnKeyPressed (TextEditor& editor) override;
-    void textEditorEscapeKeyPressed (TextEditor& editor) override;
-    void textEditorFocusLost (TextEditor& editor) override;
-    void filesDropped (const StringArray& files, int x, int y) override;
-    bool isInterestedInFileDrag (const StringArray& files) override;
-    void sliderValueChanged (Slider* sliderThatWasMoved) override;
-    void mouseDown (const MouseEvent& e) override;
-    void mouseDoubleClick (const MouseEvent& e) override;
+    void changeListenerCallback (juce::ChangeBroadcaster* source) override;
+    void buttonClicked (juce::Button*) override;
+    void buttonStateChanged (juce::Button* buttonThatWasClicked) override;
+    bool keyPressed (const juce::KeyPress& key, Component* originatingComponent) override;
+    void textEditorTextChanged (juce::TextEditor& editor) override;
+    void textEditorReturnKeyPressed (juce::TextEditor& editor) override;
+    void textEditorEscapeKeyPressed (juce::TextEditor& editor) override;
+    void textEditorFocusLost (juce::TextEditor& editor) override;
+    void filesDropped (const juce::StringArray& files, int x, int y) override;
+    bool isInterestedInFileDrag (const juce::StringArray& files) override;
+    void sliderValueChanged (juce::Slider* sliderThatWasMoved) override;
+    void mouseDown (const juce::MouseEvent& e) override;
+    void mouseDoubleClick (const juce::MouseEvent& e) override;
 
     //==============================================================================
     /** Standard Juce paint callback. */
-    void paint (Graphics&) override;
+    void paint (juce::Graphics&) override;
 
     /** Standard Juce resize callback. */
     void resized() override;
-    Colour color, color2;
+    juce::Colour color, color2;
 
 private:
     //==============================================================================
     MidiPad* imagepad;
-    TextEditor* textEditor;
-    ColourSelector* colourSelector;
-    ColourSelector* textColourSelector;
-    Slider* bankSlider;
-    Slider* progSlider;
+    juce::TextEditor* textEditor;
+    juce::ColourSelector* colourSelector;
+    juce::ColourSelector* textColourSelector;
+    juce::Slider* bankSlider;
+    juce::Slider* progSlider;
     ChannelSlider* chanSlider;
-    ResizableCornerComponent* resizer;
-    ComponentBoundsConstrainer resizeLimits;
+    juce::ResizableCornerComponent* resizer;
+    juce::ComponentBoundsConstrainer resizeLimits;
     void updateParametersFromFilter();
     Component* container;
-    Label* label;
+    juce::Label* label;
     bool fullscreen;
 
     // handy wrapper method to avoid having to cast the filter to a imagePluginFilter
-    // every time we need it..
+    // every time we need it
     imagePluginFilter* getFilter() const throw() { return (imagePluginFilter*) getAudioProcessor(); }
 };
 

--- a/pizjuce/KVRBrowser/WebBrowserFilter.h
+++ b/pizjuce/KVRBrowser/WebBrowserFilter.h
@@ -12,7 +12,7 @@
 
 */
 class WebBrowserFilter : public PizAudioProcessor,
-                         public ChangeBroadcaster
+                         public juce::ChangeBroadcaster
 {
 public:
     //==============================================================================
@@ -23,14 +23,14 @@ public:
     void prepareToPlay (double sampleRate, int samplesPerBlock) override;
     void releaseResources() override;
 
-    void processBlock (AudioSampleBuffer& buffer,
-                       MidiBuffer& midiMessages) override;
+    void processBlock (juce::AudioSampleBuffer& buffer,
+                       juce::MidiBuffer& midiMessages) override;
 
     //==============================================================================
-    AudioProcessorEditor* createEditor() override;
+    juce::AudioProcessorEditor* createEditor() override;
 
     //==============================================================================
-    const String getName() const override;
+    const juce::String getName() const override;
     bool hasEditor() const override { return true; }
 
     int getNumParameters() override;
@@ -38,11 +38,11 @@ public:
     float getParameter (int index) override;
     void setParameter (int index, float newValue) override;
 
-    const String getParameterName (int index) override;
-    const String getParameterText (int index) override;
+    const juce::String getParameterName (int index) override;
+    const juce::String getParameterText (int index) override;
 
-    const String getInputChannelName (int channelIndex) const override;
-    const String getOutputChannelName (int channelIndex) const override;
+    const juce::String getInputChannelName (int channelIndex) const override;
+    const juce::String getOutputChannelName (int channelIndex) const override;
     bool isInputChannelStereoPair (int index) const override;
     bool isOutputChannelStereoPair (int index) const override;
 
@@ -54,11 +54,11 @@ public:
     int getNumPrograms() override { return 0; }
     int getCurrentProgram() override { return 0; }
     void setCurrentProgram (int index) override {}
-    const String getProgramName (int index) override { return String(); }
-    void changeProgramName (int index, const String& newName) override {}
+    const juce::String getProgramName (int index) override { return juce::String(); }
+    void changeProgramName (int index, const juce::String& newName) override {}
 
     //==============================================================================
-    void getStateInformation (MemoryBlock& destData) override;
+    void getStateInformation (juce::MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
 
     //==============================================================================
@@ -70,23 +70,22 @@ public:
     // resized.
     int lastUIWidth, lastUIHeight;
 
-    String getURL() { return URL; }
-    void setURL (const String& newURL) { URL = newURL; }
+    juce::String getURL() { return URL; }
+    void setURL (const juce::String& newURL) { URL = newURL; }
     bool initialPageLoaded;
 
-    //==============================================================================
-    juce_UseDebuggingNewOperator
-
-        private :
-        // this is our gain - the UI and the host can access this by getting/setting
-        // parameter 0.
-        float gain;
-    String URL;
+private:
+    // this is our gain - the UI and the host can access this by getting/setting
+    // parameter 0.
+    float gain;
+    juce::String URL;
     float lastinL;
     float lastoutL;
     float lastinR;
     float lastoutR;
     float R;
+
+    JUCE_LEAK_DETECTOR (WebBrowserFilter)
 };
 
 #endif

--- a/pizjuce/KVRBrowser/WebBrowserPluginEditor.cpp
+++ b/pizjuce/KVRBrowser/WebBrowserPluginEditor.cpp
@@ -24,7 +24,7 @@
 
 //[MiscUserDefs] You can add your own user definitions and misc code here...
 //==============================================================================
-bool MyBrowser::pageAboutToLoad (const String& newURL)
+bool MyBrowser::pageAboutToLoad (const juce::String& newURL)
 {
     if (! newURL.contains ("googleads"))
     {
@@ -34,7 +34,7 @@ bool MyBrowser::pageAboutToLoad (const String& newURL)
     return true;
 }
 
-String MyBrowser::getCurrentURL()
+juce::String MyBrowser::getCurrentURL()
 {
     return lastURL;
 }
@@ -96,7 +96,7 @@ WebBrowserPluginEditor::WebBrowserPluginEditor (WebBrowserFilter* const ownerFil
     addAndMakeVisible (goButton.get());
     goButton->addListener (this);
 
-    resizer.reset (new ResizableCornerComponent (this, &resizeLimits));
+    resizer.reset (new juce::ResizableCornerComponent (this, &resizeLimits));
     addAndMakeVisible (resizer.get());
 
     //[UserPreSize]
@@ -212,7 +212,7 @@ void WebBrowserPluginEditor::buttonClicked (juce::Button* buttonThatWasClicked)
 
 //[MiscUserCode] You can add your own definitions of your custom methods or any other code here...
 //==============================================================================
-void WebBrowserPluginEditor::changeListenerCallback (ChangeBroadcaster* source)
+void WebBrowserPluginEditor::changeListenerCallback (juce::ChangeBroadcaster* source)
 {
     if (source == getFilter())
     {
@@ -226,9 +226,9 @@ void WebBrowserPluginEditor::changeListenerCallback (ChangeBroadcaster* source)
     }
 }
 
-void WebBrowserPluginEditor::textEditorReturnKeyPressed (TextEditor& editor)
+void WebBrowserPluginEditor::textEditorReturnKeyPressed (juce::TextEditor& editor)
 {
-    wb->goToURL ((const String) (editor.getText()));
+    wb->goToURL ((const juce::String) (editor.getText()));
 }
 
 void WebBrowserPluginEditor::updateParametersFromFilter()
@@ -237,14 +237,14 @@ void WebBrowserPluginEditor::updateParametersFromFilter()
 
     // we use this lock to make sure the processBlock() method isn't writing to the
     // lastMidiMessage variable while we're trying to read it, but be extra-careful to
-    // only hold the lock for a minimum amount of time..
+    // only hold the lock for a minimum amount of time
     filter->getCallbackLock().enter();
 
-    // take a local copy of the info we need while we've got the lock..
+    // take a local copy of the info we need while we've got the lock
     const float newGain = filter->getParameter (0);
-    String URL          = filter->getURL();
+    juce::String URL    = filter->getURL();
 
-    // ..release the lock ASAP
+    // release the lock ASAP
     filter->getCallbackLock().exit();
 
     if (URL.isNotEmpty())

--- a/pizjuce/KVRBrowser/WebBrowserPluginEditor.h
+++ b/pizjuce/KVRBrowser/WebBrowserPluginEditor.h
@@ -20,8 +20,8 @@
 #pragma once
 
 //[Headers]     -- You can add your own extra header files here --
-#include "juce_events/juce_events.h"
-#include "juce_gui_extra/juce_gui_extra.h"
+#include <juce_events/juce_events.h>
+#include <juce_gui_extra/juce_gui_extra.h>
 
 #include "WebBrowserFilter.h"
 
@@ -32,10 +32,10 @@ public:
     MyBrowser()
         : unloadPageWhenBrowserIsHidden (false){};
     ~MyBrowser() override{};
-    bool pageAboutToLoad (const String& newURL) override;
-    String getCurrentURL();
+    bool pageAboutToLoad (const juce::String& newURL) override;
+    juce::String getCurrentURL();
     friend class WebBrowserComponent;
-    String lastURL;
+    juce::String lastURL;
 
 private:
     bool unloadPageWhenBrowserIsHidden;
@@ -51,9 +51,9 @@ private:
     Describe your class and how it works here!
                                                                     //[/Comments]
 */
-class WebBrowserPluginEditor : public AudioProcessorEditor,
-                               public ChangeListener,
-                               public TextEditor::Listener,
+class WebBrowserPluginEditor : public juce::AudioProcessorEditor,
+                               public juce::ChangeListener,
+                               public juce::TextEditor::Listener,
                                public juce::Button::Listener
 {
 public:
@@ -63,11 +63,11 @@ public:
 
     //==============================================================================
     //[UserMethods]     -- You can add your own custom methods in this section.
-    void textEditorReturnKeyPressed (TextEditor& editor) override;
-    void textEditorEscapeKeyPressed (TextEditor& editor) override{};
-    void textEditorTextChanged (TextEditor& editor) override{};
-    void textEditorFocusLost (TextEditor& editor) override{};
-    void changeListenerCallback (ChangeBroadcaster* source) override;
+    void textEditorReturnKeyPressed (juce::TextEditor& editor) override;
+    void textEditorEscapeKeyPressed (juce::TextEditor& editor) override{};
+    void textEditorTextChanged (juce::TextEditor& editor) override{};
+    void textEditorFocusLost (juce::TextEditor& editor) override{};
+    void changeListenerCallback (juce::ChangeBroadcaster* source) override;
     //[/UserMethods]
 
     void paint (juce::Graphics& g) override;
@@ -76,13 +76,13 @@ public:
 
 private:
     //[UserVariables]   -- You can add your own custom variables in this section.
-    ComponentBoundsConstrainer resizeLimits;
-    TooltipWindow tooltipWindow;
+    juce::ComponentBoundsConstrainer resizeLimits;
+    juce::TooltipWindow tooltipWindow;
 
     void updateParametersFromFilter();
 
     // handy wrapper method to avoid having to cast the filter to a DemoJuceFilter
-    // every time we need it..
+    // every time we need it
     WebBrowserFilter* getFilter() const throw() { return (WebBrowserFilter*) getAudioProcessor(); }
     //[/UserVariables]
 
@@ -95,7 +95,7 @@ private:
     std::unique_ptr<juce::TextButton> stopButton;
     std::unique_ptr<juce::TextEditor> urlBar;
     std::unique_ptr<juce::TextButton> goButton;
-    std::unique_ptr<ResizableCornerComponent> resizer;
+    std::unique_ptr<juce::ResizableCornerComponent> resizer;
 
     //==============================================================================
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (WebBrowserPluginEditor)

--- a/pizjuce/MiddyMorphy/Controller.cpp
+++ b/pizjuce/MiddyMorphy/Controller.cpp
@@ -1,42 +1,35 @@
-
 #include "Controller.h"
 #include "ControllerValue.h"
 #include "MidiMorph.h"
 #include "Scene.h"
 
+using juce::roundToInt;
+
 Controller::Controller (MidiMorph* core)
 {
-    // Bouml preserved body begin 00034E0D
     this->core         = core;
     this->channel      = 1;
     this->ccNo         = 0;
     this->valueChanged = true;
     this->newMidi      = true;
-    //this->midiMessage =  & MidiMessage::controllerEvent(channel,ccNo,64);
-    // Bouml preserved body end 00034E0D
 }
 
 Controller::~Controller()
 {
-    // Bouml preserved body begin 00040B8D
     for (int i = 0; i < this->values.size(); i++)
     {
         delete values[i];
     }
     removeAllChangeListeners();
-    // Bouml preserved body end 00040B8D
 }
 
 ControllerValue* Controller::getValue (int index)
 {
-    // Bouml preserved body begin 0004080D
     return values[index];
-    // Bouml preserved body end 0004080D
 }
 
 ControllerValue* Controller::getValue (const Scene* scene)
 {
-    // Bouml preserved body begin 0002FB0D
     for (int i = 0; i < values.size(); i++)
     {
         if (values[i]->scene == scene)
@@ -44,14 +37,11 @@ ControllerValue* Controller::getValue (const Scene* scene)
             return values[i];
         }
     }
-    return 0;
-    // Bouml preserved body end 0002FB0D
+    return nullptr;
 }
 
-//set value for particular scene
 void Controller::setValue (int newValue, Scene* scene)
 {
-    // Bouml preserved body begin 00034C8D
     for (int i = 0; i < values.size(); i++)
     {
         if (values[i]->scene == scene)
@@ -62,29 +52,22 @@ void Controller::setValue (int newValue, Scene* scene)
             return;
         }
     }
-    ControllerValue* value = new ControllerValue (this, scene);
-    value->setValue (newValue);
-    values.add (value);
-    scene->addValue (value);
+    auto* newControllerValue = new ControllerValue (this, scene);
+    newControllerValue->setValue (newValue);
+    values.add (newControllerValue);
+    scene->addValue (newControllerValue);
     controllerChanged();
-
-    // Bouml preserved body end 00034C8D
 }
 
-//refresh value of selected scenes
 void Controller::controllerChanged()
 {
-    // Bouml preserved body begin 0003598D
     this->valueChanged = true;
     this->newMidi      = true;
     this->core->controllerChanged (this);
-    // Bouml preserved body end 0003598D
 }
 
 int Controller::getState()
 {
-    // Bouml preserved body begin 0003E98D
-
     if (core->getNumSelectedScenes() == 0)
     {
         return Controller::undefined;
@@ -103,8 +86,8 @@ int Controller::getState()
     else if (core->getNumSelectedScenes() > 1)
     {
         bool defined = false;
-        //bool multiple = false;
-        int lastVal = 0;
+        int lastVal  = 0;
+
         for (int i = 0; i < this->core->getNumSelectedScenes(); i++)
         {
             if (core->getSelectedScene (i)->getValue (this) != lastVal && i > 0)
@@ -127,12 +110,10 @@ int Controller::getState()
         }
     }
     return Controller::undefined;
-    // Bouml preserved body end 0003E98D
 }
 
 int Controller::getInterpolatedValue()
 {
-    // Bouml preserved body begin 0003518D
     if (valueChanged || core->hasNewMidi())
     {
         float tmp = 0;
@@ -146,129 +127,86 @@ int Controller::getInterpolatedValue()
         value        = roundToInt (tmp);
     }
     return value;
-    // Bouml preserved body end 0003518D
 }
 
-void Controller::addValue (ControllerValue* value)
+void Controller::addValue (ControllerValue* valueToAdd)
 {
-    // Bouml preserved body begin 0004098D
-    this->values.add (value);
-    // Bouml preserved body end 0004098D
+    this->values.add (valueToAdd);
 }
 
 void Controller::learn()
 {
-    // Bouml preserved body begin 0003100D
-    // Bouml preserved body end 0003100D
 }
 
-void Controller::removeValue (ControllerValue* value)
+void Controller::removeValue (ControllerValue* valueToRemove)
 {
-    // Bouml preserved body begin 0003FA8D
-    this->values.removeAllInstancesOf (value);
-    // Bouml preserved body end 0003FA8D
+    this->values.removeAllInstancesOf (valueToRemove);
 }
 
 int Controller::getNumValues()
 {
-    // Bouml preserved body begin 0004050D
     return this->values.size();
-    // Bouml preserved body end 0004050D
 }
 
 void Controller::getMidiMessage (juce::MidiBuffer& buffer, int pos)
 {
-    // Bouml preserved body begin 0004108D
-    /*if( newMidi )
-	{*/
-    //if( has)
     {
-        buffer.addEvent (MidiMessage::controllerEvent (channel, ccNo, getInterpolatedValue()), pos);
-
-        //lastSentValue =
-        //this->lastSentChannel = channel
+        buffer.addEvent (juce::MidiMessage::controllerEvent (channel, ccNo, getInterpolatedValue()), pos);
     }
-    /*}*/
-    //MidiMessage* m = new MidiMessage();
-    //this->newMidi = false;
-    //return *m;
-    // Bouml preserved body end 0004108D
 }
 
 void Controller::remove()
 {
-    // Bouml preserved body begin 0004150D
     core->removeController (this);
-    // Bouml preserved body end 0004150D
 }
 
 bool Controller::hasNewMidi()
 {
-    // Bouml preserved body begin 0004218D
-
     bool result = newMidi || core->needsRefresh();
     newMidi     = false;
     return result;
-
-    // Bouml preserved body end 0004218D
 }
 
-int Controller::getCcNo()
+int Controller::getCcNo() const
 {
-    // Bouml preserved body begin 0004220D
     return ccNo;
-    // Bouml preserved body end 0004220D
 }
 
 void Controller::setCcNo (int val)
 {
-    // Bouml preserved body begin 0004228D
     this->ccNo = val;
-    // Bouml preserved body end 0004228D
 }
 
-int Controller::getChannel()
+int Controller::getChannel() const
 {
-    // Bouml preserved body begin 0004230D
     return channel;
-    // Bouml preserved body end 0004230D
 }
 
-void Controller::setChannel (int channel)
+void Controller::setChannel (int channelToSet)
 {
-    // Bouml preserved body begin 0004238D
-    this->channel = channel;
-    // Bouml preserved body end 0004238D
+    this->channel = channelToSet;
 }
 
-String Controller::getName()
+juce::String Controller::getName()
 {
-    // Bouml preserved body begin 0004288D
     return this->name;
-    // Bouml preserved body end 0004288D
 }
 
-void Controller::setName (String name)
+void Controller::setName (juce::String nameToSet)
 {
-    // Bouml preserved body begin 0004290D
-    this->name = name;
-    // Bouml preserved body end 0004290D
+    this->name = nameToSet;
 }
 
-//set value for selected Scenes
-void Controller::setValue (int newValue)
+void Controller::setValueInSelectedScenes (int newValue)
 {
-    // Bouml preserved body begin 00047C8D
-
     for (int i = core->getNumSelectedScenes(); --i >= 0;)
     {
         setValue (newValue, core->getSelectedScene (i));
     }
     core->sendChangeMessage (this);
+
     if (core->getNumSelectedScenes() == 0 && core->autoKey)
     {
         core->addSceneAtCursor();
     }
-
-    // Bouml preserved body end 00047C8D
 }

--- a/pizjuce/MiddyMorphy/Controller.h
+++ b/pizjuce/MiddyMorphy/Controller.h
@@ -1,20 +1,12 @@
 #pragma once
 
-#include "juce_core/juce_core.h"
-#include "juce_events/juce_events.h"
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_core/juce_core.h>
+#include <juce_events/juce_events.h>
 
 class MidiMorph;
 class ControllerValue;
 class Scene;
-namespace juce
-{
-class MidiBuffer;
-}
-namespace juce
-{
-class MidiMessage;
-}
-using namespace juce;
 
 class Controller : public juce::ChangeBroadcaster
 {
@@ -23,20 +15,6 @@ public:
 
     ~Controller() override;
 
-private:
-    bool newMidi;
-
-    bool valueChanged;
-
-    int ccNo;
-
-    int channel;
-
-    int value;
-
-    String name;
-
-public:
     enum states
     {
         undefined = 0,
@@ -45,23 +23,12 @@ public:
 
     };
 
-private:
-    Array<ControllerValue*> values;
-
-    MidiMorph* core;
-
-    friend class ControllerValue;
-    friend class ControllerGUI;
-
-public:
     ControllerValue* getValue (int index);
 
     ControllerValue* getValue (const Scene* scene);
 
-    //set value for particular scene
     void setValue (int newValue, Scene* scene);
 
-    //refresh value of selected scenes
     void controllerChanged();
 
     int getState();
@@ -82,27 +49,37 @@ public:
 
     bool hasNewMidi();
 
-    int getCcNo();
+    int getCcNo() const;
 
     void setCcNo (int val);
 
-    int getChannel();
+    int getChannel() const;
 
     void setChannel (int channel);
 
-    String getName();
+    juce::String getName();
 
-    void setName (String name);
+    void setName (juce::String name);
 
-    //set value for selected Scenes
-    void setValue (int newValue);
+    void setValueInSelectedScenes (int newValue);
 
 private:
+    bool newMidi;
+
+    bool valueChanged;
+
+    int ccNo;
+    int channel;
+    int value;
+
+    juce::String name;
+
+    juce::Array<ControllerValue*> values;
+
+    MidiMorph* core;
+
+    friend class ControllerValue;
+    friend class ControllerGUI;
+
     juce::MidiMessage* midiMessage;
-
-    int lastSentCcNo;
-
-    int lastSentChannel;
-
-    int lastSentValue;
 };

--- a/pizjuce/MiddyMorphy/ControllerGUI.cpp
+++ b/pizjuce/MiddyMorphy/ControllerGUI.cpp
@@ -4,9 +4,10 @@
 #include "ControllerValue.h"
 #include "MidiMorph.h"
 
+using juce::roundToInt;
+
 ControllerGUI::ControllerGUI (Controller* controller, MidiMorph* core)
 {
-    // Bouml preserved body begin 00033A8D
     this->controller = controller;
     this->core       = core;
 
@@ -22,20 +23,20 @@ ControllerGUI::ControllerGUI (Controller* controller, MidiMorph* core)
     ccNo->setRange (0, 127, 1, 2);
     ccNo->addListener (this);
 
-    addAndMakeVisible (this->name = new TextEditor());
+    addAndMakeVisible (this->name = new juce::TextEditor());
     name->setSelectAllWhenFocused (true);
-    name->setColour (TextEditor::outlineColourId, Colour (0.f, 0, 0, 0.f));
-    name->setColour (TextEditor::backgroundColourId, Colour (0.f, 0, 0, 0.f));
-    name->setColour (TextEditor::focusedOutlineColourId, Colour (0.f, 0, 0, 0.f));
-    name->setColour (TextEditor::highlightColourId, Colours::white);
-    name->setFont (Font (10));
+    name->setColour (juce::TextEditor::outlineColourId, juce::Colour (0.f, 0, 0, 0.f));
+    name->setColour (juce::TextEditor::backgroundColourId, juce::Colour (0.f, 0, 0, 0.f));
+    name->setColour (juce::TextEditor::focusedOutlineColourId, juce::Colour (0.f, 0, 0, 0.f));
+    name->setColour (juce::TextEditor::highlightColourId, juce::Colours::white);
+    name->setFont (juce::Font (10));
     name->setInputRestrictions (32);
     name->addListener (this);
 
-    addAndMakeVisible (labCc = new Label ("", "cc:"));
-    addAndMakeVisible (labCh = new Label ("", "ch:"));
-    labCc->setFont (Font (10));
-    labCh->setFont (Font (10));
+    addAndMakeVisible (labCc = new juce::Label ("", "cc:"));
+    addAndMakeVisible (labCh = new juce::Label ("", "ch:"));
+    labCc->setFont (juce::Font (10));
+    labCh->setFont (juce::Font (10));
 
     setOpaque (true);
 
@@ -45,29 +46,21 @@ ControllerGUI::ControllerGUI (Controller* controller, MidiMorph* core)
     refreshControllerData();
 
     core->addChangeListener (this);
-
-    //controller->addChangeListener(this);
-    // Bouml preserved body end 00033A8D
 }
 
 ControllerGUI::~ControllerGUI()
 {
-    // Bouml preserved body begin 0003EF0D
     core->removeChangeListener (this);
-    //controller->removeChangeListener(this);
     deleteAndZero (value);
     deleteAndZero (channel);
     deleteAndZero (ccNo);
     deleteAndZero (name);
     deleteAndZero (labCc);
     deleteAndZero (labCh);
-    //deleteAndZero(test);
-    // Bouml preserved body end 0003EF0D
 }
 
 void ControllerGUI::resized()
 {
-    // Bouml preserved body begin 00033B0D
     int left       = roundToInt ((float) getWidth() * 0.30f);
     int right      = getWidth() - left;
     int h2         = getHeight() / 2;
@@ -85,33 +78,27 @@ void ControllerGUI::resized()
 
     labCc->setBounds (right2, h2, rightdelta, h2);
     ccNo->setBounds (right3, h2, rightdelta, h2);
-    // Bouml preserved body end 00033B0D
 }
 
 //==============================================================================
 
-void ControllerGUI::paint (Graphics& g)
+void ControllerGUI::paint (juce::Graphics& g)
 {
-    // Bouml preserved body begin 00033B8D
-    g.fillAll (Colours::lightgrey);
-    // Bouml preserved body end 00033B8D
+    g.fillAll (juce::Colours::lightgrey);
 }
 
 //==============================================================================
 
-void ControllerGUI::paintOverChildren (Graphics& g)
+void ControllerGUI::paintOverChildren (juce::Graphics& g)
 {
-    // Bouml preserved body begin 00033F0D
     g.drawRoundedRectangle (0, 0, (float) getWidth(), (float) getHeight(), 2, 2);
-    // Bouml preserved body end 00033F0D
 }
 
-void ControllerGUI::mouseUp (const MouseEvent& e)
+void ControllerGUI::mouseUp (const juce::MouseEvent& e)
 {
-    // Bouml preserved body begin 00033F8D
     if (e.mods.isRightButtonDown())
     {
-        PopupMenu menu;
+        juce::PopupMenu menu;
         menu.addItem (1, "remove controller");
         menu.addItem (2, "add controller");
         int result = menu.show();
@@ -126,118 +113,84 @@ void ControllerGUI::mouseUp (const MouseEvent& e)
             core->addController (cc + 1, ch);
         }
     }
-    // Bouml preserved body end 00033F8D
 }
 
-//()=
-void ControllerGUI::sliderValueChanged (Slider* slider)
+void ControllerGUI::sliderValueChanged (juce::Slider* slider)
 {
-    // Bouml preserved body begin 00034C0D
-    // Bouml preserved body end 00034C0D
 }
 
 void ControllerGUI::setSelected (bool shouldDrawSelected)
 {
-    // Bouml preserved body begin 00033E8D
     this->isSelected = true;
-    // Bouml preserved body end 00033E8D
 }
 
-void ControllerGUI::changeListenerCallback (ChangeBroadcaster* source)
+void ControllerGUI::changeListenerCallback (juce::ChangeBroadcaster* source)
 {
-    // Bouml preserved body begin 0003EA8D
-    //if(objectThatHasChanged == controller)
-    //{
-    //	refreshControllerData();
-    //	this->repaint();
-    //}
-    //else if(objectThatHasChanged == core->getSelectedScenes())
-    //{
-    //	refreshControllerData();
-    //	this->repaint();
-    //}
-    //else if(objectThatHasChanged == core->getCursor())
-    //{
     refreshControllerData();
-
-    //}
-    // Bouml preserved body end 0003EA8D
 }
 
 void ControllerGUI::refreshControllerData()
 {
-    // Bouml preserved body begin 0003F38D
     if (core->getNumSelectedScenes() > 0)
     {
         if (controller->getValue (core->getSelectedScene (0)) != 0)
         {
-            this->value->setValue (controller->getValue (core->getSelectedScene (0))->getValue(), dontSendNotification);
+            this->value->setValue (controller->getValue (core->getSelectedScene (0))->getValue(), juce::dontSendNotification);
         }
         else
         {
-            this->value->setValue (0, dontSendNotification);
+            this->value->setValue (0, juce::dontSendNotification);
         }
     }
     else
     {
-        this->value->setValue (controller->getInterpolatedValue(), dontSendNotification);
+        this->value->setValue (controller->getInterpolatedValue(), juce::dontSendNotification);
     }
-    this->channel->setValue (controller->getChannel(), dontSendNotification);
-    this->ccNo->setValue (controller->getCcNo(), dontSendNotification);
+    this->channel->setValue (controller->getChannel(), juce::dontSendNotification);
+    this->ccNo->setValue (controller->getCcNo(), juce::dontSendNotification);
     this->name->setText (controller->getName(), false);
     int state = controller->getState();
     switch (state)
     {
         case Controller::undefined:
-            value->setColour (Label::textColourId, Colours::blue);
+            value->setColour (juce::Label::textColourId, juce::Colours::blue);
             break;
         case Controller::mutival:
-            value->setColour (Label::textColourId, Colours::red);
+            value->setColour (juce::Label::textColourId, juce::Colours::red);
             break;
         case Controller::defined:
-            value->setColour (Label::textColourId, Colours::black);
+            value->setColour (juce::Label::textColourId, juce::Colours::black);
             break;
     }
 
     this->repaint();
-    // Bouml preserved body end 0003F38D
 }
 
-void ControllerGUI::textEditorTextChanged (TextEditor& editor)
+void ControllerGUI::textEditorTextChanged (juce::TextEditor& editor)
 {
-    // Bouml preserved body begin 0004178D
     if (&editor == name)
     {
         controller->setName (editor.getText());
     }
-    // Bouml preserved body end 0004178D
 }
 
-//  (       )
-void ControllerGUI::textEditorReturnKeyPressed (TextEditor& editor)
+void ControllerGUI::textEditorReturnKeyPressed (juce::TextEditor& editor)
 {
-    // Bouml preserved body begin 0004180D
-    // Bouml preserved body end 0004180D
 }
 
-void ControllerGUI::textEditorEscapeKeyPressed (TextEditor& editor)
+void ControllerGUI::textEditorEscapeKeyPressed (juce::TextEditor& editor)
 {
-    // Bouml preserved body begin 0004188D
-    // Bouml preserved body end 0004188D
 }
 
-void ControllerGUI::textEditorFocusLost (TextEditor& editor)
+void ControllerGUI::textEditorFocusLost (juce::TextEditor& editor)
 {
-    // Bouml preserved body begin 0004190D
-    // Bouml preserved body end 0004190D
 }
 
-void ControllerGUI::labelTextChanged (Label* labelThatHasChanged)
+void ControllerGUI::labelTextChanged (juce::Label* labelThatHasChanged)
 {
-    // Bouml preserved body begin 00048A0D
     if (labelThatHasChanged == value)
     {
-        controller->setValue (roundToInt (value->getValue()));
+        controller->setValueInSelectedScenes (roundToInt (value->getValue()));
         repaint();
     }
     else if (labelThatHasChanged == ccNo)
@@ -248,10 +201,4 @@ void ControllerGUI::labelTextChanged (Label* labelThatHasChanged)
     {
         controller->channel = roundToInt (channel->getValue());
     }
-    //else if(labelThatHasChanged = test)
-    //{
-
-    //}
-
-    // Bouml preserved body end 00048A0D
 }

--- a/pizjuce/MiddyMorphy/ControllerGUI.h
+++ b/pizjuce/MiddyMorphy/ControllerGUI.h
@@ -1,24 +1,11 @@
 #pragma once
-#include "TextBoxSlider.h"
 
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include "TextBoxSlider.h"
 
 class Controller;
 class MidiMorph;
-namespace juce
-{
-class TextEditor;
-}
-namespace juce
-{
-class Slider;
-}
-class ControllerValue;
-class TextBoxSlider;
-namespace juce
-{
-class Label;
-}
 
 class ControllerGUI : public juce::TextEditor::Listener, public juce::ChangeListener, public juce::Component, public juce::Slider::Listener, public juce::Label::Listener
 {
@@ -26,6 +13,32 @@ public:
     ControllerGUI (Controller* controller, MidiMorph* core);
 
     ~ControllerGUI() override;
+
+    void resized() override;
+
+    void paint (juce::Graphics& g) override;
+
+    void paintOverChildren (juce::Graphics& g) override;
+
+    void mouseUp (const juce::MouseEvent& e) override;
+
+    void sliderValueChanged (juce::Slider* slider) override;
+
+    void setSelected (bool shouldDrawSelected);
+
+    void changeListenerCallback (juce::ChangeBroadcaster* source) override;
+
+    void refreshControllerData();
+
+    void textEditorTextChanged (juce::TextEditor& editor) override;
+
+    void textEditorReturnKeyPressed (juce::TextEditor& editor) override;
+
+    void textEditorEscapeKeyPressed (juce::TextEditor& editor) override;
+
+    void textEditorFocusLost (juce::TextEditor& editor) override;
+
+    void labelTextChanged (juce::Label* labelThatHasChanged) override;
 
 private:
     bool isSelected;
@@ -36,49 +49,11 @@ private:
 
     juce::TextEditor* name;
 
-public:
-    void resized() override;
-
-    void paint (Graphics& g) override;
-
-    void paintOverChildren (Graphics& g) override;
-
-    void mouseUp (const MouseEvent& e) override;
-
-    //()=
-    void sliderValueChanged (Slider* slider) override;
-
-    void setSelected (bool shouldDrawSelected);
-
-    void changeListenerCallback (ChangeBroadcaster* source) override;
-
-    void refreshControllerData();
-
-    void textEditorTextChanged (TextEditor& editor) override;
-
-    //  (       )
-    void textEditorReturnKeyPressed (TextEditor& editor) override;
-
-    void textEditorEscapeKeyPressed (TextEditor& editor) override;
-
-    void textEditorFocusLost (TextEditor& editor) override;
-
-private:
     TextBoxSlider* test;
-
     TextBoxSlider* ccNo;
-
-public:
-    void labelTextChanged (Label* labelThatHasChanged) override;
-
-private:
     TextBoxSlider* channel;
-
     TextBoxSlider* value;
 
     juce::Label* labCc;
-
     juce::Label* labCh;
-
-    juce::Colour lineColour;
 };

--- a/pizjuce/MiddyMorphy/ControllerList.cpp
+++ b/pizjuce/MiddyMorphy/ControllerList.cpp
@@ -5,22 +5,16 @@
 
 ControllerList::ControllerList (MidiMorph* core)
 {
-    // Bouml preserved body begin 0003170D
     this->core = core;
-    // Bouml preserved body end 0003170D
 }
 
 ControllerList::~ControllerList()
 {
-    // Bouml preserved body begin 0004210D
     //this->removeAllChangeListeners();
-    // Bouml preserved body end 0004210D
 }
 
-Component* ControllerList::refreshComponentForRow (int rowNumber, bool isRowSelected, Component* existingComponentToUpdate)
+juce::Component* ControllerList::refreshComponentForRow (int rowNumber, bool isRowSelected, juce::Component* existingComponentToUpdate)
 {
-    // Bouml preserved body begin 00033A0D
-
     if (existingComponentToUpdate != 0)
     {
         //removeChangeListener((ControllerGUI*)existingComponentToUpdate);
@@ -35,39 +29,23 @@ Component* ControllerList::refreshComponentForRow (int rowNumber, bool isRowSele
     }
     else
         return 0;
-
-    // Bouml preserved body end 00033A0D
 }
 
-void ControllerList::paintListBoxItem (int rowNumber, Graphics& g, int width, int height, bool rowIsSelected)
+void ControllerList::paintListBoxItem (int rowNumber, juce::Graphics& g, int width, int height, bool rowIsSelected)
 {
-    // Bouml preserved body begin 0003168D
-    // Bouml preserved body end 0003168D
 }
 
 int ControllerList::getNumRows()
 {
-    // Bouml preserved body begin 0003160D
     return core->getNumControllers();
-    // Bouml preserved body end 0003160D
-}
-
-void ControllerList::addController()
-{
-    // Bouml preserved body begin 00034D0D
-    // Bouml preserved body end 00034D0D
 }
 
 void ControllerList::scenesSelected()
 {
-    // Bouml preserved body begin 0003EF8D
     //this->sendChangeMessage(core->getSelectedScenes());
-    // Bouml preserved body end 0003EF8D
 }
 
 void ControllerList::distancesChanged()
 {
-    // Bouml preserved body begin 0003F40D
     //sendChangeMessage(core->getCursor());
-    // Bouml preserved body end 0003F40D
 }

--- a/pizjuce/MiddyMorphy/ControllerList.h
+++ b/pizjuce/MiddyMorphy/ControllerList.h
@@ -1,16 +1,11 @@
 #pragma once
 
-#include "juce_events/juce_events.h"
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_events/juce_events.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
 class MidiMorph;
-namespace juce
-{
-class Component;
-}
 class ControllerGUI;
 
-using namespace juce;
 class ControllerList : public juce::ListBoxModel, public juce::ChangeBroadcaster
 {
 public:
@@ -18,19 +13,16 @@ public:
 
     ~ControllerList() override;
 
-private:
-    MidiMorph* core;
+    juce::Component* refreshComponentForRow (int rowNumber, bool isRowSelected, juce::Component* existingComponentToUpdate) override;
 
-public:
-    Component* refreshComponentForRow (int rowNumber, bool isRowSelected, Component* existingComponentToUpdate) override;
-
-    void paintListBoxItem (int rowNumber, Graphics& g, int width, int height, bool rowIsSelected) override;
+    void paintListBoxItem (int rowNumber, juce::Graphics& g, int width, int height, bool rowIsSelected) override;
 
     int getNumRows() override;
-
-    void addController();
 
     void scenesSelected();
 
     void distancesChanged();
+
+private:
+    MidiMorph* core;
 };

--- a/pizjuce/MiddyMorphy/ControllerValue.cpp
+++ b/pizjuce/MiddyMorphy/ControllerValue.cpp
@@ -1,68 +1,46 @@
 #include "ControllerValue.h"
 
-#include "juce_audio_basics/juce_audio_basics.h"
+#include <juce_audio_basics/juce_audio_basics.h>
 
 #include "Controller.h"
 #include "Scene.h"
 
 ControllerValue::ControllerValue (Controller* controller, Scene* scene)
 {
-    // Bouml preserved body begin 00035A8D
     this->scene      = scene;
     this->controller = controller;
-    // Bouml preserved body end 00035A8D
 }
 
-//at destruction make shure to deletete reference in controller AND scene!!
 ControllerValue::~ControllerValue()
 {
-    // Bouml preserved body begin 00035B0D
     scene->controllerValues.removeAllInstancesOf (this);
     controller->removeValue (this);
-    // Bouml preserved body end 00035B0D
 }
 
 void ControllerValue::setValue (int newValue)
 {
-    // Bouml preserved body begin 0003C50D
     this->value = newValue;
-    // Bouml preserved body end 0003C50D
 }
 
 int ControllerValue::getValue()
 {
-    // Bouml preserved body begin 0003C58D
     return value;
-    // Bouml preserved body end 0003C58D
-}
-
-float ControllerValue::getValueRation()
-{
-    // Bouml preserved body begin 0003C70D
-    return scene->getAffectionRatio() * (float) value;
-    // Bouml preserved body end 0003C70D
 }
 
 Scene* ControllerValue::getScene()
 {
-    // Bouml preserved body begin 0004068D
     return scene;
-    // Bouml preserved body end 0004068D
 }
 
 Controller* ControllerValue::getController()
 {
-    // Bouml preserved body begin 0004090D
     return controller;
-    // Bouml preserved body end 0004090D
 }
 
 void ControllerValue::getMidiMessage (juce::MidiBuffer& buffer, int pos)
 {
-    // Bouml preserved body begin 00048E0D
     if (controller->hasNewMidi())
     {
-        buffer.addEvent (MidiMessage::controllerEvent (controller->getChannel(), controller->getCcNo(), value), pos);
+        buffer.addEvent (juce::MidiMessage::controllerEvent (controller->getChannel(), controller->getCcNo(), value), pos);
     }
-    // Bouml preserved body end 00048E0D
 }

--- a/pizjuce/MiddyMorphy/ControllerValue.h
+++ b/pizjuce/MiddyMorphy/ControllerValue.h
@@ -1,37 +1,23 @@
 #pragma once
 
+#include <juce_audio_basics/juce_audio_basics.h>
+
 class Controller;
 class Scene;
-namespace juce
-{
-class MidiBuffer;
-}
 
 class ControllerValue
 {
 public:
     ControllerValue (Controller* controller, Scene* scene);
 
-    //at destruction make shure to deletete reference in controller AND scene!!
     ~ControllerValue();
 
     bool active;
 
-private:
-    int value;
-
-public:
     Scene* scene;
 
-private:
-    Controller* controller;
-
-public:
-    void setValue (int newValue);
-
     int getValue();
-
-    float getValueRation();
+    void setValue (int newValue);
 
     Scene* getScene();
 
@@ -40,4 +26,8 @@ public:
     void getMidiMessage (juce::MidiBuffer& buffer, int pos);
 
     friend class Controller;
+
+private:
+    int value;
+    Controller* controller;
 };

--- a/pizjuce/MiddyMorphy/Cursor.cpp
+++ b/pizjuce/MiddyMorphy/Cursor.cpp
@@ -4,24 +4,17 @@
 
 Cursor::Cursor (MidiMorph* core)
 {
-    // Bouml preserved body begin 0003110D
     this->core = core;
     this->size = 50;
-    // Bouml preserved body end 0003110D
 }
 
-//gets called when the XYItem gets new coordinates
 void Cursor::moved()
 {
-    // Bouml preserved body begin 0003588D
     core->cursorChanged();
     sendChangeMessage();
-    // Bouml preserved body end 0003588D
 }
 
 juce::Point<float> Cursor::getCursorPosition()
 {
-    // Bouml preserved body begin 0003C40D
-    return Point<float> (Point::getX(), Point::getY());
-    // Bouml preserved body end 0003C40D
+    return { this->getX(), this->getY() };
 }

--- a/pizjuce/MiddyMorphy/Cursor.h
+++ b/pizjuce/MiddyMorphy/Cursor.h
@@ -1,23 +1,20 @@
 #pragma once
 
-#include "juce_events/juce_events.h"
+#include <juce_events/juce_events.h>
 
 #include "Module.h"
 
 class MidiMorph;
-using namespace juce;
 
 class Cursor : public Module, public juce::ChangeBroadcaster
 {
 public:
     Cursor (MidiMorph* core);
 
-    //gets called when the XYItem gets new coordinates
     void moved() override;
+
+    juce::Point<float> getCursorPosition();
 
 private:
     MidiMorph* core;
-
-public:
-    juce::Point<float> getCursorPosition();
 };

--- a/pizjuce/MiddyMorphy/CursorGUI.cpp
+++ b/pizjuce/MiddyMorphy/CursorGUI.cpp
@@ -2,79 +2,64 @@
 #include "CursorGUI.h"
 #include "Cursor.h"
 
-//==============================================================================
-
-void CursorGUI::paint (Graphics& g)
-{
-    // Bouml preserved body begin 0003550D
-    g.setColour (Colours::blue);
-    g.drawLine ((float) getWidth() * 0.5f, 0, (float) getWidth() * 0.5f, (float) getHeight(), 2);
-    g.drawLine (0, (float) getHeight() * 0.5f, (float) getWidth(), (float) getHeight() * 0.5f, 2);
-    g.drawEllipse (6, 6, (float) (getWidth() - 12), (float) (getHeight() - 12), 2);
-    g.setColour (Colours::orange);
-    g.drawEllipse (5, 5, (float) (getWidth() - 10), (float) (getHeight() - 10), 4);
-    // Bouml preserved body end 0003550D
-}
-
 CursorGUI::CursorGUI (Cursor* cursor)
     : ModuleGUI (cursor)
 {
-    // Bouml preserved body begin 0003E20D
     this->setAlwaysOnTop (true);
     this->cursor = cursor;
     cursor->addChangeListener (this);
     this->setMouseClickGrabsKeyboardFocus (false);
-    // Bouml preserved body end 0003E20D
 }
 
-void CursorGUI::mouseDown (const MouseEvent& e)
+CursorGUI::~CursorGUI()
 {
-    // Bouml preserved body begin 0003F10D
+    cursor->removeChangeListener (this);
+}
+
+void CursorGUI::paint (juce::Graphics& g)
+{
+    g.setColour (juce::Colours::blue);
+    g.drawLine ((float) getWidth() * 0.5f, 0, (float) getWidth() * 0.5f, (float) getHeight(), 2);
+    g.drawLine (0, (float) getHeight() * 0.5f, (float) getWidth(), (float) getHeight() * 0.5f, 2);
+    g.drawEllipse (6, 6, (float) (getWidth() - 12), (float) (getHeight() - 12), 2);
+    g.setColour (juce::Colours::orange);
+    g.drawEllipse (5, 5, (float) (getWidth() - 10), (float) (getHeight() - 10), 4);
+}
+
+void CursorGUI::mouseDown (const juce::MouseEvent& e)
+{
     this->setInterceptsMouseClicks (true, false);
     if (e.mods.isLeftButtonDown() && ! e.mods.isAltDown() && ! e.mods.isCtrlDown())
     {
         startDrag (e);
     }
-    // Bouml preserved body end 0003F10D
 }
 
-void CursorGUI::mouseDrag (const MouseEvent& e)
+void CursorGUI::mouseDrag (const juce::MouseEvent& e)
 {
-    // Bouml preserved body begin 0003F18D
     this->setInterceptsMouseClicks (true, false);
     if (e.mods.isLeftButtonDown() && ! e.mods.isAltDown() && ! e.mods.isCtrlDown())
     {
         this->drag (e);
     }
-    //this->refreshOriginalBounds();
-    // Bouml preserved body end 0003F18D
 }
 
-void CursorGUI::mouseUp (const MouseEvent& e)
+void CursorGUI::mouseUp (const juce::MouseEvent& e)
 {
-    // Bouml preserved body begin 0003F20D
     if (e.mods.isRightButtonDown())
     {
         this->setInterceptsMouseClicks (false, true);
     }
     else
+    {
         this->setInterceptsMouseClicks (true, false);
-    // Bouml preserved body end 0003F20D
+    }
 }
 
-void CursorGUI::changeListenerCallback (ChangeBroadcaster* source)
+void CursorGUI::changeListenerCallback (juce::ChangeBroadcaster* source)
 {
-    // Bouml preserved body begin 00047B0D
     if (source == cursor)
     {
         rePosition();
     }
-    // Bouml preserved body end 00047B0D
-}
-
-CursorGUI::~CursorGUI()
-{
-    // Bouml preserved body begin 00047B8D
-    cursor->removeChangeListener (this);
-    // Bouml preserved body end 00047B8D
 }

--- a/pizjuce/MiddyMorphy/CursorGUI.h
+++ b/pizjuce/MiddyMorphy/CursorGUI.h
@@ -1,34 +1,26 @@
 #pragma once
 
-#include "juce_events/juce_events.h"
+#include <juce_events/juce_events.h>
 
 #include "ModuleGUI.h"
 
 class Cursor;
 
-using namespace juce;
-
 class CursorGUI : public ModuleGUI, public juce::ChangeListener
 {
+public:
+    CursorGUI (Cursor* cursor);
+    ~CursorGUI() override;
+
+    void paint (juce::Graphics& g) override;
+
+    void mouseDown (const juce::MouseEvent& e) override;
+    void mouseUp (const juce::MouseEvent& e) override;
+    void mouseDrag (const juce::MouseEvent& e) override;
+
+    void changeListenerCallback (juce::ChangeBroadcaster* source) override;
+
 private:
     juce::ComponentDragger dragger;
-
-public:
-    void paint (Graphics& g) override;
-
-    CursorGUI (Cursor* cursor);
-
-    void mouseDown (const MouseEvent& e) override;
-
-    void mouseDrag (const MouseEvent& e) override;
-
-    void mouseUp (const MouseEvent& e) override;
-
-    void changeListenerCallback (ChangeBroadcaster* source) override;
-
-private:
     Cursor* cursor;
-
-public:
-    ~CursorGUI() override;
 };

--- a/pizjuce/MiddyMorphy/D3CKLook.cpp
+++ b/pizjuce/MiddyMorphy/D3CKLook.cpp
@@ -1,17 +1,14 @@
-
 #include "D3CKLook.h"
+
+using juce::jmin;
 
 int D3CKLook::getDefaultScrollbarWidth()
 {
-    // Bouml preserved body begin 00049D0D
     return 12;
-    // Bouml preserved body end 00049D0D
 }
 
-//    int  thumbSize,      bool  isMouseOver,      bool  isMouseDown    )
-void D3CKLook::drawScrollbar (Graphics& g, ScrollBar& scrollbar, int x, int y, int width, int height, bool isScrollbarVertical, int thumbStartPosition, int thumbSize, bool isMouseOver, bool isMouseDown)
+void D3CKLook::drawScrollbar (juce::Graphics& g, juce::ScrollBar& scrollbar, int x, int y, int width, int height, bool isScrollbarVertical, int thumbStartPosition, int thumbSize, bool isMouseOver, bool isMouseDown)
 {
-    // Bouml preserved body begin 00049F0D
     if (thumbSize > 0)
     {
         if (isScrollbarVertical)
@@ -37,87 +34,68 @@ void D3CKLook::drawScrollbar (Graphics& g, ScrollBar& scrollbar, int x, int y, i
             }
         }
     }
-
-    // Bouml preserved body end 00049F0D
 }
 
-void D3CKLook::drawScrollbarButton (Graphics& g, ScrollBar& scrollbar, int width, int height, int buttonDirection, bool isScrollbarVertical, bool isMouseOver, bool isButtonDown)
+void D3CKLook::drawScrollbarButton (juce::Graphics& g, juce::ScrollBar& scrollbar, int width, int height, int buttonDirection, bool isScrollbarVertical, bool isMouseOver, bool isButtonDown)
 {
-    // Bouml preserved body begin 0004A00D
     if (isMouseOver)
     {
         g.fillRoundedRectangle (1, 1, (float) (width - 2), (float) (height - 2), (float) jmin (width, height) * 0.25f);
     }
 
     g.drawRoundedRectangle (1, 1, (float) (width - 2), (float) (height - 2), (float) jmin (width, height) * 0.25f, 1);
-    // Bouml preserved body end 0004A00D
 }
 
-//  (   &     )
-int D3CKLook::getScrollbarButtonSize (ScrollBar& scrollbar)
+int D3CKLook::getScrollbarButtonSize (juce::ScrollBar& scrollbar)
 {
-    // Bouml preserved body begin 0004A18D
     return 8;
-    // Bouml preserved body end 0004A18D
 }
 
-//getMinimumScrollbarThumbSize  (   &     )
-int D3CKLook::getMinimumScrollbarThumbSize (ScrollBar& scrollbar)
+int D3CKLook::getMinimumScrollbarThumbSize (juce::ScrollBar& scrollbar)
 {
-    // Bouml preserved body begin 0004A20D
     return 8;
-    // Bouml preserved body end 0004A20D
 }
 
-//  (   &  g,      int  width,      int  height,      TextEditor &  textEditor    )
-void D3CKLook::drawTextEditorOutline (Graphics& g, int width, int height, juce::TextEditor& textEditor)
+void D3CKLook::drawTextEditorOutline (juce::Graphics& g, int width, int height, juce::TextEditor& textEditor)
 {
-    // Bouml preserved body begin 0004A30D
     g.drawRoundedRectangle (1, 1, (float) (width - 2), (float) (height - 2), (float) jmin (width, height) * 0.5f, 1);
-    // Bouml preserved body end 0004A30D
 }
 
-void D3CKLook::drawPopupMenuItem (Graphics& g, int width, int height, const bool isSeperator, const bool isActive, const bool isHightlited, const bool isTicked, const bool hasSubmenu, const String& text, const String& shortcutText, Image* image, const juce::Colour* const textColour)
+void D3CKLook::drawPopupMenuItem (juce::Graphics& g, int width, int height, const bool isSeperator, const bool isActive, const bool isHightlited, const bool isTicked, const bool hasSubmenu, const juce::String& text, const juce::String& shortcutText, juce::Image* image, const juce::Colour* const textColour)
 {
-    // Bouml preserved body begin 0004A78D
     g.fillRect (0, 0, width, height);
     if (! isSeperator)
     {
         if (isHightlited)
         {
-            g.setColour (Colours::lightgrey);
+            g.setColour (juce::Colours::lightgrey);
         }
         else
         {
-            g.setColour (Colours::white);
+            g.setColour (juce::Colours::white);
         }
         g.fillRoundedRectangle (0, 0, (float) width, (float) height, (float) height * 0.5f);
-        g.setColour (Colours::green);
+        g.setColour (juce::Colours::green);
         g.drawRoundedRectangle (2, 2, (float) (width - 4), (float) (height - 4), (float) (height - 2) * 0.5f, 1);
         g.drawEllipse (2, 2, (float) (height - 4), (float) (height - 4), 1);
         if (isTicked)
         {
             g.fillEllipse (4, 4, (float) (height - 8), (float) (height - 8));
         }
-        g.drawText (text, height + 10, 0, width, height, Justification::left, true);
+        g.drawText (text, height + 10, 0, width, height, juce::Justification::left, true);
     }
     if (hasSubmenu)
     {
         g.fillEllipse ((float) (width + 5), 5, (float) (height - 10), (float) (height - 10));
     }
-    // Bouml preserved body end 0004A78D
 }
 
-void D3CKLook::drawPopupMenuBackground (Graphics& g, int width, int height)
+void D3CKLook::drawPopupMenuBackground (juce::Graphics& g, int width, int height)
 {
-    // Bouml preserved body begin 0004A80D
     //g.fillAll(Colours::white);
-    // Bouml preserved body end 0004A80D
 }
 
-std::unique_ptr<DropShadower> D3CKLook::createDropShadowerForComponent (juce::Component& comp)
+std::unique_ptr<juce::DropShadower> D3CKLook::createDropShadowerForComponent (juce::Component& comp)
 {
-    // Bouml preserved body begin 0004A88D
     return nullptr;
-    // Bouml preserved body end 0004A88D
 }

--- a/pizjuce/MiddyMorphy/D3CKLook.h
+++ b/pizjuce/MiddyMorphy/D3CKLook.h
@@ -1,10 +1,8 @@
 #pragma once
 
-#include "juce_core/juce_core.h"
-#include "juce_graphics/juce_graphics.h"
-#include "juce_gui_basics/juce_gui_basics.h"
-
-using namespace juce;
+#include <juce_core/juce_core.h>
+#include <juce_graphics/juce_graphics.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
 class D3CKLook : public juce::LookAndFeel_V1
 {
@@ -13,23 +11,19 @@ public:
 
     int getDefaultScrollbarWidth() override;
 
-    //    int  thumbSize,      bool  isMouseOver,      bool  isMouseDown    )
-    void drawScrollbar (Graphics& g, ScrollBar& scrollbar, int x, int y, int width, int height, bool isScrollbarVertical, int thumbStartPosition, int thumbSize, bool isMouseOver, bool isMouseDown) override;
+    void drawScrollbar (juce::Graphics& g, juce::ScrollBar& scrollbar, int x, int y, int width, int height, bool isScrollbarVertical, int thumbStartPosition, int thumbSize, bool isMouseOver, bool isMouseDown) override;
 
-    void drawScrollbarButton (Graphics& g, ScrollBar& scrollbar, int width, int height, int buttonDirection, bool isScrollbarVertical, bool isMouseOver, bool isButtonDown) override;
+    void drawScrollbarButton (juce::Graphics& g, juce::ScrollBar& scrollbar, int width, int height, int buttonDirection, bool isScrollbarVertical, bool isMouseOver, bool isButtonDown) override;
 
-    //  (   &     )
-    int getScrollbarButtonSize (ScrollBar& scrollbar) override;
+    int getScrollbarButtonSize (juce::ScrollBar& scrollbar) override;
 
-    //getMinimumScrollbarThumbSize  (   &     )
-    int getMinimumScrollbarThumbSize (ScrollBar& scrollbar) override;
+    int getMinimumScrollbarThumbSize (juce::ScrollBar& scrollbar) override;
 
-    //  (   &  g,      int  width,      int  height,      TextEditor &  textEditor    )
-    void drawTextEditorOutline (Graphics& g, int width, int height, juce::TextEditor& textEditor) override;
+    void drawTextEditorOutline (juce::Graphics& g, int width, int height, juce::TextEditor& textEditor) override;
 
-    void drawPopupMenuItem (Graphics& g, int width, int height, bool isSeperator, bool isActive, bool isHightlited, bool isTicked, bool hasSubmenu, const String& text, const String& shortcutText, Image* image, const juce::Colour* const textColour);
+    void drawPopupMenuItem (juce::Graphics& g, int width, int height, bool isSeperator, bool isActive, bool isHightlited, bool isTicked, bool hasSubmenu, const juce::String& text, const juce::String& shortcutText, juce::Image* image, const juce::Colour* const textColour);
 
-    void drawPopupMenuBackground (Graphics& g, int width, int height) override;
+    void drawPopupMenuBackground (juce::Graphics& g, int width, int height) override;
 
-    std::unique_ptr<DropShadower> createDropShadowerForComponent (juce::Component& comp) override;
+    std::unique_ptr<juce::DropShadower> createDropShadowerForComponent (juce::Component& comp) override;
 };

--- a/pizjuce/MiddyMorphy/MidiMorph.cpp
+++ b/pizjuce/MiddyMorphy/MidiMorph.cpp
@@ -3,9 +3,11 @@
 #include "ControllerValue.h"
 #include "Cursor.h"
 
+using juce::jmax;
+using juce::roundToInt;
+
 MidiMorph::MidiMorph()
 {
-    // Bouml preserved body begin 0003540D
     cursor        = new Cursor (this);
     valuesChanged = false;
     refreshRate   = 200;
@@ -15,102 +17,74 @@ MidiMorph::MidiMorph()
     autoKey             = true;
     autoLearn           = true;
     controllerListWidth = 150;
-    // Bouml preserved body end 0003540D
 }
 
 MidiMorph::~MidiMorph()
 {
-    // Bouml preserved body begin 00041F8D
-    if (guiState != 0)
+    if (guiState != nullptr)
     {
         deleteAndZero (guiState);
     }
     deleteAndZero (cursor);
-    // Bouml preserved body end 00041F8D
 }
 
 void MidiMorph::setCursorXRatio (float x)
 {
-    // Bouml preserved body begin 00042D8D
-    cursor->setXY ((float) roundToInt (x * paneSize.getWidth()) - cursor->size / 2, cursor->Point::getY());
-    // Bouml preserved body end 00042D8D
+    cursor->setXY ((float) roundToInt (x * paneSize.getWidth()) - cursor->size / 2, cursor->getY());
 }
 
 void MidiMorph::setCursorYRatio (float y)
 {
-    // Bouml preserved body begin 00042E0D
-    cursor->setXY (cursor->Point::getX(), (float) roundToInt (y * paneSize.getHeight()) - cursor->size / 2);
-    // Bouml preserved body end 00042E0D
+    cursor->setXY (cursor->getX(), (float) roundToInt (y * paneSize.getHeight()) - cursor->size / 2);
 }
 
 float MidiMorph::getCursorXRatio()
 {
-    // Bouml preserved body begin 00042E8D
-    return (cursor->Point::getX() + cursor->size / 2) / paneSize.getWidth();
-    // Bouml preserved body end 00042E8D
+    return (cursor->getX() + cursor->size / 2) / paneSize.getWidth();
 }
 
 float MidiMorph::getCursorYRatio()
 {
-    // Bouml preserved body begin 00042F0D
-    return (cursor->Point::getY() + cursor->size / 2) / paneSize.getHeight();
-    // Bouml preserved body end 00042F0D
+    return (cursor->getY() + cursor->size / 2) / paneSize.getHeight();
 }
 
-//-can happen by input or slider movement.
-//
-//-if a scene is selected, (or multiple scenes) the value for that controller gets set.
-//-if no scene is selected and auto key is on, a scene gets added.
 void MidiMorph::controllerChanged (const Controller* controllerThatHasChanged)
 {
-    // Bouml preserved body begin 0003538D
     this->valueChanged = true;
-    // Bouml preserved body end 0003538D
 }
 
-//send interpolated controller vaules  that actually differ from the last output to midi out
 void MidiMorph::distancesChanged()
 {
-    // Bouml preserved body begin 00034E8D
     this->sumDistancesChanged = true;
     if (! auditSelScene || selectedScenes.size() == 0)
     {
         this->valuesChanged = true;
     }
     this->sendChangeMessage (cursor);
-
-    // Bouml preserved body end 00034E8D
 }
 
-//foreach scene : moved();
 void MidiMorph::cursorChanged()
 {
-    // Bouml preserved body begin 00035A0D
     distancesChanged();
     for (int i = 0; i < scenes.size(); i++)
     {
         scenes[i]->distanceFromCursorChanged();
     }
-    // Bouml preserved body end 00035A0D
 }
 
 void MidiMorph::addController (int ccNo, int Channel)
 {
-    // Bouml preserved body begin 00034F0D
-    Controller* nc = new Controller (this);
+    auto* nc = new Controller (this);
     nc->setCcNo (ccNo);
     nc->setChannel (Channel);
-    nc->setName (MidiMessage::getControllerName (ccNo));
+    nc->setName (juce::MidiMessage::getControllerName (ccNo));
 
     controllers.add (nc);
     sendChangeMessage (&controllers);
-
-    // Bouml preserved body end 00034F0D
 }
 
 void MidiMorph::addController()
 {
-    // Bouml preserved body begin 0004800D
     if (controllers.size() > 0)
     {
         addController (controllers.getLast()->getCcNo() + 1, controllers.getLast()->getChannel());
@@ -119,56 +93,37 @@ void MidiMorph::addController()
     {
         addController (0, 1);
     }
-    // Bouml preserved body end 0004800D
 }
 
 void MidiMorph::addScene (Scene* scene)
 {
-    // Bouml preserved body begin 0003F98D
     scene->id = scenes.size();
     scenes.add (scene);
     sendChangeMessage (&scenes);
 
-    Array<Scene*> selScenes (&scene, 1);
+    juce::Array<Scene*> selScenes (&scene, 1);
     setSelectedScenes (selScenes);
-    //OwnedArray<Scene>* scenes = getScenes();
-
-    // Bouml preserved body end 0003F98D
 }
 
 int MidiMorph::getNumControllers()
 {
-    // Bouml preserved body begin 00035B8D
     return controllers.size();
-    // Bouml preserved body end 00035B8D
 }
 
 int MidiMorph::getControllerCCNo (int index)
 {
-    // Bouml preserved body begin 00035C0D
     return controllers[index]->getCcNo();
-    // Bouml preserved body end 00035C0D
 }
 
 int MidiMorph::getControllerValue (int index)
 {
-    // Bouml preserved body begin 00035C8D
     return controllers[index]->getInterpolatedValue();
-    // Bouml preserved body end 00035C8D
 }
 
-//if controller != cursor controller
-//if   controller is in list
-//	if - scene/s is selected, .> set/add value for selected scenes/s
-//	else if  "autokey" is on, ->add scene at cursor pos, select scene, set/add value for cursor,
-//
-//else if "autolearn" is on add controller.
-//		if - scene/s is selected, .> set/add value for selected scenes/s
-//		else if no scene is selected && "autokey" is on, ->add scene at cursor pos, select scene, set/add value for cursor
 void MidiMorph::onMidiEvent (juce::MidiMessage& events)
 {
-    // Bouml preserved body begin 00035D8D
     bool controllerIsInList = false;
+
     if (events.isController())
     {
         for (int i = 0; i < controllers.size(); i++)
@@ -176,22 +131,21 @@ void MidiMorph::onMidiEvent (juce::MidiMessage& events)
             if (controllers[i]->getCcNo() == events.getControllerNumber()
                 && controllers[i]->getChannel() == events.getChannel())
             {
-                controllers[i]->setValue (events.getControllerValue());
+                controllers[i]->setValueInSelectedScenes (events.getControllerValue());
                 controllerIsInList = true;
             }
         }
+
         if (! controllerIsInList && autoLearn)
         {
             this->addController (events.getControllerNumber(), events.getChannel());
             onMidiEvent (events);
         }
     }
-    // Bouml preserved body end 00035D8D
 }
 
 void MidiMorph::getMidiMessages (int offset, juce::MidiBuffer& buffer)
 {
-    // Bouml preserved body begin 0004100D
     if (auditSelScene && selectedScenes.size() > 0 && hasNewMidi())
     {
         selectedScenes.getFirst()->getMidiMessages (buffer, offset);
@@ -214,13 +168,10 @@ void MidiMorph::getMidiMessages (int offset, juce::MidiBuffer& buffer)
         valueChanged  = false;
         valuesChanged = false;
     }
-
-    // Bouml preserved body end 0004100D
 }
 
 float MidiMorph::getSumDistances()
 {
-    // Bouml preserved body begin 0003C60D
     if (sumDistancesChanged)
     {
         sumDistancesChanged = false;
@@ -231,74 +182,55 @@ float MidiMorph::getSumDistances()
         }
     }
     return sumDistances;
-    // Bouml preserved body end 0003C60D
 }
 
 Controller* MidiMorph::getController (int index)
 {
-    // Bouml preserved body begin 0003E60D
     return controllers[index];
-    // Bouml preserved body end 0003E60D
 }
 
 int MidiMorph::getNumSelectedScenes()
 {
-    // Bouml preserved body begin 0003E68D
     return selectedScenes.size();
-    // Bouml preserved body end 0003E68D
 }
 
-void MidiMorph::setSelectedScenes (Array<Scene*>& scenes)
+void MidiMorph::setSelectedScenes (juce::Array<Scene*>& scenes)
 {
-    // Bouml preserved body begin 0003E80D
-
     this->selectedScenes.swapWith (scenes);
     if (auditSelScene && selectedScenes.size() == 1)
     {
         valuesChanged = true;
     }
     sendChangeMessage (&selectedScenes);
-    // Bouml preserved body end 0003E80D
 }
 
-Array<Scene*>* MidiMorph::getSelectedScenes()
+juce::Array<Scene*>* MidiMorph::getSelectedScenes()
 {
-    // Bouml preserved body begin 0003E90D
     return &this->selectedScenes;
-    // Bouml preserved body end 0003E90D
 }
 
 Scene* MidiMorph::getSelectedScene (int index)
 {
-    // Bouml preserved body begin 0003EA0D
     return selectedScenes[index];
-    // Bouml preserved body end 0003EA0D
 }
 
 Cursor* MidiMorph::getCursor()
 {
-    // Bouml preserved body begin 0003F28D
     return cursor;
-    // Bouml preserved body end 0003F28D
 }
 
 float MidiMorph::getSumAffectionValues()
 {
-    // Bouml preserved body begin 0003F50D
     float sum = 0;
     for (int i = 0; i < scenes.size(); i++)
     {
         sum += scenes[i]->getAffectionValue();
     }
     return sum;
-    // Bouml preserved body end 0003F50D
 }
 
 void MidiMorph::removeScene (Scene* scene)
 {
-    // Bouml preserved body begin 0003F90D
-    //Array<Scene*> noSelection;
-    //setSelectedScenes(noSelection);
     scenes.getLock().enter();
     scenes.removeObject (scene);
     for (int i = scenes.size(); --i >= 0;)
@@ -307,32 +239,28 @@ void MidiMorph::removeScene (Scene* scene)
     }
     scenes.getLock().exit();
     sendChangeMessage (&scenes);
-    // Bouml preserved body end 0003F90D
 }
 
-OwnedArray<Controller>* MidiMorph::getControllers()
+juce::OwnedArray<Controller>* MidiMorph::getControllers()
 {
-    // Bouml preserved body begin 0003FA0D
     return &controllers;
-    // Bouml preserved body end 0003FA0D
 }
 
 juce::XmlElement* MidiMorph::getXml (const juce::String tagname)
 {
-    // Bouml preserved body begin 0004040D
-    XmlElement* xml = new XmlElement (tagname);
+    auto* xml = new juce::XmlElement (tagname);
 
-    XmlElement* controllersXml = new XmlElement ("controllers");
-    XmlElement* controllerXml;
+    auto* controllersXml = new juce::XmlElement ("controllers");
+    juce::XmlElement* controllerXml;
     for (int i = 0; i < this->controllers.size(); i++)
     {
         Controller* controller = controllers[i];
-        controllerXml          = new XmlElement ("controller");
-        XmlElement* valueXml;
+        controllerXml          = new juce::XmlElement ("controller");
+        juce::XmlElement* valueXml;
         for (int i = 0; i < controller->getNumValues(); i++)
         {
             ControllerValue* value = controller->getValue (i);
-            valueXml               = new XmlElement ("value");
+            valueXml               = new juce::XmlElement ("value");
             valueXml->setAttribute ("value", value->getValue());
             valueXml->setAttribute ("scene", value->getScene()->getId());
             controllerXml->addChildElement (valueXml);
@@ -343,12 +271,12 @@ juce::XmlElement* MidiMorph::getXml (const juce::String tagname)
         controllersXml->addChildElement (controllerXml);
     }
 
-    XmlElement* scenesXml = new XmlElement ("scenes");
-    XmlElement* sceneXml;
+    auto* scenesXml = new juce::XmlElement ("scenes");
+    juce::XmlElement* sceneXml;
     for (int i = 0; i < this->scenes.size(); i++)
     {
         Scene* scene = scenes[i];
-        sceneXml     = new XmlElement ("scene");
+        sceneXml     = new juce::XmlElement ("scene");
         sceneXml->setAttribute ("id", i);
         sceneXml->setAttribute ("name", scene->getName());
         sceneXml->setAttribute ("colour", scene->getColour().toString());
@@ -359,16 +287,16 @@ juce::XmlElement* MidiMorph::getXml (const juce::String tagname)
         scenesXml->addChildElement (sceneXml);
     }
 
-    XmlElement* gui = new XmlElement ("gui");
+    auto* gui = new juce::XmlElement ("gui");
     gui->setAttribute ("width", this->guiBounds.getWidth());
     gui->setAttribute ("height", this->guiBounds.getHeight());
     gui->setAttribute ("listwidth", this->controllerListWidth);
 
-    XmlElement* cursorXml = new XmlElement ("cursor");
+    auto* cursorXml = new juce::XmlElement ("cursor");
     cursorXml->setAttribute ("x", cursor->Point::getX());
     cursorXml->setAttribute ("y", cursor->Point::getY());
 
-    XmlElement* options = new XmlElement ("options");
+    auto* options = new juce::XmlElement ("options");
     options->setAttribute ("autokey", this->autoKey);
     options->setAttribute ("autolearn", this->autoLearn);
     options->setAttribute ("auditselscene", getAuditSelScene());
@@ -382,43 +310,41 @@ juce::XmlElement* MidiMorph::getXml (const juce::String tagname)
     xml->addChildElement (options);
 
     return xml;
-    // Bouml preserved body end 0004040D
 }
 
 void MidiMorph::setFromXml (juce::XmlElement* xmlData)
 {
-    // Bouml preserved body begin 0004048D
     scenes.clear();
     controllers.clear();
 
-    XmlElement* scenesXml = xmlData->getChildByName ("scenes");
+    juce::XmlElement* scenesXml = xmlData->getChildByName ("scenes");
     for (int i = 0; i < scenesXml->getNumChildElements(); i++)
     {
-        XmlElement* sceneXml = scenesXml->getChildElement (i);
-        Scene* scene         = new Scene (this);
+        juce::XmlElement* sceneXml = scenesXml->getChildElement (i);
+        auto* scene                = new Scene (this);
         scene->setXY ((float) sceneXml->getIntAttribute ("x"), (float) sceneXml->getIntAttribute ("y"));
-        scene->setColour (Colour::fromString (sceneXml->getStringAttribute ("colour")));
+        scene->setColour (juce::Colour::fromString (sceneXml->getStringAttribute ("colour")));
         scene->setName (sceneXml->getStringAttribute ("name"));
         scene->size = sceneXml->getIntAttribute ("size", scene->size);
         scenes.add (scene);
     }
 
-    XmlElement* controllersXml = xmlData->getChildByName ("controllers");
+    juce::XmlElement* controllersXml = xmlData->getChildByName ("controllers");
     for (int i = 0; i < controllersXml->getNumChildElements(); i++)
     {
         Controller* controller;
-        XmlElement* controllerXml = controllersXml->getChildElement (i);
-        controller                = new Controller (this);
+        juce::XmlElement* controllerXml = controllersXml->getChildElement (i);
+        controller                      = new Controller (this);
         controller->setCcNo (controllerXml->getIntAttribute ("ccno"));
         controller->setChannel (controllerXml->getIntAttribute ("channel"));
 
         for (int j = 0; j < controllerXml->getNumChildElements(); j++)
         {
-            XmlElement* valueXml   = controllerXml->getChildElement (j);
-            int cValue             = valueXml->getIntAttribute ("value");
-            int sceneId            = valueXml->getIntAttribute ("scene");
-            Scene* scene           = scenes[sceneId];
-            ControllerValue* value = new ControllerValue (controller, scene);
+            juce::XmlElement* valueXml = controllerXml->getChildElement (j);
+            int cValue                 = valueXml->getIntAttribute ("value");
+            int sceneId                = valueXml->getIntAttribute ("scene");
+            Scene* scene               = scenes[sceneId];
+            auto* value                = new ControllerValue (controller, scene);
             value->setValue (cValue);
             controller->addValue (value);
             scene->addValue (value);
@@ -427,7 +353,7 @@ void MidiMorph::setFromXml (juce::XmlElement* xmlData)
         controllers.add (controller);
     }
 
-    XmlElement* cursorXml = xmlData->getChildByName ("cursor");
+    juce::XmlElement* cursorXml = xmlData->getChildByName ("cursor");
     if (xmlData->containsChildElement (cursorXml))
     {
         cursor->setXY ((float) cursorXml->getDoubleAttribute ("x"), (float) cursorXml->getDoubleAttribute ("y"));
@@ -435,11 +361,11 @@ void MidiMorph::setFromXml (juce::XmlElement* xmlData)
 
     this->guiState = xmlData->getChildByName ("morphpanestate");
 
-    XmlElement* gui = xmlData->getChildByName ("gui");
+    juce::XmlElement* gui = xmlData->getChildByName ("gui");
     this->guiBounds.setSize (gui->getIntAttribute ("width"), gui->getIntAttribute ("height"));
     this->controllerListWidth = gui->getIntAttribute ("listwidth", this->controllerListWidth);
 
-    XmlElement* options = xmlData->getChildByName ("options");
+    juce::XmlElement* options = xmlData->getChildByName ("options");
     if (xmlData->containsChildElement (options))
     {
         this->autoKey   = options->getBoolAttribute ("autokey", this->autoKey);
@@ -450,28 +376,20 @@ void MidiMorph::setFromXml (juce::XmlElement* xmlData)
 
     sendChangeMessage (&controllers);
     sendChangeMessage (&scenes);
-
-    // Bouml preserved body end 0004048D
 }
 
 int MidiMorph::getSceneIndex (Scene* scene)
 {
-    // Bouml preserved body begin 0004088D
     return scenes.indexOf (scene);
-    // Bouml preserved body end 0004088D
 }
 
 int MidiMorph::getUpdateRateSmpls (int rate)
 {
-    // Bouml preserved body begin 00040A8D
     return jmax (1, (rate / refreshRate));
-    // Bouml preserved body end 00040A8D
 }
 
 void MidiMorph::removeController (Controller* controllerToRemove)
 {
-    // Bouml preserved body begin 0004158D
-
     controllers.getLock().enter();
     for (int i = scenes.size(); --i >= 0;)
     {
@@ -481,132 +399,106 @@ void MidiMorph::removeController (Controller* controllerToRemove)
     controllers.getLock().exit();
 
     sendChangeMessage (&controllers);
-    // Bouml preserved body end 0004158D
 }
 
 void MidiMorph::saveGUIState (juce::XmlElement* state)
 {
-    // Bouml preserved body begin 00041A8D
-    if (guiState != 0)
+    if (guiState != nullptr)
     {
         deleteAndZero (guiState);
     }
     this->guiState = state;
-    // Bouml preserved body end 00041A8D
 }
 
 juce::XmlElement* MidiMorph::getSavedGUIState()
 {
-    // Bouml preserved body begin 00041B0D
     return guiState;
-    // Bouml preserved body end 00041B0D
 }
 
-void MidiMorph::setPaneSize (Rectangle<int> size)
+void MidiMorph::setPaneSize (juce::Rectangle<int> size)
 {
-    // Bouml preserved body begin 0004798D
     paneSize = size;
-    // Bouml preserved body end 0004798D
 }
 
-Rectangle<int> MidiMorph::getPaneSize()
+juce::Rectangle<int> MidiMorph::getPaneSize()
 {
-    // Bouml preserved body begin 00047A0D
     return paneSize;
-    // Bouml preserved body end 00047A0D
 }
 
 void MidiMorph::addSceneAtCursor()
 {
-    // Bouml preserved body begin 00047D0D
-    Scene* scene = new Scene (this);
+    auto* scene = new Scene (this);
     scene->setXY (cursor->getCursorPosition().getX(), cursor->getCursorPosition().getY());
     addScene (scene);
-
-    // Bouml preserved body end 00047D0D
 }
 
 int MidiMorph::getRefreshRate()
 {
-    // Bouml preserved body begin 00047F8D
     return this->refreshRate;
-    // Bouml preserved body end 00047F8D
 }
 
 bool MidiMorph::hasNewMidi()
 {
-    // Bouml preserved body begin 00048B8D
     return (valuesChanged || valueChanged);
-    // Bouml preserved body end 00048B8D
 }
 
-OwnedArray<Scene>* MidiMorph::getScenes()
+juce::OwnedArray<Scene>* MidiMorph::getScenes()
 {
-    // Bouml preserved body begin 00048C0D
     return &scenes;
-    // Bouml preserved body end 00048C0D
 }
 
 void MidiMorph::sendChangeMessage (void* ptr)
 {
-    // Bouml preserved body begin 00048D0D
     if (ptr != lastRecipant)
     {
-        MessageManagerLock lock;
+        juce::MessageManagerLock lock;
         dispatchPendingMessages();
     }
     currentChangeBroadcastRecipient = ptr;
     ChangeBroadcaster::sendChangeMessage();
     this->lastRecipant = ptr;
-    // Bouml preserved body end 00048D0D
 }
 
 void MidiMorph::sceneMoved()
 {
-    // Bouml preserved body begin 00048E8D
     if (! auditSelScene)
     {
         this->valuesChanged = true;
     }
     sumDistancesChanged = true;
-    // Bouml preserved body end 00048E8D
 }
 
 void MidiMorph::setAuditSelScene (bool shouldAudit)
 {
-    // Bouml preserved body begin 00048F0D
     auditSelScene = shouldAudit;
     valuesChanged = true;
-    // Bouml preserved body end 00048F0D
 }
 
 bool MidiMorph::getAuditSelScene()
 {
-    // Bouml preserved body begin 00048F8D
     return auditSelScene;
-
-    // Bouml preserved body end 00048F8D
 }
 
 bool MidiMorph::needsRefresh()
 {
-    // Bouml preserved body begin 0004900D
     return valuesChanged;
-    // Bouml preserved body end 0004900D
 }
 
 bool MidiMorph::needsOneRefresh()
 {
-    // Bouml preserved body begin 0004908D
     return valueChanged;
-    // Bouml preserved body end 0004908D
 }
 
 void MidiMorph::showControllers (bool show)
 {
     if (show)
+    {
         controllerListWidth = 120;
+    }
     else
+    {
         controllerListWidth = 0;
+    }
+
     sendChangeMessage (this);
 }

--- a/pizjuce/MiddyMorphy/MidiMorph.h
+++ b/pizjuce/MiddyMorphy/MidiMorph.h
@@ -1,28 +1,14 @@
 #pragma once
 
-#include "juce_audio_basics/juce_audio_basics.h"
-#include "juce_core/juce_core.h"
-#include "juce_events/juce_events.h"
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_core/juce_core.h>
+#include <juce_events/juce_events.h>
 
 #include "Controller.h"
 #include "Scene.h"
 
 class Cursor;
-namespace juce
-{
-class XmlElement;
-}
-namespace juce
-{
-class MidiMessage;
-}
-namespace juce
-{
-class MidiBuffer;
-}
 class ControllerValue;
-
-using namespace juce;
 
 class MidiMorph : public juce::ChangeBroadcaster
 {
@@ -30,7 +16,7 @@ public:
     MidiMorph();
     ~MidiMorph() override;
 
-    OwnedArray<Scene> scenes;
+    juce::OwnedArray<Scene> scenes;
     Cursor* cursor;
 
     int refreshRate;
@@ -44,16 +30,10 @@ public:
     float getCursorXRatio();
     float getCursorYRatio();
 
-    //-can happen by input or slider movement.
-    //
-    //-if a scene is selected, (or multiple scenes) the value for that controller gets set.
-    //-if no scene is selected and auto key is on, a scene gets added.
     void controllerChanged (const Controller* controllerThatHasChanged);
 
-    //send interpolated controller vaules  that actually differ from the last output to midi out
     void distancesChanged();
 
-    //foreach scene : moved();
     void cursorChanged();
 
     void showControllers (bool show);
@@ -64,14 +44,6 @@ public:
     int getControllerCCNo (int index);
     int getControllerValue (int index);
 
-    //if controller != cursor controller
-    //if   controller is in list
-    //	if - scene/s is selected, .> set/add value for selected scenes/s
-    //	else if  "autokey" is on, ->add scene at cursor pos, select scene, set/add value for cursor,
-    //
-    //else if "autolearn" is on add controller.
-    //		if - scene/s is selected, .> set/add value for selected scenes/s
-    //		else if no scene is selected && "autokey" is on, ->add scene at cursor pos, select scene, set/add value for cursor
     void onMidiEvent (juce::MidiMessage& events);
 
     void getMidiMessages (int offset, juce::MidiBuffer& buffer);
@@ -82,9 +54,9 @@ public:
 
     int getNumSelectedScenes();
 
-    void setSelectedScenes (Array<Scene*>& scenes);
+    void setSelectedScenes (juce::Array<Scene*>& scenes);
 
-    Array<Scene*>* getSelectedScenes();
+    juce::Array<Scene*>* getSelectedScenes();
 
     Scene* getSelectedScene (int index);
 
@@ -94,9 +66,9 @@ public:
 
     void removeScene (Scene* scene);
 
-    OwnedArray<Controller>* getControllers();
+    juce::OwnedArray<Controller>* getControllers();
 
-    juce::XmlElement* getXml (const juce::String tagname);
+    juce::XmlElement* getXml (juce::String tagname);
 
     void setFromXml (juce::XmlElement* xmlData);
 
@@ -122,7 +94,7 @@ public:
 
     bool hasNewMidi();
 
-    OwnedArray<Scene>* getScenes();
+    juce::OwnedArray<Scene>* getScenes();
 
     void sendChangeMessage (void* ptr);
 
@@ -139,8 +111,8 @@ public:
     void* currentChangeBroadcastRecipient;
 
 private:
-    OwnedArray<Controller> controllers;
-    Array<Scene*> selectedScenes;
+    juce::OwnedArray<Controller> controllers;
+    juce::Array<Scene*> selectedScenes;
     juce::XmlElement* guiState;
     bool valuesChanged;
     bool valueChanged;

--- a/pizjuce/MiddyMorphy/MidiMorphGUI.cpp
+++ b/pizjuce/MiddyMorphy/MidiMorphGUI.cpp
@@ -8,12 +8,10 @@
 #include "MorphPane.h"
 #include "MorphPaneModel.h"
 
-MidiMorphGUI::MidiMorphGUI (AudioProcessor* const ownerPlugIn)
+MidiMorphGUI::MidiMorphGUI (juce::AudioProcessor* const ownerPlugIn)
     : AudioProcessorEditor (ownerPlugIn)
 {
-    // Bouml preserved body begin 0002E80D
-
-    LookAndFeel::setDefaultLookAndFeel (new D3CKLook());
+    juce::LookAndFeel::setDefaultLookAndFeel (new D3CKLook());
     this->setMouseClickGrabsKeyboardFocus (false);
 
     this->ownerFilter = ownerPlugIn;
@@ -32,98 +30,70 @@ MidiMorphGUI::MidiMorphGUI (AudioProcessor* const ownerPlugIn)
 
     controllerListModel = new ControllerList (core);
 
-    addAndMakeVisible (controllerList = new ListBox ("controls", controllerListModel));
+    addAndMakeVisible (controllerList = new juce::ListBox ("controls", controllerListModel));
     controllerList->setRowHeight (24);
     controllerList->getVerticalScrollBar().setAutoHide (false);
     controllerList->setMouseClickGrabsKeyboardFocus (false);
 
-    this->addAndMakeVisible (resizer = new ResizableBorderComponent (this, 0));
+    this->addAndMakeVisible (resizer = new juce::ResizableBorderComponent (this, 0));
     resizer->setMouseClickGrabsKeyboardFocus (false);
 
     this->morphPane->setFromXml (core->getSavedGUIState());
 
-    //this->setWantsKeyboardFocus(true);
-
-    //this->grabKeyboardFocus();
-
     this->setSize (w, h);
-
-    // Bouml preserved body end 0002E80D
 }
 
 MidiMorphGUI::~MidiMorphGUI()
 {
-    // Bouml preserved body begin 0003188D
     core->saveGUIState (morphPane->getXml ("morphpanestate"));
     core->removeChangeListener (this);
 
     deleteAndZero (morphPane);
-    //deleteAndZero (sceneOptionsBar);
     deleteAndZero (controllerList);
     deleteAndZero (resizer);
 
     deleteAndZero (morphPaneModel);
-    //deleteAndZero(controllerAdd);
     deleteAndZero (controllerListModel);
-    // Bouml preserved body end 0003188D
 }
 
-//ApplicationCommandTarget *  getNextCommandTarget
-ApplicationCommandTarget* MidiMorphGUI::getNextCommandTarget()
+juce::ApplicationCommandTarget* MidiMorphGUI::getNextCommandTarget()
 {
-    // Bouml preserved body begin 0003058D
-    return 0;
-    // Bouml preserved body end 0003058D
+    return nullptr;
 }
 
 void MidiMorphGUI::resized()
 {
-    // Bouml preserved body begin 0002F30D
     this->resizer->setBounds (0, 0, getWidth(), getHeight());
     this->controllerList->setBounds (0, 0, core->controllerListWidth, getHeight());
     this->morphPane->setBounds (controllerList->getWidth(), 0, getWidth() - core->controllerListWidth, getHeight());
     core->paneSize.setSize (morphPane->getWidth(), morphPane->getHeight());
     core->guiBounds.setSize (getWidth(), getHeight());
-    // Bouml preserved body end 0002F30D
 }
 
-//void  getAllCommands (Array< CommandID > &commands)=0
-void MidiMorphGUI::getAllCommands (Array<CommandID>& commands)
+void MidiMorphGUI::getAllCommands (juce::Array<juce::CommandID>& commands)
 {
-    // Bouml preserved body begin 0003060D
-    // Bouml preserved body end 0003060D
 }
 
-//void  getCommandInfo (const CommandID commandID, ApplicationCommandInfo &result)=
-void MidiMorphGUI::getCommandInfo (const CommandID commandID, ApplicationCommandInfo& result)
+void MidiMorphGUI::getCommandInfo (const juce::CommandID commandID, juce::ApplicationCommandInfo& result)
 {
-    // Bouml preserved body begin 0003068D
-    // Bouml preserved body end 0003068D
 }
 
-//perform ()=0
 bool MidiMorphGUI::perform (const InvocationInfo& info)
 {
-    // Bouml preserved body begin 0003070D
     return true;
-    // Bouml preserved body end 0003070D
 }
 
-void MidiMorphGUI::changeListenerCallback (ChangeBroadcaster* source)
+void MidiMorphGUI::changeListenerCallback (juce::ChangeBroadcaster* source)
 {
-    // Bouml preserved body begin 0003350D
     void* objectThatHasChanged = source;
     if (core->currentChangeBroadcastRecipient == core->getSelectedScenes())
     {
         this->controllerListModel->scenesSelected();
-        //morphPane->setSelectedScenes(
     }
     else if (core->currentChangeBroadcastRecipient == core->getCursor())
     {
         controllerListModel->distancesChanged();
         core->saveGUIState (morphPane->getXml ("morphpanestate"));
-        //    	ownerFilter->setParameterNotifyingHost(0,core->getCursorXRatio());
-        //    	ownerFilter->setParameterNotifyingHost(1,core->getCursorYRatio());
     }
     else if (core->currentChangeBroadcastRecipient == core->getScenes())
     {
@@ -142,15 +112,10 @@ void MidiMorphGUI::changeListenerCallback (ChangeBroadcaster* source)
         this->resized();
     }
     repaint();
-    // Bouml preserved body end 0003350D
 }
 
-//==============================================================================
-
-void MidiMorphGUI::paint (Graphics& g)
+void MidiMorphGUI::paint (juce::Graphics& g)
 {
-    // Bouml preserved body begin 00040A0D
-    g.setColour (Colours::white);
+    g.setColour (juce::Colours::white);
     g.fillRect (0, 0, getWidth(), getHeight());
-    // Bouml preserved body end 00040A0D
 }

--- a/pizjuce/MiddyMorphy/MidiMorphGUI.h
+++ b/pizjuce/MiddyMorphy/MidiMorphGUI.h
@@ -1,24 +1,12 @@
 #pragma once
 
-#include "juce_audio_processors/juce_audio_processors.h"
-#include "juce_events/juce_events.h"
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_events/juce_events.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
-namespace juce
-{
-class AudioProcessor;
-}
 class MidiMorph;
-namespace juce
-{
-class ListBox;
-}
 class ControllerList;
 class MorphPaneModel;
-namespace juce
-{
-class ResizableBorderComponent;
-}
 class MidiMorphPlugInInterface;
 class CursorGUI;
 class MorphPane;
@@ -29,43 +17,36 @@ class MidiMorphGUI : public juce::ChangeListener,
                      public juce::AudioProcessorEditor
 {
 public:
-    MidiMorphGUI (juce::AudioProcessor* const ownerPlugIn);
+    MidiMorphGUI (juce::AudioProcessor* ownerPlugIn);
 
     ~MidiMorphGUI() override;
 
-private:
-    MidiMorph* core;
-
-    juce::ListBox* controllerList;
-
-    juce::AudioProcessor* ownerFilter;
-
-public:
     ControllerList* controllerListModel;
 
-private:
-    MorphPaneModel* morphPaneModel;
-
-    juce::ResizableBorderComponent* resizer;
-
-public:
-    //ApplicationCommandTarget *  getNextCommandTarget
     ApplicationCommandTarget* getNextCommandTarget() override;
 
     void resized() override;
 
-    //void  getAllCommands (Array< CommandID > &commands)=0
     void getAllCommands (juce::Array<juce::CommandID>& commands) override;
 
-    //void  getCommandInfo (const CommandID commandID, ApplicationCommandInfo &result)=
     void getCommandInfo (juce::CommandID commandID, juce::ApplicationCommandInfo& result) override;
 
-    //perform ()=0
     bool perform (const InvocationInfo& info) override;
 
     void changeListenerCallback (juce::ChangeBroadcaster* objectThatHasChanged) override;
 
     void paint (juce::Graphics& g) override;
 
-    juce_UseDebuggingNewOperator private : MorphPane* morphPane;
+private:
+    MorphPane* morphPane;
+
+private:
+    MidiMorph* core;
+    MorphPaneModel* morphPaneModel;
+
+    juce::ListBox* controllerList;
+    juce::AudioProcessor* ownerFilter;
+    juce::ResizableBorderComponent* resizer;
+
+    JUCE_LEAK_DETECTOR (MidiMorphGUI)
 };

--- a/pizjuce/MiddyMorphy/MidiMorphPlugInInterface.cpp
+++ b/pizjuce/MiddyMorphy/MidiMorphPlugInInterface.cpp
@@ -2,6 +2,9 @@
 #include "MidiMorphPlugInInterface.h"
 #include "MidiMorphGUI.h"
 
+using juce::jmax;
+using juce::roundToInt;
+
 juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()
 {
     return new MidiMorphPlugInInterface();
@@ -9,78 +12,53 @@ juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()
 
 MidiMorphPlugInInterface::MidiMorphPlugInInterface()
 {
-    // Bouml preserved body begin 0003038D
     this->lastGUIw  = 300;
     this->lastGUIh  = 400;
     this->samplePos = 0;
     this->sendPos   = 0;
     loadDefaultFxb();
-    // Bouml preserved body end 0003038D
 }
 
 MidiMorphPlugInInterface::~MidiMorphPlugInInterface()
 {
-    // Bouml preserved body begin 0003040D
-    // Bouml preserved body end 0003040D
 }
 
 void MidiMorphPlugInInterface::prepareToPlay (double sampleRate, int estimatedSamplesPerBlock)
 {
-    // Bouml preserved body begin 0002D90D
-    // Bouml preserved body end 0002D90D
 }
 
-//
-const String MidiMorphPlugInInterface::getInputChannelName (const int channelIndex) const
+const juce::String MidiMorphPlugInInterface::getInputChannelName (const int channelIndex) const
 {
-    // Bouml preserved body begin 0002DA0D
-    return "getInputChannelName(" + String (channelIndex) + ")";
-    // Bouml preserved body end 0002DA0D
+    return "getInputChannelName(" + juce::String (channelIndex) + ")";
 }
 
-//virtual  AudioProcessor::getOutputChannelName  (       )  const
-const String MidiMorphPlugInInterface::getOutputChannelName (const int channelIndex) const
+const juce::String MidiMorphPlugInInterface::getOutputChannelName (const int channelIndex) const
 {
-    // Bouml preserved body begin 0002DA8D
-    return "getOutputChannelName(" + String (channelIndex) + ")";
-    // Bouml preserved body end 0002DA8D
+    return "getOutputChannelName(" + juce::String (channelIndex) + ")";
 }
 
-//virtual bool AudioProcessor::isInputChannelStereoPair  (  int  index   )  const
 bool MidiMorphPlugInInterface::isInputChannelStereoPair (int index) const
 {
-    // Bouml preserved body begin 0002DB0D
     return true;
-    // Bouml preserved body end 0002DB0D
 }
 
-//virtual bool AudioProcessor::isInputChannelStereoPair  (  int  index   )  const
 bool MidiMorphPlugInInterface::isOutputChannelStereoPair (int index) const
 {
-    // Bouml preserved body begin 0002DB8D
     return true;
-    // Bouml preserved body end 0002DB8D
 }
 
-//virtual AudioProcessorEditor* AudioProcessor::createEditor  (    )
-
-AudioProcessorEditor* MidiMorphPlugInInterface::createEditor()
+juce::AudioProcessorEditor* MidiMorphPlugInInterface::createEditor()
 {
-    // Bouml preserved body begin 0002DC0D
     return new MidiMorphGUI (this);
-    // Bouml preserved body end 0002DC0D
 }
 
 int MidiMorphPlugInInterface::getNumParameters()
 {
-    // Bouml preserved body begin 0002DC8D
     return 2;
-    // Bouml preserved body end 0002DC8D
 }
 
-const String MidiMorphPlugInInterface::getParameterName (int parameterIndex)
+const juce::String MidiMorphPlugInInterface::getParameterName (int parameterIndex)
 {
-    // Bouml preserved body begin 0002DD0D
     if (parameterIndex == 0)
     {
         return "cursor X";
@@ -89,13 +67,11 @@ const String MidiMorphPlugInInterface::getParameterName (int parameterIndex)
     {
         return "cursor Y";
     }
-    return String();
-    // Bouml preserved body end 0002DD0D
+    return juce::String();
 }
 
 float MidiMorphPlugInInterface::getParameter (int parameterIndex)
 {
-    // Bouml preserved body begin 0002DD8D
     if (parameterIndex == 0)
     {
         return core.getCursorXRatio();
@@ -105,19 +81,15 @@ float MidiMorphPlugInInterface::getParameter (int parameterIndex)
         return core.getCursorYRatio();
     }
     return 0.f;
-    // Bouml preserved body end 0002DD8D
 }
 
-const String MidiMorphPlugInInterface::getParameterText (int parameterIndex)
+const juce::String MidiMorphPlugInInterface::getParameterText (int parameterIndex)
 {
-    // Bouml preserved body begin 0002DE0D
-    return String (getParameter (parameterIndex));
-    // Bouml preserved body end 0002DE0D
+    return juce::String (getParameter (parameterIndex));
 }
 
 void MidiMorphPlugInInterface::setParameter (int parameterIndex, float newValue)
 {
-    // Bouml preserved body begin 0002DE8D
     if (newValue != getParameter (parameterIndex))
     {
         if (parameterIndex == 0)
@@ -129,67 +101,47 @@ void MidiMorphPlugInInterface::setParameter (int parameterIndex, float newValue)
             core.setCursorYRatio (newValue);
         }
     }
-    // Bouml preserved body end 0002DE8D
 }
 
-//bool AudioProcessor::isParameterAutomatable  (  int  parameterIndex   )
 bool MidiMorphPlugInInterface::isParameterAutomatable (int parameterIndex)
 {
-    // Bouml preserved body begin 0002DF0D
     return true;
-    // Bouml preserved body end 0002DF0D
 }
 
 int MidiMorphPlugInInterface::getNumPrograms()
 {
-    // Bouml preserved body begin 0002DF8D
     return 0;
-    // Bouml preserved body end 0002DF8D
 }
 
 int MidiMorphPlugInInterface::getCurrentProgram()
 {
-    // Bouml preserved body begin 0002E00D
     return 0;
-    // Bouml preserved body end 0002E00D
 }
 
-//  (  int     )
 void MidiMorphPlugInInterface::setCurrentProgram (int index)
 {
-    // Bouml preserved body begin 0002E08D
-    // Bouml preserved body end 0002E08D
 }
 
-// AudioProcessor::getProgramName  (  int  index   )
-const String MidiMorphPlugInInterface::getProgramName (int index)
+const juce::String MidiMorphPlugInInterface::getProgramName (int index)
 {
-    // Bouml preserved body begin 0002E10D
-    return "getProgramName(" + String (index) + ")";
-    // Bouml preserved body end 0002E10D
+    return "getProgramName(" + juce::String (index) + ")";
 }
 
-//
-void MidiMorphPlugInInterface::changeProgramName (int index, const String& newName)
+void MidiMorphPlugInInterface::changeProgramName (int index, const juce::String& newName)
 {
-    // Bouml preserved body begin 0002E18D
-    // Bouml preserved body end 0002E18D
 }
 
 void MidiMorphPlugInInterface::setStateInformation (const void* data, int sizeInBytes)
 {
-    // Bouml preserved body begin 0002E30D
     auto state = AudioProcessor::getXmlFromBinary (data, sizeInBytes);
-    if (state != 0)
+    if (state != nullptr)
     {
         core.setFromXml (state.get());
     }
-    // Bouml preserved body end 0002E30D
 }
 
-void MidiMorphPlugInInterface::processBlock (AudioSampleBuffer& buffer, MidiBuffer& midiMessages)
+void MidiMorphPlugInInterface::processBlock (juce::AudioSampleBuffer& buffer, juce::MidiBuffer& midiMessages)
 {
-    // Bouml preserved body begin 0002EB0D
     for (auto&& m : midiMessages)
     {
         auto msg = m.getMessage();
@@ -207,44 +159,32 @@ void MidiMorphPlugInInterface::processBlock (AudioSampleBuffer& buffer, MidiBuff
     {
         delta = roundToInt (jmax ((double) 0, sendPos - samplePos));
         core.getMidiMessages (delta, midiMessages);
-        //midiMessages.addEvents(core.getMidiMessages(delta),0,99999,0);
+
         sendPos += stepSize;
     }
     samplePos += buffer.getNumSamples();
-    // Bouml preserved body end 0002EB0D
 }
 
-//  (       )
-void MidiMorphPlugInInterface::getStateInformation (JUCE_NAMESPACE::MemoryBlock& destData)
+void MidiMorphPlugInInterface::getStateInformation (juce::MemoryBlock& destData)
 {
-    // Bouml preserved body begin 0002EB8D
-    AudioProcessor::copyXmlToBinary (*core.getXml ("midimorph"), destData);
-    // Bouml preserved body end 0002EB8D
+    juce::AudioProcessor::copyXmlToBinary (*core.getXml ("midimorph"), destData);
 }
 
 void MidiMorphPlugInInterface::releaseResources()
 {
-    // Bouml preserved body begin 0002EC8D
-    // Bouml preserved body end 0002EC8D
 }
 
 bool MidiMorphPlugInInterface::acceptsMidi() const
 {
-    // Bouml preserved body begin 0002ED0D
     return true;
-    // Bouml preserved body end 0002ED0D
 }
 
 bool MidiMorphPlugInInterface::producesMidi() const
 {
-    // Bouml preserved body begin 0002ED8D
     return true;
-    // Bouml preserved body end 0002ED8D
 }
 
-const String MidiMorphPlugInInterface::getName() const
+const juce::String MidiMorphPlugInInterface::getName() const
 {
-    // Bouml preserved body begin 0002EE0D
     return ("MidiMorph");
-    // Bouml preserved body end 0002EE0D
 }

--- a/pizjuce/MiddyMorphy/MidiMorphPlugInInterface.h
+++ b/pizjuce/MiddyMorphy/MidiMorphPlugInInterface.h
@@ -1,16 +1,12 @@
 #pragma once
 
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_core/juce_core.h>
+
 #include "../_common/PizAudioProcessor.h"
 #include "MidiMorph.h"
 
-namespace juce
-{
-class AudioProcessorEditor;
-}
-namespace juce
-{
-class MidiBuffer;
-}
 class MidiMorphGUI;
 
 class MidiMorphPlugInInterface : public PizAudioProcessor
@@ -24,69 +20,47 @@ public:
 
     int lastGUIh;
 
-private:
-    double sendPos;
-
-    double samplePos;
-
-public:
     MidiMorph core;
 
     void prepareToPlay (double sampleRate, int estimatedSamplesPerBlock) override;
 
-    //
-    const String getInputChannelName (const int channelIndex) const override;
+    const juce::String getInputChannelName (int channelIndex) const override;
 
-    //virtual  AudioProcessor::getOutputChannelName  (       )  const
-    const String getOutputChannelName (const int channelIndex) const override;
+    const juce::String getOutputChannelName (int channelIndex) const override;
 
-    //virtual bool AudioProcessor::isInputChannelStereoPair  (  int  index   )  const
     bool isInputChannelStereoPair (int index) const override;
 
-    //virtual bool AudioProcessor::isInputChannelStereoPair  (  int  index   )  const
     bool isOutputChannelStereoPair (int index) const override;
 
-    //virtual AudioProcessorEditor* AudioProcessor::createEditor  (    )
-
-    AudioProcessorEditor* createEditor() override;
+    juce::AudioProcessorEditor* createEditor() override;
 
     int getNumParameters() override;
 
-    const String getParameterName (int parameterIndex) override;
+    const juce::String getParameterName (int parameterIndex) override;
 
     float getParameter (int parameterIndex) override;
 
-    //const String AudioProcessor::getParameterText  (  int  parameterIndex   )
-    const String getParameterText (int parameterIndex) override;
-
-    //setParameter  (  int  parameterIndex,
-    //  float  newValue
-    // )
+    const juce::String getParameterText (int parameterIndex) override;
 
     void setParameter (int parameterIndex, float newValue) override;
 
-    //bool AudioProcessor::isParameterAutomatable  (  int  parameterIndex   )
     bool isParameterAutomatable (int parameterIndex);
 
     int getNumPrograms() override;
 
     int getCurrentProgram() override;
 
-    //  (  int     )
     void setCurrentProgram (int index) override;
 
-    // AudioProcessor::getProgramName  (  int  index   )
-    const String getProgramName (int index) override;
+    const juce::String getProgramName (int index) override;
 
-    //
-    void changeProgramName (int index, const String& newName) override;
+    void changeProgramName (int index, const juce::String& newName) override;
 
     void setStateInformation (const void* data, int sizeInBytes) override;
 
-    void processBlock (AudioSampleBuffer& buffer, MidiBuffer& midiMessages) override;
+    void processBlock (juce::AudioSampleBuffer& buffer, juce::MidiBuffer& midiMessages) override;
 
-    //  (       )
-    void getStateInformation (JUCE_NAMESPACE::MemoryBlock& destData) override;
+    void getStateInformation (juce::MemoryBlock& destData) override;
 
     void releaseResources() override;
 
@@ -94,9 +68,13 @@ public:
 
     bool producesMidi() const override;
 
-    const String getName() const override;
+    const juce::String getName() const override;
 
     double getTailLengthSeconds() const override { return 0; }
 
     bool hasEditor() const override { return true; }
+
+private:
+    double sendPos;
+    double samplePos;
 };

--- a/pizjuce/MiddyMorphy/Module.cpp
+++ b/pizjuce/MiddyMorphy/Module.cpp
@@ -1,21 +1,14 @@
 
 #include "Module.h"
 
-void Module::mouseDown (const MouseEvent&)
+void Module::mouseDown (const juce::MouseEvent&)
 {
-    // Bouml preserved body begin 0003F60D
-
-    // Bouml preserved body end 0003F60D
 }
 
-void Module::mouseDrag (const MouseEvent&)
+void Module::mouseDrag (const juce::MouseEvent&)
 {
-    // Bouml preserved body begin 0003F68D
-    // Bouml preserved body end 0003F68D
 }
 
-void Module::mouseUp (const MouseEvent& e)
+void Module::mouseUp (const juce::MouseEvent& e)
 {
-    // Bouml preserved body begin 0003F70D
-    // Bouml preserved body end 0003F70D
 }

--- a/pizjuce/MiddyMorphy/Module.h
+++ b/pizjuce/MiddyMorphy/Module.h
@@ -1,25 +1,23 @@
 #pragma once
 
-#include "juce_core/juce_core.h"
-#include "juce_graphics/juce_graphics.h"
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_core/juce_core.h>
+#include <juce_graphics/juce_graphics.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
 #include "XYItem.h"
-
-using namespace juce;
 
 class Module : public XYItem
 {
 public:
-    virtual void mouseDown (const MouseEvent& e);
+    virtual void mouseDown (const juce::MouseEvent& e);
 
-    virtual void mouseDrag (const MouseEvent&);
+    virtual void mouseDrag (const juce::MouseEvent&);
 
-    virtual void mouseUp (const MouseEvent& e);
+    virtual void mouseUp (const juce::MouseEvent& e);
 
-    Colour colour;
+    juce::Colour colour;
 
-    String name;
+    juce::String name;
 
     int size;
 };

--- a/pizjuce/MiddyMorphy/ModuleGUI.cpp
+++ b/pizjuce/MiddyMorphy/ModuleGUI.cpp
@@ -3,17 +3,16 @@
 #include "Module.h"
 #include "ModulePane.h"
 
+using juce::roundToInt;
+
 ModuleGUI::ModuleGUI (Module* module)
 {
-    // Bouml preserved body begin 0003C20D
     this->module = module;
     this->setMouseClickGrabsKeyboardFocus (false);
-    // Bouml preserved body end 0003C20D
 }
 
-void ModuleGUI::mouseDrag (const MouseEvent& e)
+void ModuleGUI::mouseDrag (const juce::MouseEvent& e)
 {
-    // Bouml preserved body begin 0003B80D
     module->mouseDrag (e);
     if (e.mods.isLeftButtonDown())
     {
@@ -27,15 +26,12 @@ void ModuleGUI::mouseDrag (const MouseEvent& e)
         else
             pane->mouseDrag (e.getEventRelativeTo (pane));
     }
-
-    // Bouml preserved body end 0003B80D
 }
 
-void ModuleGUI::mouseUp (const MouseEvent& e)
+void ModuleGUI::mouseUp (const juce::MouseEvent& e)
 {
-    // Bouml preserved body begin 0003B88D
     module->mouseUp (e);
-    //pane->mouseUp(e.getEventRelativeTo(pane));
+
     if (e.mods.isLeftButtonDown() && (e.mods.isAltDown() || e.mods.isCtrlDown()))
     {
         if (e.mods.isCtrlDown())
@@ -47,13 +43,10 @@ void ModuleGUI::mouseUp (const MouseEvent& e)
             pane->selectedModules.deselectAll();
         }
     }
-
-    // Bouml preserved body end 0003B88D
 }
 
-void ModuleGUI::mouseDown (const MouseEvent& e)
+void ModuleGUI::mouseDown (const juce::MouseEvent& e)
 {
-    // Bouml preserved body begin 0003B90D
     module->mouseDown (e);
     pane->mouseDown (e.getEventRelativeTo (pane));
     if (e.mods.isLeftButtonDown() && (e.mods.isAltDown() || e.mods.isCtrlDown()))
@@ -67,78 +60,58 @@ void ModuleGUI::mouseDown (const MouseEvent& e)
     }
     else if (e.mods.isRightButtonDown())
     {
-        //this->selectionBool = pane->selectedModules.addToSelectionOnMouseDown(this,e.mods);
         this->toFront (true);
     }
-    // Bouml preserved body end 0003B90D
 }
 
-void ModuleGUI::setOriginalBounds (const Rectangle<int> bounds)
+void ModuleGUI::setOriginalBounds (const juce::Rectangle<int> bounds)
 {
-    // Bouml preserved body begin 0003DF8D
     module->setXY ((float) bounds.getX(), (float) bounds.getY());
-    // Bouml preserved body end 0003DF8D
 }
 
-Rectangle<int> ModuleGUI::getOriginalBounds()
+juce::Rectangle<int> ModuleGUI::getOriginalBounds()
 {
-    // Bouml preserved body begin 0003DA8D
-    return Rectangle<int> (roundToInt (module->getX()), roundToInt (module->getY()), module->size, module->size);
-    // Bouml preserved body end 0003DA8D
+    return { roundToInt (module->getX()), roundToInt (module->getY()), module->size, module->size };
 }
 
-//==============================================================================
-
-void ModuleGUI::paint (Graphics& g)
+void ModuleGUI::paint (juce::Graphics& g)
 {
-    // Bouml preserved body begin 0003DC0D
     int s = getWidth();
     g.setColour (module->colour);
     g.fillEllipse (2.f, 2.f, (float) (s - 4), (float) (s - 4));
     if (isSelected())
     {
-        g.setColour (Colours::black);
+        g.setColour (juce::Colours::black);
         g.drawEllipse (2, 2, (float) (s - 4), (float) (s - 4), 2);
     }
 
-    g.setColour (Colours::white);
-    g.setFont (g.getCurrentFont().withHeight (s * 0.4f).withStyle (Font::bold));
-    g.drawFittedText (module->name, 0, 0, s, s, Justification::centred, 1);
-    // Bouml preserved body end 0003DC0D
+    g.setColour (juce::Colours::white);
+    g.setFont (g.getCurrentFont().withHeight (s * 0.4f).withStyle (juce::Font::bold));
+    g.drawFittedText (module->name, 0, 0, s, s, juce::Justification::centred, 1);
 }
 
-void ModuleGUI::setPane (ModulePane* pane)
+void ModuleGUI::setPane (ModulePane* paneToSet)
 {
-    // Bouml preserved body begin 0003DD0D
-    this->pane = pane;
-    // Bouml preserved body end 0003DD0D
+    this->pane = paneToSet;
 }
 
 void ModuleGUI::startDrag (juce::MouseEvent const& e)
 {
-    // Bouml preserved body begin 0003DE0D
     this->dragger.startDraggingComponent (this, e);
-    // Bouml preserved body end 0003DE0D
 }
 
-void ModuleGUI::drag (const MouseEvent& e)
+void ModuleGUI::drag (const juce::MouseEvent& e)
 {
-    // Bouml preserved body begin 0003DE8D
     dragger.dragComponent (this, e, nullptr);
     refreshOriginalBounds();
-    // Bouml preserved body end 0003DE8D
 }
 
 bool ModuleGUI::isSelected()
 {
-    // Bouml preserved body begin 0003E40D
     return this->pane->selectedModules.isSelected (this);
-    // Bouml preserved body end 0003E40D
 }
 
 Module* ModuleGUI::getModule()
 {
-    // Bouml preserved body begin 0003E88D
     return module;
-    // Bouml preserved body end 0003E88D
 }

--- a/pizjuce/MiddyMorphy/ModuleGUI.h
+++ b/pizjuce/MiddyMorphy/ModuleGUI.h
@@ -1,18 +1,38 @@
 #pragma once
 
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_gui_basics/juce_gui_basics.h>
 
 #include "ZoomableShiftableComponent.h"
 
 class Module;
 class ModulePane;
 
-using namespace juce;
-
 class ModuleGUI : public ZoomableShiftableComponent
 {
 public:
     ModuleGUI (Module* module);
+
+    void mouseDrag (const juce::MouseEvent& e) override;
+
+    void mouseUp (const juce::MouseEvent& e) override;
+
+    void mouseDown (const juce::MouseEvent& e) override;
+
+    void setOriginalBounds (juce::Rectangle<int> bounds) override;
+
+    juce::Rectangle<int> getOriginalBounds() override;
+
+    void paint (juce::Graphics& g) override;
+
+    void setPane (ModulePane* pane);
+
+    void startDrag (juce::MouseEvent const& e);
+
+    void drag (const juce::MouseEvent& e);
+
+    bool isSelected();
+
+    Module* getModule();
 
 private:
     bool selectionBool;
@@ -22,27 +42,4 @@ private:
     juce::ComponentDragger dragger;
 
     ModulePane* pane;
-
-public:
-    void mouseDrag (const MouseEvent& e) override;
-
-    void mouseUp (const MouseEvent& e) override;
-
-    void mouseDown (const MouseEvent& e) override;
-
-    void setOriginalBounds (const juce::Rectangle<int> bounds) override;
-
-    juce::Rectangle<int> getOriginalBounds() override;
-
-    void paint (Graphics& g) override;
-
-    void setPane (ModulePane* pane);
-
-    void startDrag (juce::MouseEvent const& e);
-
-    void drag (const MouseEvent& e);
-
-    bool isSelected();
-
-    Module* getModule();
 };

--- a/pizjuce/MiddyMorphy/ModulePane.cpp
+++ b/pizjuce/MiddyMorphy/ModulePane.cpp
@@ -3,11 +3,9 @@
 #include "Module.h"
 #include "ModuleGUI.h"
 #include "ModulePaneModel.h"
-//#include "D3CKStdCommands.h"
 
 ModulePane::ModulePane (ModulePaneModel* modulePaneModel)
 {
-    // Bouml preserved body begin 0003C18D
     this->model = modulePaneModel;
     this->model->setOwnerPane (this);
     this->updateContent();
@@ -15,24 +13,18 @@ ModulePane::ModulePane (ModulePaneModel* modulePaneModel)
     this->addAndMakeVisible (&lasso);
     this->setMouseClickGrabsKeyboardFocus (false);
     this->setInterceptsMouseClicks (true, true);
-    // Bouml preserved body end 0003C18D
 }
 
 ModulePane::~ModulePane()
 {
-    // Bouml preserved body begin 0004208D
     selectedModules.removeChangeListener (this);
     modules.clear();
-    // Bouml preserved body end 0004208D
 }
 
-//drag the origin around
-//call the reArrangeChildren
-void ModulePane::mouseDrag (const MouseEvent& e)
+void ModulePane::mouseDrag (const juce::MouseEvent& e)
 {
-    // Bouml preserved body begin 0003B78D
     model->mouseDrag (e);
-    if (e.mods.isMiddleButtonDown()) // || e.mods.isShiftDown())
+    if (e.mods.isMiddleButtonDown())
     {
         dragOrigin (e);
     }
@@ -40,18 +32,15 @@ void ModulePane::mouseDrag (const MouseEvent& e)
     {
         this->lasso.dragLasso (e);
     }
-    // Bouml preserved body end 0003B78D
 }
 
-void ModulePane::mouseDown (const MouseEvent& e)
+void ModulePane::mouseDown (const juce::MouseEvent& e)
 {
-    // Bouml preserved body begin 0003B98D
-
     model->mouseDown (e);
 
-    if (e.mods.isMiddleButtonDown()) // || e.mods.isShiftDown())
+    if (e.mods.isMiddleButtonDown())
     {
-        setMouseCursor (MouseCursor::DraggingHandCursor);
+        setMouseCursor (juce::MouseCursor::DraggingHandCursor);
         startDragOrigin (e);
     }
     else if (e.mods.isLeftButtonDown() && (e.mods.isAltDown() || e.mods.isCtrlDown()))
@@ -62,94 +51,72 @@ void ModulePane::mouseDown (const MouseEvent& e)
         }
         this->lasso.beginLasso (e, this);
     }
-    // Bouml preserved body end 0003B98D
 }
 
-void ModulePane::mouseUp (const MouseEvent& e)
+void ModulePane::mouseUp (const juce::MouseEvent& e)
 {
-    // Bouml preserved body begin 0003BA0D
-
     lasso.endLasso();
     model->mouseUp (e);
 
-    setMouseCursor (MouseCursor::NormalCursor);
-    // Bouml preserved body end 0003BA0D
+    setMouseCursor (juce::MouseCursor::NormalCursor);
 }
 
-void ModulePane::mouseWheelMove (const MouseEvent& e, float wheelIncrementX, float wheelIncrementY)
+void ModulePane::mouseWheelMove (const juce::MouseEvent& e, float wheelIncrementX, float wheelIncrementY)
 {
-    // Bouml preserved body begin 0003E18D
     float factor = 1 + wheelIncrementY;
     this->zoom (factor, factor, (float) e.x, (float) e.y);
-    // Bouml preserved body end 0003E18D
 }
 
 void ModulePane::updateContent()
 {
-    // Bouml preserved body begin 0003D70D
     this->selectedModules.deselectAll();
     while (modules.size() > 0)
     {
         ModuleGUI* oldGUI = modules.removeAndReturn (0);
         removeZoomedComp (oldGUI);
     }
-    //this->zoomedComponents.clear();
+
     for (int i = 0; i < model->getNumModules(); i++)
     {
         ModuleGUI* gui = model->createGUI (i);
-        if (gui == 0)
+        if (gui == nullptr)
         {
             gui = new ModuleGUI (model->getModule (i));
         }
         modules.add (gui);
         gui->setPane (this);
         addZoomedComp (gui);
-
-        //zoomedComponents.add(gui);
     }
     rePositionChildren();
-    // Bouml preserved body end 0003D70D
 }
 
 bool ModulePane::isModuleSelected (const Module* module)
 {
-    // Bouml preserved body begin 0003E30D
     return true;
-    // Bouml preserved body end 0003E30D
 }
 
-//==============================================================================
-
-void ModulePane::paintOverChildren (Graphics& g)
+void ModulePane::paintOverChildren (juce::Graphics& g)
 {
-    // Bouml preserved body begin 0003E38D
     g.drawRoundedRectangle (0.f, 0.f, (float) getWidth(), (float) getHeight(), 2.f, 2.f);
-    // Bouml preserved body end 0003E38D
 }
 
-void ModulePane::changeListenerCallback (ChangeBroadcaster* source)
+void ModulePane::changeListenerCallback (juce::ChangeBroadcaster* source)
 {
-    // Bouml preserved body begin 0003E48D
     void* objectThatHasChanged = source;
     if (objectThatHasChanged == &selectedModules)
     {
         repaint();
         model->selectionChanged (selectedModules.getItemArray());
     }
-    // Bouml preserved body end 0003E48D
 }
 
-//  getLassoSelection
-SelectedItemSet<ModuleGUI*>& ModulePane::getLassoSelection()
+juce::SelectedItemSet<ModuleGUI*>& ModulePane::getLassoSelection()
 {
-    // Bouml preserved body begin 0003E50D
     return this->selectedModules;
-    // Bouml preserved body end 0003E50D
 }
 
-void ModulePane::findLassoItemsInArea (Array<ModuleGUI*>& itemsFound, const juce::Rectangle<int>& area)
+void ModulePane::findLassoItemsInArea (juce::Array<ModuleGUI*>& itemsFound, const juce::Rectangle<int>& area)
 {
-    // Bouml preserved body begin 0003E58D
     for (int i = 0; i < this->modules.size(); i++)
     {
         ModuleGUI* current = modules[i];
@@ -158,61 +125,44 @@ void ModulePane::findLassoItemsInArea (Array<ModuleGUI*>& itemsFound, const juce
             itemsFound.add (current);
         }
     }
-    // Bouml preserved body end 0003E58D
 }
 
 void ModulePane::selectModule (int index, bool deselectOthers)
 {
-    // Bouml preserved body begin 00047D8D
     if (deselectOthers)
     {
         selectedModules.deselectAll();
     }
     this->selectedModules.addToSelection (modules[index]);
-    // Bouml preserved body end 00047D8D
 }
 
-//perform ()=0
 bool ModulePane::perform (const InvocationInfo& info)
 {
-    // Bouml preserved body begin 0004910D
-    if (info.commandID == 0) //D3CKStdCommands::del)
+    if (info.commandID == 0)
     {
     }
-    else if (info.commandID == 1) //D3CKStdCommands::selectAll)
+    else if (info.commandID == 1)
     {
         for (int i = modules.size(); --i >= 0;)
         {
             selectedModules.addToSelection (modules[i]);
         }
         return true;
-        //this->selectedModules.changed();
     }
     return false;
-    // Bouml preserved body end 0004910D
 }
 
-//ApplicationCommandTarget *  getNextCommandTarget
-ApplicationCommandTarget* ModulePane::getNextCommandTarget()
+juce::ApplicationCommandTarget* ModulePane::getNextCommandTarget()
 {
-    // Bouml preserved body begin 0004918D
-    return 0;
-    // Bouml preserved body end 0004918D
+    return nullptr;
 }
 
-//void  getCommandInfo (const CommandID commandID, ApplicationCommandInfo &result)=
-void ModulePane::getCommandInfo (const CommandID commandID, ApplicationCommandInfo& result)
+void ModulePane::getCommandInfo (const juce::CommandID commandID, juce::ApplicationCommandInfo& result)
 {
-    // Bouml preserved body begin 0004920D
-
-    // Bouml preserved body end 0004920D
 }
 
-//void  getAllCommands (Array< CommandID > &commands)=0
-void ModulePane::getAllCommands (Array<CommandID>& commands)
+void ModulePane::getAllCommands (juce::Array<juce::CommandID>& commands)
 {
-    // Bouml preserved body begin 0004928D
-    commands.add (0); //D3CKStdCommands::del);
-    commands.add (1); //D3CKStdCommands::selectAll);
-    // Bouml preserved body end 0004928D
+    commands.add (0);
+    commands.add (1);
 }

--- a/pizjuce/MiddyMorphy/ModulePane.h
+++ b/pizjuce/MiddyMorphy/ModulePane.h
@@ -1,14 +1,12 @@
 #pragma once
 
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_gui_basics/juce_gui_basics.h>
+
 #include "ZoomingShiftingComponent.h"
 
 class ModulePaneModel;
 class ModuleGUI;
 class Module;
-//class D3CKStdCommands;
-
-using namespace juce;
 
 class ModulePane : public juce::LassoSource<ModuleGUI*>, public juce::ChangeListener, public ZoomingShiftingComponent, public juce::ApplicationCommandTarget
 {
@@ -17,50 +15,40 @@ public:
 
     ~ModulePane() override;
 
-private:
-    LassoComponent<ModuleGUI*> lasso;
+    juce::SelectedItemSet<ModuleGUI*> selectedModules;
 
-    Array<ModuleGUI*> modules;
-
-    ModulePaneModel* model;
-
-public:
-    SelectedItemSet<ModuleGUI*> selectedModules;
-
-    //drag the origin around
-    //call the reArrangeChildren
-    void mouseDrag (const MouseEvent& e) override;
-
-    void mouseDown (const MouseEvent& e) override;
-
-    void mouseUp (const MouseEvent& e) override;
-
-    void mouseWheelMove (const MouseEvent& e, float wheelIncrementX, float wheelIncrementY);
+    void mouseDrag (const juce::MouseEvent& e) override;
+    void mouseDown (const juce::MouseEvent& e) override;
+    void mouseUp (const juce::MouseEvent& e) override;
+    void mouseWheelMove (const juce::MouseEvent& e, float wheelIncrementX, float wheelIncrementY);
 
     void updateContent();
 
     bool isModuleSelected (const Module* module);
 
-    void paintOverChildren (Graphics& g) override;
+    void paintOverChildren (juce::Graphics& g) override;
 
-    juce_UseDebuggingNewOperator void changeListenerCallback (ChangeBroadcaster* source) override;
+    void changeListenerCallback (juce::ChangeBroadcaster* source) override;
 
-    //  getLassoSelection
-    SelectedItemSet<ModuleGUI*>& getLassoSelection() override;
+    juce::SelectedItemSet<ModuleGUI*>& getLassoSelection() override;
 
-    void findLassoItemsInArea (Array<ModuleGUI*>& itemsFound, const juce::Rectangle<int>& area) override;
+    void findLassoItemsInArea (juce::Array<ModuleGUI*>& itemsFound, const juce::Rectangle<int>& area) override;
 
     void selectModule (int index, bool deselectOthers);
 
-    //perform ()=0
     bool perform (const InvocationInfo& info) override;
 
-    //ApplicationCommandTarget *  getNextCommandTarget
     ApplicationCommandTarget* getNextCommandTarget() override;
 
-    //void  getCommandInfo (const CommandID commandID, ApplicationCommandInfo &result)=
-    void getCommandInfo (CommandID commandID, ApplicationCommandInfo& result) override;
+    void getCommandInfo (juce::CommandID commandID, juce::ApplicationCommandInfo& result) override;
 
-    //void  getAllCommands (Array< CommandID > &commands)=0
-    void getAllCommands (Array<CommandID>& commands) override;
+    void getAllCommands (juce::Array<juce::CommandID>& commands) override;
+
+private:
+    juce::LassoComponent<ModuleGUI*> lasso;
+    juce::Array<ModuleGUI*> modules;
+
+    ModulePaneModel* model;
+
+    JUCE_LEAK_DETECTOR (ModulePane)
 };

--- a/pizjuce/MiddyMorphy/ModulePaneModel.cpp
+++ b/pizjuce/MiddyMorphy/ModulePaneModel.cpp
@@ -4,73 +4,48 @@
 #include "ModuleGUI.h"
 #include "ModulePane.h"
 
-void ModulePaneModel::mouseDown (const MouseEvent& e)
+void ModulePaneModel::mouseDown (const juce::MouseEvent& e)
 {
-    // Bouml preserved body begin 0003D30D
-
-    // Bouml preserved body end 0003D30D
 }
 
-void ModulePaneModel::mouseUp (const MouseEvent& e)
+void ModulePaneModel::mouseUp (const juce::MouseEvent& e)
 {
-    // Bouml preserved body begin 0003D38D
-
-    // Bouml preserved body end 0003D38D
 }
 
-void ModulePaneModel::mouseDoubleClick (const MouseEvent& e)
+void ModulePaneModel::mouseDoubleClick (const juce::MouseEvent& e)
 {
-    // Bouml preserved body begin 0003D40D
-    // Bouml preserved body end 0003D40D
 }
 
-void ModulePaneModel::mouseDrag (const MouseEvent& e)
+void ModulePaneModel::mouseDrag (const juce::MouseEvent& e)
 {
 }
 
 ModulePane* ModulePaneModel::getOwnerPane()
 {
-    // Bouml preserved body begin 0003DA0D
     return ownerPane;
-    // Bouml preserved body end 0003DA0D
 }
 
 void ModulePaneModel::refreshModulePane()
 {
-    // Bouml preserved body begin 0003DB0D
     ownerPane->updateContent();
-    // Bouml preserved body end 0003DB0D
 }
 
 void ModulePaneModel::setOwnerPane (ModulePane* ownerPane)
 {
-    // Bouml preserved body begin 0003DB8D
     this->ownerPane = ownerPane;
-    // Bouml preserved body end 0003DB8D
 }
 
 bool ModulePaneModel::isModuleSelected (const Module* module)
 {
-    // Bouml preserved body begin 0003DD8D
     return false;
-    // Bouml preserved body end 0003DD8D
 }
 
-//SelectedItemSet<Module*> ModulePaneModel::getSelectedModules() {
-//  return 0;
-//}
-
-//const InvocationInfo &
 bool ModulePaneModel::performCommand (const juce::ApplicationCommandTarget::InvocationInfo& info)
 {
-    // Bouml preserved body begin 0004930D
     return this->ownerPane->perform (info);
-    // Bouml preserved body end 0004930D
 }
 
 bool ModulePaneModel::deleteModule (const Module* moduleToDelete, int indexOfModule)
 {
-    // Bouml preserved body begin 0004978D
     return false;
-    // Bouml preserved body end 0004978D
 }

--- a/pizjuce/MiddyMorphy/ModulePaneModel.h
+++ b/pizjuce/MiddyMorphy/ModulePaneModel.h
@@ -1,12 +1,10 @@
 #pragma once
 
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_gui_basics/juce_gui_basics.h>
 
 class ModuleGUI;
 class ModulePane;
 class Module;
-
-using namespace juce;
 
 class ModulePaneModel
 {
@@ -15,17 +13,13 @@ public:
 
     virtual int getNumModules() = 0;
 
-    virtual void mouseDown (const MouseEvent& e);
+    virtual void mouseDown (const juce::MouseEvent& e);
 
-    virtual void mouseUp (const MouseEvent& e);
-    virtual void mouseDrag (const MouseEvent& e);
+    virtual void mouseUp (const juce::MouseEvent& e);
+    virtual void mouseDrag (const juce::MouseEvent& e);
 
-    virtual void mouseDoubleClick (const MouseEvent& e);
+    virtual void mouseDoubleClick (const juce::MouseEvent& e);
 
-private:
-    ModulePane* ownerPane;
-
-public:
     virtual Module* getModule (int index) = 0;
 
     ModulePane* getOwnerPane();
@@ -36,12 +30,12 @@ public:
 
     bool isModuleSelected (const Module* module);
 
-    //    virtual SelectedItemSet<Module*> getSelectedModules();
+    virtual void selectionChanged (const juce::Array<ModuleGUI*>& modules) = 0;
 
-    virtual void selectionChanged (const Array<ModuleGUI*>& modules) = 0;
-
-    //const InvocationInfo &
     bool performCommand (const juce::ApplicationCommandTarget::InvocationInfo& info);
 
     bool deleteModule (const Module* moduleToDelete, int indexOfModule);
+
+private:
+    ModulePane* ownerPane;
 };

--- a/pizjuce/MiddyMorphy/MorphPane.cpp
+++ b/pizjuce/MiddyMorphy/MorphPane.cpp
@@ -2,13 +2,11 @@
 #include "MorphPane.h"
 #include "MidiMorph.h"
 #include "ModulePaneModel.h"
-//#include "ResizableBorderComponentEx.h"
 #include "Scene.h"
 
 MorphPane::MorphPane (ModulePaneModel* model, MidiMorph* core)
     : ModulePane (model)
 {
-    // Bouml preserved body begin 00042F8D
     this->core = core;
     this->setSelectedScenes (core->getSelectedScenes(), false);
     //this->selectedModules.addChangeListener(core);
@@ -17,37 +15,27 @@ MorphPane::MorphPane (ModulePaneModel* model, MidiMorph* core)
 
     //addAndMakeVisible(resizer = new ResizableBorderComponentEx(this,limit));
     //resizer->setActiveBorders(false,true,true,false);
-
-    // Bouml preserved body end 00042F8D
 }
 
 void MorphPane::resized()
 {
-    // Bouml preserved body begin 0004300D
-
     //resizer->setBounds(0,0,getWidth(),getHeight());
 
     //core->setPaneSize(getBounds());
 
     //getParentComponent()->resized();
-
-    // Bouml preserved body end 0004300D
 }
 
 MorphPane::~MorphPane()
 {
-    // Bouml preserved body begin 0004790D
     //deleteAndZero(resizer);
-    // Bouml preserved body end 0004790D
 }
 
-void MorphPane::setSelectedScenes (Array<Scene*>* scenes, bool sendChangeMessage)
+void MorphPane::setSelectedScenes (juce::Array<Scene*>* scenes, bool sendChangeMessage)
 {
-    // Bouml preserved body begin 0004808D
     for (int i = 0; i < scenes->size(); i++)
     {
         int isc = core->getSceneIndex (scenes->operator[] (i));
         selectModule (isc, i == 0);
     }
-    // Bouml preserved body end 0004808D
 }

--- a/pizjuce/MiddyMorphy/MorphPane.h
+++ b/pizjuce/MiddyMorphy/MorphPane.h
@@ -12,17 +12,13 @@ class MorphPane : public ModulePane
 public:
     MorphPane (ModulePaneModel* model, MidiMorph* core);
 
+    ~MorphPane() override;
+
     void resized() override;
+
+    void setSelectedScenes (juce::Array<Scene*>* scenes, bool sendChangeMessage);
 
 private:
     ResizableBorderComponentEx* resizer;
-
-public:
-    ~MorphPane() override;
-
-private:
     MidiMorph* core;
-
-public:
-    void setSelectedScenes (Array<Scene*>* scenes, bool sendChangeMessage);
 };

--- a/pizjuce/MiddyMorphy/MorphPaneModel.cpp
+++ b/pizjuce/MiddyMorphy/MorphPaneModel.cpp
@@ -1,7 +1,7 @@
 
 #include "MorphPaneModel.h"
 
-#include "juce_events/juce_events.h"
+#include <juce_events/juce_events.h>
 
 #include "Cursor.h"
 #include "CursorGUI.h"
@@ -9,40 +9,26 @@
 #include "Module.h"
 #include "TextBoxSlider.h"
 
+using juce::roundToInt;
+
 MorphPaneModel::MorphPaneModel (MidiMorph* core)
 {
-    // Bouml preserved body begin 0003CC0D
     this->core   = core;
     this->cursor = core->getCursor();
 
     addAndMakeVisible (rateBox = new TextBoxSlider (0));
     rateBox->setRange (1, 5000, 1, 2);
     rateBox->addListener (this);
-    rateBox->setColour (rateBox->backgroundColourId, Colours::white);
-    rateBox->setValue (core->refreshRate, dontSendNotification);
-
-    // Bouml preserved body end 0003CC0D
+    rateBox->setColour (rateBox->backgroundColourId, juce::Colours::white);
+    rateBox->setValue (core->refreshRate, juce::dontSendNotification);
 }
 
 int MorphPaneModel::getNumModules()
 {
-    // Bouml preserved body begin 0003CE0D
     return core->scenes.size();
-    // Bouml preserved body end 0003CE0D
 }
 
-void MorphPaneModel::mouseDown (const MouseEvent& e)
-{
-    // Bouml preserved body begin 0003D20D
-    if (e.mods.isLeftButtonDown() && ! e.mods.isCtrlDown() && ! e.mods.isAltDown())
-    {
-        int s = cursor->size / 2;
-        cursor->setXY ((float) (e.x - s), (float) (e.y - s));
-    }
-    // Bouml preserved body end 0003D20D
-}
-
-void MorphPaneModel::mouseDrag (const MouseEvent& e)
+void MorphPaneModel::mouseDown (const juce::MouseEvent& e)
 {
     if (e.mods.isLeftButtonDown() && ! e.mods.isCtrlDown() && ! e.mods.isAltDown())
     {
@@ -51,12 +37,20 @@ void MorphPaneModel::mouseDrag (const MouseEvent& e)
     }
 }
 
-void MorphPaneModel::mouseUp (const MouseEvent& e)
+void MorphPaneModel::mouseDrag (const juce::MouseEvent& e)
 {
-    // Bouml preserved body begin 0003D28D
+    if (e.mods.isLeftButtonDown() && ! e.mods.isCtrlDown() && ! e.mods.isAltDown())
+    {
+        int s = cursor->size / 2;
+        cursor->setXY ((float) (e.x - s), (float) (e.y - s));
+    }
+}
+
+void MorphPaneModel::mouseUp (const juce::MouseEvent& e)
+{
     if (e.mods.isRightButtonDown())
     {
-        PopupMenu menu, sub1;
+        juce::PopupMenu menu, sub1;
         menu.addItem (1, "add scene");
         menu.addItem (5, "add controller");
         menu.addSeparator();
@@ -73,7 +67,7 @@ void MorphPaneModel::mouseUp (const MouseEvent& e)
         int result = menu.show();
         if (result == 1)
         {
-            Scene* ns = new Scene (core);
+            auto* ns = new Scene (core);
             ns->setXY ((float) e.x, (float) e.y);
             core->addScene (ns);
         }
@@ -106,7 +100,7 @@ void MorphPaneModel::mouseUp (const MouseEvent& e)
         }
         else if (result == 7)
         {
-            ApplicationCommandTarget::InvocationInfo info (1);
+            juce::ApplicationCommandTarget::InvocationInfo info (1);
             performCommand (info);
         }
         else if (result == 8)
@@ -118,36 +112,29 @@ void MorphPaneModel::mouseUp (const MouseEvent& e)
             core->sendChangeMessage (this);
         }
     }
-    // Bouml preserved body end 0003D28D
 }
 
 Module* MorphPaneModel::getModule (int index)
 {
-    // Bouml preserved body begin 0003D80D
     return core->scenes[index];
-    // Bouml preserved body end 0003D80D
 }
 
 ModuleGUI* MorphPaneModel::createGUI (int index)
 {
-    // Bouml preserved body begin 0003D98D
-    return 0;
-    // Bouml preserved body end 0003D98D
+    return nullptr;
 }
 
-void MorphPaneModel::selectionChanged (const Array<ModuleGUI*>& modules)
+void MorphPaneModel::selectionChanged (const juce::Array<ModuleGUI*>& modules)
 {
-    // Bouml preserved body begin 0003E78D
-    Array<Scene*> scenes;
+    juce::Array<Scene*> scenes;
     for (int i = 0; i < modules.size(); i++)
     {
         scenes.add ((Scene*) modules[i]->getModule());
     }
     core->setSelectedScenes (scenes);
-    // Bouml preserved body end 0003E78D
 }
 
-void MorphPaneModel::labelTextChanged (Label* labelThatHasChanged)
+void MorphPaneModel::labelTextChanged (juce::Label* labelThatHasChanged)
 {
     if (labelThatHasChanged == rateBox)
     {

--- a/pizjuce/MiddyMorphy/MorphPaneModel.h
+++ b/pizjuce/MiddyMorphy/MorphPaneModel.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_gui_basics/juce_gui_basics.h>
 
 #include "ModuleGUI.h"
 #include "ModulePaneModel.h"
@@ -11,30 +11,28 @@ class Cursor;
 class MidiMorph;
 class Module;
 
-using namespace juce;
-
 class MorphPaneModel : public ModulePaneModel,
-                       public Label::Listener,
-                       public Component
+                       public juce::Label::Listener,
+                       public juce::Component
 {
-private:
-    Cursor* cursor;
-    MidiMorph* core;
-    TextBoxSlider* rateBox;
-
 public:
     MorphPaneModel (MidiMorph* core);
 
     int getNumModules() override;
 
-    void mouseDown (const MouseEvent& e) override;
-    void mouseUp (const MouseEvent& e) override;
-    void mouseDrag (const MouseEvent& e) override;
+    void mouseDown (const juce::MouseEvent& e) override;
+    void mouseUp (const juce::MouseEvent& e) override;
+    void mouseDrag (const juce::MouseEvent& e) override;
 
     Module* getModule (int index) override;
     ModuleGUI* createGUI (int index) override;
 
-    void selectionChanged (const Array<ModuleGUI*>& modules) override;
+    void selectionChanged (const juce::Array<ModuleGUI*>& modules) override;
 
-    void labelTextChanged (Label* labelThatHasChanged) override;
+    void labelTextChanged (juce::Label* labelThatHasChanged) override;
+
+private:
+    Cursor* cursor;
+    MidiMorph* core;
+    TextBoxSlider* rateBox;
 };

--- a/pizjuce/MiddyMorphy/NumberBox.cpp
+++ b/pizjuce/MiddyMorphy/NumberBox.cpp
@@ -1,14 +1,11 @@
 
 #include "NumberBox.h"
 
-// Component::keyPressed  (  const KeyPress &  key   )
-bool NumberBox::keyPressed (const KeyPress& key)
+bool NumberBox::keyPressed (const juce::KeyPress& key)
 {
-    // Bouml preserved body begin 0004868D
-    if (String ("0123456789.,-+").indexOfChar (key.getTextCharacter()) > -1 || key == KeyPress::returnKey || key.isKeyCode (KeyPress::escapeKey))
+    if (juce::String ("0123456789.,-+").indexOfChar (key.getTextCharacter()) > -1 || key == juce::KeyPress::returnKey || key.isKeyCode (juce::KeyPress::escapeKey))
     {
         TextEditor::keyPressed (key);
     }
     return false;
-    // Bouml preserved body end 0004868D
 }

--- a/pizjuce/MiddyMorphy/NumberBox.h
+++ b/pizjuce/MiddyMorphy/NumberBox.h
@@ -1,12 +1,9 @@
 #pragma once
 
-#include "juce_gui_basics/juce_gui_basics.h"
-
-using namespace juce;
+#include <juce_gui_basics/juce_gui_basics.h>
 
 class NumberBox : public juce::TextEditor
 {
 public:
-    // Component::keyPressed  (  const KeyPress &  key   )
-    bool keyPressed (const KeyPress& key) override;
+    bool keyPressed (const juce::KeyPress& key) override;
 };

--- a/pizjuce/MiddyMorphy/Origin.cpp
+++ b/pizjuce/MiddyMorphy/Origin.cpp
@@ -2,31 +2,21 @@
 #include "Origin.h"
 #include "ZoomingShiftingComponent.h"
 
-//==============================================================================
-
-void Origin::paint (Graphics& g)
-{
-    // Bouml preserved body begin 0003238D
-    g.drawLine (0, 0, (float) getWidth(), 0);
-    g.drawLine (0, 0, 0, (float) getHeight());
-    // Bouml preserved body end 0003238D
-}
-
 Origin::Origin()
 {
-    // Bouml preserved body begin 0003240D
     this->setSize (10, 10);
-    // Bouml preserved body end 0003240D
+}
+
+void Origin::paint (juce::Graphics& g)
+{
+    g.drawLine (0, 0, (float) getWidth(), 0);
+    g.drawLine (0, 0, 0, (float) getHeight());
 }
 
 void Origin::resized()
 {
-    // Bouml preserved body begin 0003B08D
-    // Bouml preserved body end 0003B08D
 }
 
 void Origin::moved()
 {
-    // Bouml preserved body begin 0003C38D
-    // Bouml preserved body end 0003C38D
 }

--- a/pizjuce/MiddyMorphy/Origin.h
+++ b/pizjuce/MiddyMorphy/Origin.h
@@ -1,26 +1,20 @@
 #pragma once
 
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_gui_basics/juce_gui_basics.h>
 
 class ZoomingShiftingComponent;
-
-using namespace juce;
 
 class Origin : public juce::Component
 {
 public:
-    void paint (Graphics& g) override;
-
     Origin();
+
+    void paint (juce::Graphics& g) override;
 
     void resized() override;
 
-private:
-    ZoomingShiftingComponent* owner;
-
-public:
     void moved() override;
 
 private:
-    float originalSize;
+    ZoomingShiftingComponent* owner;
 };

--- a/pizjuce/MiddyMorphy/Scene.cpp
+++ b/pizjuce/MiddyMorphy/Scene.cpp
@@ -6,20 +6,19 @@
 #include "MidiMorph.h"
 #include "ModuleGUI.h"
 
+using juce::jmax;
+
 Scene::Scene (const Scene& scene)
 {
-    // Bouml preserved body begin 0003D10D
-    // Bouml preserved body end 0003D10D
 }
 
 Scene::Scene (MidiMorph* core)
 {
-    // Bouml preserved body begin 00034B0D
     this->core   = core;
-    this->colour = Colours::green;
+    this->colour = juce::Colours::green;
     this->size   = 50;
 
-    addAndMakeVisible (textEditor = new TextEditor ("new text editor"));
+    addAndMakeVisible (textEditor = new juce::TextEditor ("new text editor"));
     textEditor->setMultiLine (false);
     textEditor->setReturnKeyStartsNewLine (false);
     textEditor->setReadOnly (false);
@@ -30,61 +29,49 @@ Scene::Scene (MidiMorph* core)
     textEditor->addListener (this);
     textEditor->setText (this->getName());
 
-    colourSelector = new ColourSelector (ColourSelector::showColourAtTop | ColourSelector::showSliders | ColourSelector::showColourspace);
+    colourSelector = new juce::ColourSelector (juce::ColourSelector::showColourAtTop | juce::ColourSelector::showSliders | juce::ColourSelector::showColourspace);
     colourSelector->setName ("color");
     colourSelector->setCurrentColour (this->colour);
     colourSelector->addChangeListener (this);
 
-    addAndMakeVisible (sizeSlider = new Slider ("size"));
+    addAndMakeVisible (sizeSlider = new juce::Slider ("size"));
     sizeSlider->setRange (10, 100, 1);
-    sizeSlider->setSliderStyle (Slider::LinearHorizontal);
+    sizeSlider->setSliderStyle (juce::Slider::LinearHorizontal);
     sizeSlider->addListener (this);
 
     this->setMouseClickGrabsKeyboardFocus (false);
-
-    // Bouml preserved body end 00034B0D
 }
 
 Scene::~Scene()
 {
-    // Bouml preserved body begin 00040B0D
     for (int i = 0; i < this->controllerValues.size(); i++)
     {
         delete controllerValues[i];
     }
-    // Bouml preserved body end 00040B0D
 }
 
 float Scene::getAffectionRatio()
 {
-    // Bouml preserved body begin 0003C68D
     if (affectionRatioChanged || core->needsRefresh())
     {
         affectionRatio        = getAffectionValue() / core->getSumAffectionValues();
         affectionRatioChanged = false;
     }
     return affectionRatio;
-    //return 1. - getDistanceFromCursor() / core->getSumDistances() * ;
-    // Bouml preserved body end 0003C68D
 }
 
-//get Precalculated Value
 float Scene::getDistanceFromCursor()
 {
-    // Bouml preserved body begin 00034F8D
     if (distanceFromCursorChanged_)
     {
-        this->distanceFromCursor = jmax (0.f, getDistance (*core->cursor) - this->size * 0.5f);
-        //this->setName(String(this->distanceFromCursor));
+        this->distanceFromCursor   = jmax (0.f, getDistance (*core->cursor) - this->size * 0.5f);
         distanceFromCursorChanged_ = false;
     }
     return this->distanceFromCursor;
-    // Bouml preserved body end 00034F8D
 }
 
 int Scene::getValue (const Controller* controller)
 {
-    // Bouml preserved body begin 0003520D
     for (int i = 0; i < controllerValues.size(); i++)
     {
         if (controllerValues[i]->getController() == controller)
@@ -93,44 +80,32 @@ int Scene::getValue (const Controller* controller)
         }
     }
     return -1;
-    // Bouml preserved body end 0003520D
 }
 
-//gets called when the XYItem gets new coordinates
-//in this implementation refresh the distance value
 void Scene::moved()
 {
-    // Bouml preserved body begin 0003590D
     distanceFromCursorChanged();
     core->sceneMoved();
-    // Bouml preserved body end 0003590D
 }
 
 juce::Colour Scene::getColour()
 {
-    // Bouml preserved body begin 0003D00D
     return this->colour;
-    // Bouml preserved body end 0003D00D
 }
 
 void Scene::setColour (const juce::Colour& colour)
 {
-    // Bouml preserved body begin 0003D08D
     this->colour = colour;
     core->sendChangeMessage (this);
-    // Bouml preserved body end 0003D08D
 }
 
 void Scene::addValue (ControllerValue* value)
 {
-    // Bouml preserved body begin 0003F30D
     this->controllerValues.add (value);
-    // Bouml preserved body end 0003F30D
 }
 
 float Scene::getAffectionValue()
 {
-    // Bouml preserved body begin 0003F48D
     if (affectionValueChanged || core->needsRefresh())
     {
         float sumOtherDis = 0;
@@ -148,32 +123,24 @@ float Scene::getAffectionValue()
         this->affectionValueChanged = false;
     }
     return this->affectionValue;
-
-    // Bouml preserved body end 0003F48D
 }
 
 void Scene::distanceFromCursorChanged()
 {
-    // Bouml preserved body begin 0003F58D
     distanceFromCursorChanged_ = true;
     affectionRatioChanged      = true;
     affectionValueChanged      = true;
-    // Bouml preserved body end 0003F58D
 }
 
-void Scene::mouseDown (const MouseEvent& e)
+void Scene::mouseDown (const juce::MouseEvent& e)
 {
-    // Bouml preserved body begin 0003F78D
-
-    // Bouml preserved body end 0003F78D
 }
 
-void Scene::mouseUp (const MouseEvent& e)
+void Scene::mouseUp (const juce::MouseEvent& e)
 {
-    // Bouml preserved body begin 0003F80D
     if (e.mods.isRightButtonDown())
     {
-        PopupMenu menu, sub1, sub2, sub3;
+        juce::PopupMenu menu, sub1, sub2, sub3;
         menu.addItem (1, "delete");
         textEditor->setText (this->getName());
         sub1.addCustomItem (2, *textEditor, 64, 20, false, nullptr);
@@ -181,7 +148,6 @@ void Scene::mouseUp (const MouseEvent& e)
         sub2.addCustomItem (3, *colourSelector, 300, 300, false, nullptr);
         menu.addSubMenu ("color", sub2);
         sub3.addCustomItem (4, *sizeSlider, 300, 20, false, nullptr);
-        //menu.addSubMenu("size",sub3);
 
         int result = menu.show();
         if (result == 1)
@@ -189,44 +155,37 @@ void Scene::mouseUp (const MouseEvent& e)
             this->core->removeScene (this);
         }
     }
-    // Bouml preserved body end 0003F80D
 }
 
-void Scene::mouseDrag (const MouseEvent& e)
+void Scene::mouseDrag (const juce::MouseEvent& e)
 {
-    // Bouml preserved body begin 0003F88D
-    // Bouml preserved body end 0003F88D
 }
 
 void Scene::getMidiMessages (juce::MidiBuffer& buffer, int pos)
 {
-    // Bouml preserved body begin 00048D8D
     for (int i = controllerValues.size(); --i >= 0;)
     {
         controllerValues[i]->getMidiMessage (buffer, pos);
     }
-    // Bouml preserved body end 00048D8D
 }
 
 int Scene::getId()
 {
-    // Bouml preserved body begin 0004070D
     return core->getSceneIndex (this);
-    // Bouml preserved body end 0004070D
 }
 
-String Scene::getName()
+juce::String Scene::getName()
 {
     return this->name;
 }
 
-void Scene::setName (String newName)
+void Scene::setName (juce::String newName)
 {
     this->name = newName;
     core->sendChangeMessage (this);
 }
 
-void Scene::textEditorTextChanged (TextEditor& editor)
+void Scene::textEditorTextChanged (juce::TextEditor& editor)
 {
     if (&editor == textEditor)
     {
@@ -234,7 +193,7 @@ void Scene::textEditorTextChanged (TextEditor& editor)
     }
 }
 
-void Scene::textEditorReturnKeyPressed (TextEditor& editor)
+void Scene::textEditorReturnKeyPressed (juce::TextEditor& editor)
 {
     if (&editor == textEditor)
     {
@@ -242,26 +201,26 @@ void Scene::textEditorReturnKeyPressed (TextEditor& editor)
     }
 }
 
-void Scene::textEditorEscapeKeyPressed (TextEditor& editor)
+void Scene::textEditorEscapeKeyPressed (juce::TextEditor& editor)
 {
 }
 
-void Scene::textEditorFocusLost (TextEditor& editor)
+void Scene::textEditorFocusLost (juce::TextEditor& editor)
 {
 }
 
-void Scene::changeListenerCallback (ChangeBroadcaster* source)
+void Scene::changeListenerCallback (juce::ChangeBroadcaster* source)
 {
-    ColourSelector* cs = (ColourSelector*) source;
+    auto* cs = (juce::ColourSelector*) source;
     this->setColour (cs->getCurrentColour());
 }
 
-void Scene::sliderValueChanged (Slider* sliderThatWasMoved)
+void Scene::sliderValueChanged (juce::Slider* sliderThatWasMoved)
 {
     if (sliderThatWasMoved == sizeSlider)
     {
-        this->size = ::roundToInt (sizeSlider->getValue());
-        this->setSize (::roundToInt (sizeSlider->getValue()), ::roundToInt (sizeSlider->getValue()));
+        this->size = juce::roundToInt (sizeSlider->getValue());
+        this->setSize (juce::roundToInt (sizeSlider->getValue()), juce::roundToInt (sizeSlider->getValue()));
         this->resized();
         core->sendChangeMessage (this);
     }

--- a/pizjuce/MiddyMorphy/Scene.h
+++ b/pizjuce/MiddyMorphy/Scene.h
@@ -1,25 +1,21 @@
 #pragma once
 
-#include "juce_gui_basics/juce_gui_basics.h"
-#include "juce_gui_extra/juce_gui_extra.h"
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <juce_gui_extra/juce_gui_extra.h>
 
 #include "Module.h"
 
 class MidiMorph;
 class ControllerValue;
 class Controller;
-namespace juce
-{
-class MidiBuffer;
-}
 class Cursor;
 
-using namespace juce;
 class Scene : public Module,
-              public Component,
-              public ChangeListener,
-              public Slider::Listener,
-              public TextEditor::Listener
+              public juce::Component,
+              public juce::ChangeListener,
+              public juce::Slider::Listener,
+              public juce::TextEditor::Listener
 {
 public:
     Scene (const Scene& scene);
@@ -28,53 +24,29 @@ public:
 
     ~Scene() override;
 
-    void sliderValueChanged (Slider* sliderThatWasMoved) override;
-    void textEditorTextChanged (TextEditor&) override;
-    void textEditorReturnKeyPressed (TextEditor&) override;
-    void textEditorEscapeKeyPressed (TextEditor&) override;
-    void textEditorFocusLost (TextEditor&) override;
-    void changeListenerCallback (ChangeBroadcaster* source) override;
+    void sliderValueChanged (juce::Slider* sliderThatWasMoved) override;
+    void textEditorTextChanged (juce::TextEditor&) override;
+    void textEditorReturnKeyPressed (juce::TextEditor&) override;
+    void textEditorEscapeKeyPressed (juce::TextEditor&) override;
+    void textEditorFocusLost (juce::TextEditor&) override;
+    void changeListenerCallback (juce::ChangeBroadcaster* source) override;
 
-private:
-    //stored for performance reason
-    float distanceFromCursor;
-
-    float affectionRatio;
-
-    float affectionValue;
-
-    bool distanceFromCursorChanged_;
-
-    bool affectionRatioChanged;
-
-    bool affectionValueChanged;
-
-    MidiMorph* core;
-
-    TextEditor* textEditor;
-    ColourSelector* colourSelector;
-    Slider* sizeSlider;
-
-public:
-    Array<ControllerValue*> controllerValues;
+    juce::Array<ControllerValue*> controllerValues;
     float getAffectionRatio();
 
-    //get Precalculated Value
     float getDistanceFromCursor();
 
     int getValue (const Controller* controller);
 
-    //gets called when the XYItem gets new coordinates
-    //in this implementation refresh the distance value
     void moved() override;
 
     juce::Colour getColour();
 
     void setColour (const juce::Colour& colour);
 
-    String getName();
+    juce::String getName();
 
-    void setName (String newName);
+    void setName (juce::String newName);
 
     void addValue (ControllerValue* value);
 
@@ -82,16 +54,31 @@ public:
 
     void distanceFromCursorChanged();
 
-    void mouseDown (const MouseEvent& e) override;
-
-    void mouseUp (const MouseEvent& e) override;
+    void mouseDown (const juce::MouseEvent& e) override;
+    void mouseUp (const juce::MouseEvent& e) override;
+    void mouseDrag (const juce::MouseEvent& e) override;
 
     void getMidiMessages (juce::MidiBuffer& buffer, int pos);
-
-    void mouseDrag (const MouseEvent& e) override;
 
     int getId();
 
     friend class ControllerValue;
     int id;
+
+private:
+    float distanceFromCursor;
+
+    float affectionRatio;
+    float affectionValue;
+
+    bool distanceFromCursorChanged_;
+
+    bool affectionRatioChanged;
+    bool affectionValueChanged;
+
+    MidiMorph* core;
+
+    juce::TextEditor* textEditor;
+    juce::ColourSelector* colourSelector;
+    juce::Slider* sizeSlider;
 };

--- a/pizjuce/MiddyMorphy/TextBoxSlider.cpp
+++ b/pizjuce/MiddyMorphy/TextBoxSlider.cpp
@@ -2,104 +2,80 @@
 #include "TextBoxSlider.h"
 #include "NumberBox.h"
 
-void TextBoxSlider::mouseDrag (const MouseEvent& e)
-{
-    // Bouml preserved body begin 0004818D
-    double delta  = this->step * e.getDistanceFromDragStartY() / pixelStep;
-    double newVal = oldValue - delta;
-    setValue (newVal, sendNotification);
+using juce::jmax;
+using juce::jmin;
+using juce::roundToInt;
 
-    // Bouml preserved body end 0004818D
-}
-
-void TextBoxSlider::labelTextChanged (Label* labelThatHasChanged)
-{
-    // Bouml preserved body begin 0004820D
-
-    // Bouml preserved body end 0004820D
-}
-
-TextBoxSlider::TextBoxSlider (double initval)
+TextBoxSlider::TextBoxSlider (double initVal)
     : Label ("", "")
 {
-    // Bouml preserved body begin 0004830D
     setRange (0, 100, 1, 10);
-    setValue (initval, dontSendNotification);
-    //addListener(this);
+    setValue (initVal, juce::dontSendNotification);
     setEditable (true, true);
-    this->setJustificationType (Justification::centred);
-    // Bouml preserved body end 0004830D
+    this->setJustificationType (juce::Justification::centred);
 }
 
 TextBoxSlider::~TextBoxSlider()
 {
-    // Bouml preserved body begin 0004838D
-    //this->removeListener(this);
-    // Bouml preserved body end 0004838D
 }
 
-void TextBoxSlider::mouseDown (const MouseEvent& e)
+void TextBoxSlider::mouseDrag (const juce::MouseEvent& e)
 {
-    // Bouml preserved body begin 0004840D
+    double delta  = this->step * e.getDistanceFromDragStartY() / pixelStep;
+    double newVal = oldValue - delta;
+    setValue (newVal, juce::sendNotification);
+}
+
+void TextBoxSlider::labelTextChanged (Label* labelThatHasChanged)
+{
+}
+
+void TextBoxSlider::mouseDown (const juce::MouseEvent& e)
+{
     this->oldValue = getText().getDoubleValue();
-    // Bouml preserved body end 0004840D
 }
 
-void TextBoxSlider::mouseUp (const MouseEvent& e)
+void TextBoxSlider::mouseUp (const juce::MouseEvent& e)
 {
-    // Bouml preserved body begin 0004840D
     this->getParentComponent()->mouseUp (e);
-    // Bouml preserved body end 0004840D
 }
 
-void TextBoxSlider::setRange (double min, double max, double stepsize, int pixelPerStep)
+void TextBoxSlider::setRange (double newMin, double newMax, double stepSize, int pixelPerStep)
 {
-    // Bouml preserved body begin 0004848D
-    this->min       = min;
-    this->max       = max;
-    this->step      = stepsize;
+    this->min       = newMin;
+    this->max       = newMax;
+    this->step      = stepSize;
     this->pixelStep = pixelPerStep;
-    // Bouml preserved body end 0004848D
 }
 
 juce::TextEditor* TextBoxSlider::createEditorComponent()
 {
-    // Bouml preserved body begin 0004850D
-    TextEditor* te = new NumberBox();
+    juce::TextEditor* te = new NumberBox();
     te->setSelectAllWhenFocused (true);
     te->setFont (getFont());
     te->setInputRestrictions (256, "0123456789.,-+");
-    te->setColour (te->outlineColourId, Colour (0.f, 0, 0, 0.f));
-    te->setColour (te->backgroundColourId, Colour (0.f, 0, 0, 0.f));
-    te->setColour (te->focusedOutlineColourId, Colour (0.f, 0, 0, 0.f));
-    te->setColour (te->highlightColourId, Colours::white);
-    ////te->setIndents(getWidth()/2,0);
+    te->setColour (te->outlineColourId, juce::Colour (0.f, 0, 0, 0.f));
+    te->setColour (te->backgroundColourId, juce::Colour (0.f, 0, 0, 0.f));
+    te->setColour (te->focusedOutlineColourId, juce::Colour (0.f, 0, 0, 0.f));
+    te->setColour (te->highlightColourId, juce::Colours::white);
+
     return te;
-    // Bouml preserved body end 0004850D
 }
 
-//==============================================================================
-
-void TextBoxSlider::paintOverChildren (Graphics& g)
+void TextBoxSlider::paintOverChildren (juce::Graphics& g)
 {
-    // Bouml preserved body begin 0004858D
     g.setColour (findColour (textColourId));
     g.drawRoundedRectangle (1.f, 1.f, (float) (getWidth() - 2), (float) (getHeight() - 2), (float) (getHeight() - 2) / 2.f, 1.f);
-    // Bouml preserved body end 0004858D
 }
 
 double TextBoxSlider::getValue()
 {
-    // Bouml preserved body begin 0004870D
     return value;
-    // Bouml preserved body end 0004870D
 }
 
-// (const String& newText,                       const bool broadcastChangeMessage)
-void TextBoxSlider::setText (const String& newText, NotificationType notification)
+void TextBoxSlider::setText (const juce::String& newText, juce::NotificationType notification)
 {
-    // Bouml preserved body begin 00048B0D
-    String t (newText.trimStart());
+    juce::String t (newText.trimStart());
 
     while (t.startsWithChar ('+'))
     {
@@ -109,34 +85,26 @@ void TextBoxSlider::setText (const String& newText, NotificationType notificatio
     double newVal = t.initialSectionContainingOnly ("0123456789.,-").getDoubleValue();
 
     setValue (newVal, notification);
-    // Bouml preserved body end 00048B0D
 }
 
-void TextBoxSlider::setValue (double newVal, NotificationType notification)
+void TextBoxSlider::setValue (double newVal, juce::NotificationType notification)
 {
-    // Bouml preserved body begin 00048A8D
     long newValInt = roundToInt (newVal / step);
     newVal         = newValInt * step;
     newVal         = jmin (max, newVal);
     newVal         = jmax (min, newVal);
 
     value = newVal;
-    Label::setText (String (value), notification);
-
-    // Bouml preserved body end 00048A8D
+    Label::setText (juce::String (value), notification);
 }
 
 void TextBoxSlider::resized()
 {
-    // Bouml preserved body begin 00049C0D
-    setFont (Font ((float) (getHeight() - 2)));
+    setFont (juce::Font ((float) (getHeight() - 2)));
     Label::resized();
-    // Bouml preserved body end 00049C0D
 }
 
 void TextBoxSlider::textWasEdited()
 {
-    // Bouml preserved body begin 0004A70D
-    this->setText (getText(), sendNotification);
-    // Bouml preserved body end 0004A70D
+    this->setText (getText(), juce::sendNotification);
 }

--- a/pizjuce/MiddyMorphy/TextBoxSlider.h
+++ b/pizjuce/MiddyMorphy/TextBoxSlider.h
@@ -1,62 +1,47 @@
 #pragma once
 
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_gui_basics/juce_gui_basics.h>
 
-namespace juce
-{
-class TextEditor;
-}
 class NumberBox;
-namespace juce
-{
-class String;
-}
-using namespace juce;
 
 class TextBoxSlider : public juce::Label::Listener, public juce::Label
 {
 public:
-    void mouseDrag (const MouseEvent& e) override;
-
-    void labelTextChanged (Label* labelThatHasChanged) override;
-
-    TextBoxSlider (double initval);
+    TextBoxSlider (double initVal);
 
     ~TextBoxSlider() override;
 
-    void mouseDown (const MouseEvent& e) override;
-    void mouseUp (const MouseEvent& e) override;
+    void mouseDrag (const juce::MouseEvent& e) override;
+
+    void labelTextChanged (Label* labelThatHasChanged) override;
+
+    void mouseDown (const juce::MouseEvent& e) override;
+    void mouseUp (const juce::MouseEvent& e) override;
+
+    void setRange (double newMin, double newMax, double stepSize, int pixelPerStep);
+
+    juce::TextEditor* createEditorComponent() override;
+
+    void paintOverChildren (juce::Graphics& g) override;
+
+    double getValue();
+
+    void setValue (double newVal, juce::NotificationType notification);
+
+    void resized() override;
+
+    void textWasEdited() override;
 
 private:
     int pixelStep;
 
     double oldValue;
-
     double value;
 
     double min;
-
     double max;
 
     double step;
 
-public:
-    void setRange (double min, double max, double stepsize, int pixelPerStep);
-
-    juce::TextEditor* createEditorComponent() override;
-
-    void paintOverChildren (Graphics& g) override;
-
-    double getValue();
-
-private:
-    // (const String& newText,                       const bool broadcastChangeMessage)
-    void setText (const String& newText, NotificationType notification);
-
-public:
-    void setValue (double newVal, NotificationType notification);
-
-    void resized() override;
-
-    void textWasEdited() override;
+    void setText (const juce::String& newText, juce::NotificationType notification);
 };

--- a/pizjuce/MiddyMorphy/XYItem.cpp
+++ b/pizjuce/MiddyMorphy/XYItem.cpp
@@ -3,24 +3,17 @@
 
 float XYItem::getDistance (juce::Point<float>& otherPoint)
 {
-    // Bouml preserved body begin 0003500D
     float dx = otherPoint.getX() - getX();
     float dy = otherPoint.getY() - getY();
     return pow (pow (dx, 2.f) + pow (dy, 2.f), 0.5f);
-    // Bouml preserved body end 0003500D
 }
 
-//gets called when the XYItem gets new coordinates
 void XYItem::moved()
 {
-    // Bouml preserved body begin 0003570D
-    // Bouml preserved body end 0003570D
 }
 
 void XYItem::setXY (float x, float y)
 {
-    // Bouml preserved body begin 0003578D
     Point::setXY (x, y);
     moved();
-    // Bouml preserved body end 0003578D
 }

--- a/pizjuce/MiddyMorphy/XYItem.h
+++ b/pizjuce/MiddyMorphy/XYItem.h
@@ -1,13 +1,12 @@
 #pragma once
 
-#include "juce_graphics/juce_graphics.h"
+#include <juce_graphics/juce_graphics.h>
 
 class XYItem : public juce::Point<float>
 {
 public:
     float getDistance (juce::Point<float>& otherPoint);
 
-    //gets called when the XYItem gets new coordinates
     virtual void moved();
 
     void setXY (float x, float y);

--- a/pizjuce/MiddyMorphy/ZoomableShiftableComponent.cpp
+++ b/pizjuce/MiddyMorphy/ZoomableShiftableComponent.cpp
@@ -2,33 +2,25 @@
 #include "ZoomableShiftableComponent.h"
 #include "ZoomingShiftingComponent.h"
 
-void ZoomableShiftableComponent::setOriginalBounds (const Rectangle<int> bounds)
+using juce::roundToInt;
+
+void ZoomableShiftableComponent::setOriginalBounds (const juce::Rectangle<int> bounds)
 {
-    // Bouml preserved body begin 0003DF0D
-    // Bouml preserved body end 0003DF0D
 }
 
-//returns
 float ZoomableShiftableComponent::getZoomFactorX()
 {
-    // Bouml preserved body begin 0003AE8D
     return this->zoomingComponent->getZoomFactorX();
-    // Bouml preserved body end 0003AE8D
 }
 
-//returns
 float ZoomableShiftableComponent::getZoomFactorY()
 {
-    // Bouml preserved body begin 0003E10D
     return this->zoomingComponent->getZoomFactorY();
-    // Bouml preserved body end 0003E10D
 }
 
-//calcu
 void ZoomableShiftableComponent::rePosition()
 {
-    // Bouml preserved body begin 0003AF0D
-    Rectangle<int> rect = getOriginalBounds();
+    juce::Rectangle<int> rect = getOriginalBounds();
 
     int w = roundToInt ((float) rect.getWidth() * getZoomFactorX());
     int h = roundToInt ((float) rect.getHeight() * getZoomFactorY());
@@ -36,19 +28,15 @@ void ZoomableShiftableComponent::rePosition()
     int y = roundToInt ((float) rect.getY() * getZoomFactorY());
 
     setBounds (roundToInt (zoomingComponent->getXOffset()) + x, roundToInt (zoomingComponent->getYOffset()) + y, w, h);
-    // Bouml preserved body end 0003AF0D
 }
 
 void ZoomableShiftableComponent::setZoomer (ZoomingShiftingComponent* zoomer)
 {
-    // Bouml preserved body begin 0003DC8D
     zoomingComponent = zoomer;
-    // Bouml preserved body end 0003DC8D
 }
 
 void ZoomableShiftableComponent::refreshOriginalBounds()
 {
-    // Bouml preserved body begin 0003E00D
     float x = getX() - zoomingComponent->getXOffset();
     float y = getY() - zoomingComponent->getYOffset();
 
@@ -57,7 +45,6 @@ void ZoomableShiftableComponent::refreshOriginalBounds()
     x       = x / getZoomFactorX();
     y       = y / getZoomFactorY();
 
-    Rectangle<int> rect (roundToInt (x), roundToInt (y), roundToInt (w), roundToInt (h));
+    juce::Rectangle<int> rect (roundToInt (x), roundToInt (y), roundToInt (w), roundToInt (h));
     setOriginalBounds (rect);
-    // Bouml preserved body end 0003E00D
 }

--- a/pizjuce/MiddyMorphy/ZoomableShiftableComponent.h
+++ b/pizjuce/MiddyMorphy/ZoomableShiftableComponent.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_gui_basics/juce_gui_basics.h>
 
-using namespace juce;
 class ZoomingShiftingComponent;
 
 class ZoomableShiftableComponent : public juce::Component
@@ -10,22 +9,17 @@ class ZoomableShiftableComponent : public juce::Component
 public:
     virtual juce::Rectangle<int> getOriginalBounds() = 0;
 
-    virtual void setOriginalBounds (const juce::Rectangle<int> bounds);
+    virtual void setOriginalBounds (juce::Rectangle<int> bounds);
 
-    //returns
     float getZoomFactorX();
-
-    //returns
     float getZoomFactorY();
 
-    //calcu
     void rePosition();
 
-private:
-    ZoomingShiftingComponent* zoomingComponent;
-
-public:
     void setZoomer (ZoomingShiftingComponent* zoomer);
 
     void refreshOriginalBounds();
+
+private:
+    ZoomingShiftingComponent* zoomingComponent;
 };

--- a/pizjuce/MiddyMorphy/ZoomingShiftingComponent.cpp
+++ b/pizjuce/MiddyMorphy/ZoomingShiftingComponent.cpp
@@ -1,22 +1,27 @@
 #include "ZoomingShiftingComponent.h"
 #include "ZoomableShiftableComponent.h"
 
-juce::XmlElement* ZoomingShiftingComponent::getXml (const String tagName)
+using juce::roundToInt;
+
+ZoomingShiftingComponent::ZoomingShiftingComponent()
 {
-    // Bouml preserved body begin 0004198D
-    XmlElement* state = new XmlElement (tagName);
+    addAndMakeVisible (&origin);
+    zoomFactorX = zoomFactorY = 1;
+}
+
+juce::XmlElement* ZoomingShiftingComponent::getXml (const juce::String tagName)
+{
+    auto* state = new juce::XmlElement (tagName);
     state->setAttribute ("xoff", this->origin.getX());
     state->setAttribute ("yoff", this->origin.getY());
     state->setAttribute ("xzoom", this->zoomFactorX);
     state->setAttribute ("yzoom", this->zoomFactorX);
     return state;
-    // Bouml preserved body end 0004198D
 }
 
 void ZoomingShiftingComponent::setFromXml (juce::XmlElement* data)
 {
-    // Bouml preserved body begin 00041A0D
-    if (data != 0)
+    if (data != nullptr)
     {
         int x = data->getIntAttribute ("xoff");
         int y = data->getIntAttribute ("yoff");
@@ -25,27 +30,20 @@ void ZoomingShiftingComponent::setFromXml (juce::XmlElement* data)
         this->zoomFactorY = (float) data->getDoubleAttribute ("yzoom");
         origin.setTopLeftPosition (x, y);
     }
-    // Bouml preserved body end 00041A0D
 }
 
-void ZoomingShiftingComponent::dragOrigin (const MouseEvent& e)
+void ZoomingShiftingComponent::dragOrigin (const juce::MouseEvent& e)
 {
-    // Bouml preserved body begin 0003D58D
     this->dragger.dragComponent (&origin, e, nullptr);
-    // Bouml preserved body end 0003D58D
 }
 
-void ZoomingShiftingComponent::startDragOrigin (const MouseEvent& e)
+void ZoomingShiftingComponent::startDragOrigin (const juce::MouseEvent& e)
 {
-    // Bouml preserved body begin 0003D60D
     dragger.startDraggingComponent (&origin, e);
-    // Bouml preserved body end 0003D60D
 }
 
 void ZoomingShiftingComponent::zoom (float multX, float multY, float x, float y)
 {
-    // Bouml preserved body begin 0003AF8D
-
     float newZoomRatioX = multX * zoomFactorX;
     float newZoomRatioY = multY * zoomFactorY;
 
@@ -67,101 +65,68 @@ void ZoomingShiftingComponent::zoom (float multX, float multY, float x, float y)
 
     origin.setTopLeftPosition (roundToInt ((double) origin.getX() + grownLeft),
                                roundToInt ((double) origin.getY() + grownTop));
-
-    // Bouml preserved body end 0003AF8D
 }
 
-//drag the origin around
-//call the reArrangeChildren
 void ZoomingShiftingComponent::shift (const juce::Point<int> newPosition)
 {
-    // Bouml preserved body begin 0003B10D
     origin.setTopLeftPosition (newPosition.getX(), newPosition.getY());
-    // Bouml preserved body end 0003B10D
 }
 
-//call all childrens reposition method
 void ZoomingShiftingComponent::rePositionChildren()
 {
-    // Bouml preserved body begin 0003B00D
     for (int i = 0; i < zoomedComponents.size(); i++)
     {
         zoomedComponents[i]->rePosition();
     }
-    // Bouml preserved body end 0003B00D
 }
 
 float ZoomingShiftingComponent::getXOffset()
 {
-    // Bouml preserved body begin 0003B18D
     return (float) origin.getX();
-    // Bouml preserved body end 0003B18D
 }
 
 float ZoomingShiftingComponent::getYOffset()
 {
-    // Bouml preserved body begin 0003B20D
     return (float) origin.getY();
-    // Bouml preserved body end 0003B20D
 }
 
 float ZoomingShiftingComponent::getZoomFactorX()
 {
-    // Bouml preserved body begin 0003CD0D
     return this->zoomFactorX;
-    // Bouml preserved body end 0003CD0D
 }
 
 float ZoomingShiftingComponent::getZoomFactorY()
 {
-    // Bouml preserved body begin 0003E08D
     return this->zoomFactorY;
-    // Bouml preserved body end 0003E08D
 }
 
 void ZoomingShiftingComponent::childBoundsChanged (juce::Component* component)
 {
-    // Bouml preserved body begin 0003D50D
     if (component == &origin)
     {
         this->rePositionChildren();
     }
-    // Bouml preserved body end 0003D50D
-}
-
-ZoomingShiftingComponent::ZoomingShiftingComponent()
-{
-    // Bouml preserved body begin 0003D68D
-    addAndMakeVisible (&origin);
-    zoomFactorX = zoomFactorY = 1;
-    // Bouml preserved body end 0003D68D
 }
 
 void ZoomingShiftingComponent::deleteAllZoomedComps()
 {
-    // Bouml preserved body begin 0003D88D
     for (int i = 0; i < zoomedComponents.size(); i++)
     {
         removeChildComponent (zoomedComponents[i]);
     }
     zoomedComponents.clear (true);
-    // Bouml preserved body end 0003D88D
 }
 
 void ZoomingShiftingComponent::addZoomedComp (ZoomableShiftableComponent* zsComp, bool doZoom)
 {
-    // Bouml preserved body begin 0003D90D
     addAndMakeVisible (zsComp);
     zsComp->setZoomer (this);
     this->zoomedComponents.add (zsComp);
     zsComp->rePosition();
-    // Bouml preserved body end 0003D90D
 }
 
 void ZoomingShiftingComponent::removeZoomedComp (ZoomableShiftableComponent* comp)
 {
-    // Bouml preserved body begin 0003F08D
     removeChildComponent (comp);
     zoomedComponents.remove (zoomedComponents.indexOf (comp), true);
-    // Bouml preserved body end 0003F08D
 }

--- a/pizjuce/MiddyMorphy/ZoomingShiftingComponent.h
+++ b/pizjuce/MiddyMorphy/ZoomingShiftingComponent.h
@@ -1,69 +1,47 @@
 #pragma once
 
-#include "juce_core/juce_core.h"
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_core/juce_core.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
 #include "Origin.h"
 
-using namespace juce;
-
-namespace juce
-{
-class XmlElement;
-}
 class ZoomableShiftableComponent;
 
 class ZoomingShiftingComponent : public juce::Component
 {
 public:
-    juce::XmlElement* getXml (const String tagName);
+    ZoomingShiftingComponent();
 
+    juce::XmlElement* getXml (juce::String tagName);
     void setFromXml (juce::XmlElement* data);
 
-    void dragOrigin (const MouseEvent& e);
+    void dragOrigin (const juce::MouseEvent& e);
+    void startDragOrigin (const juce::MouseEvent& e);
 
-    void startDragOrigin (const MouseEvent& e);
-
-private:
-    Origin origin;
-
-public:
     void zoom (float multX, float multY, float x, float y);
+    void shift (juce::Point<int> newPosition);
 
-    //drag the origin around
-    //call the reArrangeChildren
-    void shift (const juce::Point<int> newPosition);
-
-    //call all childrens reposition method
     void rePositionChildren();
 
     float getXOffset();
-
     float getYOffset();
 
-private:
-    float zoomFactorX;
-
-    float zoomFactorY;
-
-    OwnedArray<ZoomableShiftableComponent> zoomedComponents;
-
-public:
     float getZoomFactorX();
-
     float getZoomFactorY();
 
     void childBoundsChanged (juce::Component* component) override;
 
-private:
-    juce::ComponentDragger dragger;
-
-public:
-    ZoomingShiftingComponent();
-
+    void addZoomedComp (ZoomableShiftableComponent* zsComp, bool doZoom = true);
+    void removeZoomedComp (ZoomableShiftableComponent* comp);
     void deleteAllZoomedComps();
 
-    void addZoomedComp (ZoomableShiftableComponent* zsComp, bool doZoom = true);
+private:
+    Origin origin;
 
-    void removeZoomedComp (ZoomableShiftableComponent* comp);
+    float zoomFactorX;
+    float zoomFactorY;
+
+    juce::OwnedArray<ZoomableShiftableComponent> zoomedComponents;
+
+    juce::ComponentDragger dragger;
 };

--- a/pizjuce/_common/BankStorage.h
+++ b/pizjuce/_common/BankStorage.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "juce_core/juce_core.h"
-#include "juce_data_structures/juce_data_structures.h"
+#include <juce_core/juce_core.h>
+#include <juce_data_structures/juce_data_structures.h>
 
 class BankStorage
 {

--- a/pizjuce/_common/ChannelSlider.h
+++ b/pizjuce/_common/ChannelSlider.h
@@ -1,8 +1,8 @@
 #ifndef PIZ_CHANNEL_SLIDER_HEADER
 #define PIZ_CHANNEL_SLIDER_HEADER
 
-#include "juce_core/juce_core.h"
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_core/juce_core.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
 class ChannelSlider : public juce::Slider
 {

--- a/pizjuce/_common/ChordFunctions.cpp
+++ b/pizjuce/_common/ChordFunctions.cpp
@@ -1,11 +1,11 @@
 #include "ChordFunctions.h"
 
-PizChord::PizChord (Array<int> newChord)
+PizChord::PizChord (juce::Array<int> newChord)
 {
     chord.addArray (newChord);
     makeIntervalPattern();
 }
-void PizChord::setChord (Array<int> newChord)
+void PizChord::setChord (juce::Array<int> newChord)
 {
     chord.clear();
     chord.addArray (newChord);
@@ -18,12 +18,12 @@ int PizChord::getSum() const
         sum += pattern[i];
     return sum;
 }
-String PizChord::getStringPattern() const
+juce::String PizChord::getStringPattern() const
 {
-    String p;
+    juce::String p;
     for (int i = 0; i < pattern.size(); i++)
     {
-        p += String (pattern[i]) + ",";
+        p += juce::String (pattern[i]) + ",";
     }
     return p;
 }
@@ -54,47 +54,47 @@ bool operator<(const PizChord& first, const PizChord& second)
     return first.getStringPattern() < second.getStringPattern();
 }
 
-ChordName::ChordName (String chordName, String noteString)
+ChordName::ChordName (juce::String chordName, juce::String noteString)
 {
     name    = chordName;
     pattern = getIntervalString (noteString);
 }
 
-String ChordName::getName (int rootNote, int bassNote, bool flats)
+juce::String ChordName::getName (int rootNote, int bassNote, bool flats)
 {
     if (name == "dim7" || name == "+")
         rootNote = bassNote;
-    String chordName = getNoteNameWithoutOctave (rootNote, ! flats) + name;
+    juce::String chordName = getNoteNameWithoutOctave (rootNote, ! flats) + name;
     if (bassNote % 12 != rootNote % 12)
         chordName += "/" + getNoteNameWithoutOctave (bassNote, ! flats);
     return chordName;
 }
 
-bool ChordName::equals (String& noteString)
+bool ChordName::equals (juce::String& noteString)
 {
     return getIntervalString (noteString) == pattern;
 }
-bool ChordName::equals (Array<int>& chord)
+bool ChordName::equals (juce::Array<int>& chord)
 {
     return getIntervalString (chord).equalsIgnoreCase (pattern);
 }
-bool ChordName::equals2 (String& intervalString)
+bool ChordName::equals2 (juce::String& intervalString)
 {
     return intervalString.equalsIgnoreCase (pattern);
 }
-String ChordName::getIntervalString (String noteString)
+juce::String ChordName::getIntervalString (juce::String noteString)
 {
-    String p;
-    StringArray a;
-    a.addTokens (noteString, ",", String());
+    juce::String p;
+    juce::StringArray a;
+    a.addTokens (noteString, ",", juce::String());
 
-    Array<int> temp;
+    juce::Array<int> temp;
     for (int i = 0; i < a.size(); i++)
     {
         temp.add (getNoteValue (a[i]));
     }
-    root               = temp[0];
-    Array<int> stacked = getAsStackedChord (temp);
+    root                     = temp[0];
+    juce::Array<int> stacked = getAsStackedChord (temp);
     for (int i = 0; i < stacked.size(); i++)
     {
         if (stacked[i] == root)
@@ -104,29 +104,29 @@ String ChordName::getIntervalString (String noteString)
             int interval = stacked[i + 1] - stacked[i];
             while (interval < 0)
                 interval += 12;
-            p += String (interval) + ",";
+            p += juce::String (interval) + ",";
         }
     }
     return p;
 }
 
-String ChordName::getIntervalString (Array<int> chord)
+juce::String ChordName::getIntervalString (juce::Array<int> chord)
 {
-    Array<int> newChord = getAsStackedChord (chord);
-    String p;
+    juce::Array<int> newChord = getAsStackedChord (chord);
+    juce::String p;
     for (int i = 0; i < chord.size() - 1; i++)
     {
         int interval = chord[i + 1] - chord[i];
         while (interval < 0)
             interval += 12;
-        p += String (interval) + ",";
+        p += juce::String (interval) + ",";
     }
     return p;
 }
 
-Array<int> getAsStackedChord (Array<int>& chord, bool reduce)
+juce::Array<int> getAsStackedChord (juce::Array<int>& chord, bool reduce)
 {
-    Array<int> temp;
+    juce::Array<int> temp;
     if (reduce)
     {
         //remove duplicate notes
@@ -141,14 +141,14 @@ Array<int> getAsStackedChord (Array<int>& chord, bool reduce)
         temp.addArray (chord);
 
     //sort
-    DefaultElementComparator<int> intsorter;
+    juce::DefaultElementComparator<int> intsorter;
     temp.sort (intsorter);
 
     int Minimum = -1;
     //the base chord is the one with the minimal energy function
     //the energy function is the sum of the number of half steps between successive notes in the chord
     //hence, the canonic chord is the chord in which the notes lie as closely spaced as possible
-    Array<PizChord> MinimumEnergyChordList;
+    juce::Array<PizChord> MinimumEnergyChordList;
 
     PizChord tempChord0 (temp);
     //DBG("permutation: " + tempChord0.getStringPattern());
@@ -177,7 +177,7 @@ Array<int> getAsStackedChord (Array<int>& chord, bool reduce)
     //we need a way of picking one chord that will always lead to the same interval pattern, no matter
     //what note names are used. Normal "sort" will sort alphabetically. This is unusable.
     //We need to sort on the interval patterns instead, but return the chord that corresponds to the pattern.
-    DefaultElementComparator<PizChord> sorter;
+    juce::DefaultElementComparator<PizChord> sorter;
     MinimumEnergyChordList.sort (sorter);
     //DBG("picked" + MinimumEnergyChordList.getFirst().getStringPattern());
     return MinimumEnergyChordList.getFirst().getChord();
@@ -300,7 +300,7 @@ void fillChordDatabase()
     //ChordNames.add(ChordName("m7(no5)"      , "c,eb,bb"));
 }
 
-String getIntervalName (int semitones)
+juce::String getIntervalName (int semitones)
 {
     while (semitones > 21)
         semitones -= 12;
@@ -352,27 +352,27 @@ String getIntervalName (int semitones)
         case 21:
             return "13th";
         default:
-            return String();
+            return juce::String();
     }
 }
 
-String listNoteNames (Array<int> chord, bool flats)
+juce::String listNoteNames (juce::Array<int> chord, bool flats)
 {
-    String s;
+    juce::String s;
     for (int i = 0; i < chord.size() - 1; i++)
         s += getNoteNameWithoutOctave (chord[i], ! flats) + ", ";
     s += getNoteNameWithoutOctave (chord[chord.size() - 1], ! flats);
     return s;
 }
 
-String getFirstRecognizedChord (Array<int> chord, bool flats)
+juce::String getFirstRecognizedChord (juce::Array<int> chord, bool flats)
 {
     if (chord.size() == 0)
         return " ";
     if (chord.size() == 2)
         return getIntervalName (chord[1] - chord[0]) + " (" + listNoteNames (chord, flats) + ")";
 
-    Array<int> temp;
+    juce::Array<int> temp;
     for (int i = 0; i < chord.size(); i++)
     {
         temp.addIfNotAlreadyThere (chord[i] % 12);
@@ -381,11 +381,11 @@ String getFirstRecognizedChord (Array<int> chord, bool flats)
     if (temp.size() >= 9)
         return getNoteNameWithoutOctave (chord[0], ! flats) + " Note Soup";
 
-    Array<int> stackedChord = getAsStackedChord (temp, false);
+    juce::Array<int> stackedChord = getAsStackedChord (temp, false);
     if (stackedChord.size() == 1)
         return "(" + getNoteNameWithoutOctave (stackedChord[0], ! flats) + ")";
 
-    String s = ChordName::getIntervalString (stackedChord);
+    juce::String s = ChordName::getIntervalString (stackedChord);
     for (int i = 0; i < ChordNames.size(); i++)
     {
         if (ChordNames.getReference (i).equals2 (s))
@@ -396,15 +396,15 @@ String getFirstRecognizedChord (Array<int> chord, bool flats)
     return "(" + listNoteNames (temp, flats) + ")"; // "Unknown chord";
 }
 
-String getIntervalStringFromNoteNames (int root, String noteString, int bottomOctave)
+juce::String getIntervalStringFromNoteNames (int root, juce::String noteString, int bottomOctave)
 {
     bool multichannel = noteString.contains (".");
-    StringArray sa;
-    sa.addTokens (noteString, " ,", String());
+    juce::StringArray sa;
+    sa.addTokens (noteString, " ,", juce::String());
     bool absolute;
     int bass = getNoteValue (sa[0].upToFirstOccurrenceOf (".", false, false), bottomOctave, absolute);
     int last = 0;
-    String string;
+    juce::String string;
     if (bass != NOT_A_NOTE)
     {
         int channel = multichannel ? sa[0].fromFirstOccurrenceOf (".", false, false).getIntValue() : 0;
@@ -416,9 +416,9 @@ String getIntervalStringFromNoteNames (int root, String noteString, int bottomOc
                 bass -= 12;
             last = bass - root;
             if (channel > 0)
-                string += String (last) + "." + String (channel);
+                string += juce::String (last) + "." + juce::String (channel);
             else
-                string += String (last);
+                string += juce::String (last);
             for (int i = 1; i < sa.size(); i++)
             {
                 const int note = getNoteValue (sa[i].upToFirstOccurrenceOf (".", false, false));
@@ -429,9 +429,9 @@ String getIntervalStringFromNoteNames (int root, String noteString, int bottomOc
                         step += 12;
                     channel = sa[i].fromFirstOccurrenceOf (".", false, false).getIntValue();
                     if (channel > 0)
-                        string += " " + String (step) + "." + String (channel);
+                        string += " " + juce::String (step) + "." + juce::String (channel);
                     else
-                        string += " " + String (step);
+                        string += " " + juce::String (step);
                     last = step;
                 }
             }
@@ -440,9 +440,9 @@ String getIntervalStringFromNoteNames (int root, String noteString, int bottomOc
         {
             last = bass - root;
             if (channel > 0)
-                string += String (last) + "." + String (channel);
+                string += juce::String (last) + "." + juce::String (channel);
             else
-                string += String (last);
+                string += juce::String (last);
             for (int i = 1; i < sa.size(); i++)
             {
                 const int note = getNoteValue (sa[i].upToFirstOccurrenceOf (".", false, false), bottomOctave, absolute);
@@ -453,9 +453,9 @@ String getIntervalStringFromNoteNames (int root, String noteString, int bottomOc
                         step += 12;
                     channel = sa[i].fromFirstOccurrenceOf (".", false, false).getIntValue();
                     if (channel > 0)
-                        string += " " + String (step) + "." + String (channel);
+                        string += " " + juce::String (step) + "." + juce::String (channel);
                     else
-                        string += " " + String (step);
+                        string += " " + juce::String (step);
                     last = step;
                 }
             }
@@ -470,9 +470,9 @@ String getIntervalStringFromNoteNames (int root, String noteString, int bottomOc
         last        = bass - root;
         int channel = multichannel ? sa[0].fromFirstOccurrenceOf (".", false, false).getIntValue() : 0;
         if (channel > 0)
-            string += String (last) + "." + String (channel);
+            string += juce::String (last) + "." + juce::String (channel);
         else
-            string += String (last);
+            string += juce::String (last);
         for (int i = 1; i < sa.size(); i++)
         {
             const int note = getIntervalValue (sa[i].upToFirstOccurrenceOf (".", false, false));
@@ -482,9 +482,9 @@ String getIntervalStringFromNoteNames (int root, String noteString, int bottomOc
                 while (step - last < 0)
                     step += 12;
                 if (channel > 0)
-                    string += " " + String (step) + "." + String (channel);
+                    string += " " + juce::String (step) + "." + juce::String (channel);
                 else
-                    string += " " + String (step);
+                    string += " " + juce::String (step);
                 last = step;
             }
         }

--- a/pizjuce/_common/ChordFunctions.h
+++ b/pizjuce/_common/ChordFunctions.h
@@ -4,24 +4,26 @@
 // Chord regognition functions are adapted from PyChoReLib: http://chordrecognizer.sourceforge.net/
 // (GPL chord recognizer written in Python)
 
-#include "../_common/midistuff.h"
-#include "juce_core/juce_core.h"
 #include <algorithm>
 
-Array<int> getAsStackedChord (Array<int>& chord, bool reduce = true);
+#include <juce_core/juce_core.h>
+
+#include "../_common/midistuff.h"
+
+juce::Array<int> getAsStackedChord (juce::Array<int>& chord, bool reduce = true);
 
 class PizChord
 {
 public:
     PizChord() {}
-    PizChord (Array<int> newChord);
+    PizChord (juce::Array<int> newChord);
     ~PizChord() {}
 
-    void setChord (Array<int> newChord);
+    void setChord (juce::Array<int> newChord);
     int getSum() const;
-    Array<int> getChord() const { return chord; }
-    Array<int> getPattern() const { return pattern; }
-    String getStringPattern() const;
+    juce::Array<int> getChord() const { return chord; }
+    juce::Array<int> getPattern() const { return pattern; }
+    juce::String getStringPattern() const;
 
     bool operator<(const PizChord& other)
     {
@@ -44,8 +46,8 @@ public:
     }
 
 private:
-    Array<int> chord;
-    Array<int> pattern;
+    juce::Array<int> chord;
+    juce::Array<int> pattern;
     void makeIntervalPattern();
 };
 
@@ -54,29 +56,29 @@ bool operator<(const PizChord& first, const PizChord& second);
 class ChordName
 {
 public:
-    ChordName (String chordName, String noteString);
+    ChordName (juce::String chordName, juce::String noteString);
     ~ChordName() {}
-    String getName (int rootNote, int bassNote, bool flats);
+    juce::String getName (int rootNote, int bassNote, bool flats);
     int getRootIndex() { return rootIndex; }
 
-    bool equals (String& noteString);
-    bool equals (Array<int>& chord);
-    bool equals2 (String& intervalString);
-    String getIntervalString (String noteString);
-    static String getIntervalString (Array<int> chord);
+    bool equals (juce::String& noteString);
+    bool equals (juce::Array<int>& chord);
+    bool equals2 (juce::String& intervalString);
+    juce::String getIntervalString (juce::String noteString);
+    static juce::String getIntervalString (juce::Array<int> chord);
 
 private:
-    String name;
-    String pattern;
+    juce::String name;
+    juce::String pattern;
     int root;
     int rootIndex;
 };
 
-static Array<ChordName> ChordNames;
+static juce::Array<ChordName> ChordNames;
 void fillChordDatabase();
 
-String listNoteNames (Array<int> chord);
-String getFirstRecognizedChord (Array<int> chord, bool flats);
-String getIntervalStringFromNoteNames (int root, String noteString, int bottomOctave);
+juce::String listNoteNames (juce::Array<int> chord);
+juce::String getFirstRecognizedChord (juce::Array<int> chord, bool flats);
+juce::String getIntervalStringFromNoteNames (int root, juce::String noteString, int bottomOctave);
 
 #endif

--- a/pizjuce/_common/ClickableLabel.h
+++ b/pizjuce/_common/ClickableLabel.h
@@ -1,27 +1,25 @@
 #ifndef CLICKABLELABEL_H
 #define CLICKABLELABEL_H
 
-#include "juce_gui_basics/juce_gui_basics.h"
-
-using namespace juce;
+#include <juce_gui_basics/juce_gui_basics.h>
 
 class ClickableLabel;
 class ClickableLabelListener
 {
 public:
     virtual ~ClickableLabelListener(){};
-    virtual void clickableLabelMouseDown (ClickableLabel* label, const MouseEvent& e)        = 0;
-    virtual void clickableLabelMouseDoubleClick (ClickableLabel* label, const MouseEvent& e) = 0;
+    virtual void clickableLabelMouseDown (ClickableLabel* label, const juce::MouseEvent& e)        = 0;
+    virtual void clickableLabelMouseDoubleClick (ClickableLabel* label, const juce::MouseEvent& e) = 0;
 };
 
-class ClickableLabel : public Label
+class ClickableLabel : public juce::Label
 {
 public:
-    ClickableLabel (const String& _name, const String& _text)
+    ClickableLabel (const juce::String& _name, const juce::String& _text)
         : Label (_name, _text)
     {
         id       = 0;
-        listener = 0;
+        listener = nullptr;
         setRepaintsOnMouseActivity (true);
     }
 
@@ -43,27 +41,27 @@ public:
     // pop ups a modal text editor
     void edit()
     {
-        TextEditor* ed = new TextEditor();
-        if (ed == 0)
+        juce::TextEditor* ed = new juce::TextEditor();
+        if (ed == nullptr)
             return;
         ed->setFont (getFont());
-        const int cols[] = { TextEditor::backgroundColourId,
-                             TextEditor::textColourId,
-                             TextEditor::highlightColourId,
-                             TextEditor::highlightedTextColourId,
-                             TextEditor::outlineColourId,
-                             TextEditor::focusedOutlineColourId,
-                             TextEditor::shadowColourId };
+        const int cols[] = { juce::TextEditor::backgroundColourId,
+                             juce::TextEditor::textColourId,
+                             juce::TextEditor::highlightColourId,
+                             juce::TextEditor::highlightedTextColourId,
+                             juce::TextEditor::outlineColourId,
+                             juce::TextEditor::focusedOutlineColourId,
+                             juce::TextEditor::shadowColourId };
 
-        for (int i = 0; i < numElementsInArray (cols); ++i)
+        for (int i = 0; i < juce::numElementsInArray (cols); ++i)
             ed->setColour (cols[i], findColour (cols[i]));
         ed->setBounds (0, 0, getWidth(), getHeight());
         ed->setText (getText(), false);
-        ed->setHighlightedRegion (Range<int> (0, getText().length()));
+        ed->setHighlightedRegion (juce::Range<int> (0, getText().length()));
         addAndMakeVisible (ed);
         ed->addListener (this);
         ed->runModalLoop();
-        setText (ed->getText(), dontSendNotification);
+        setText (ed->getText(), juce::dontSendNotification);
         deleteAndZero (ed);
     }
 
@@ -71,34 +69,34 @@ private:
     int id;
     ClickableLabelListener* listener;
 
-    void mouseDown (const MouseEvent& e) override
+    void mouseDown (const juce::MouseEvent& e) override
     {
-        if (listener != 0)
+        if (listener != nullptr)
             listener->clickableLabelMouseDown (this, e);
     }
 
-    void mouseDoubleClick (const MouseEvent& e) override
+    void mouseDoubleClick (const juce::MouseEvent& e) override
     {
-        if (listener != 0)
+        if (listener != nullptr)
             listener->clickableLabelMouseDoubleClick (this, e);
     }
 
-    void textEditorTextChanged (TextEditor& editor) override
+    void textEditorTextChanged (juce::TextEditor& editor) override
     {
     }
 
-    void textEditorReturnKeyPressed (TextEditor& editor) override
+    void textEditorReturnKeyPressed (juce::TextEditor& editor) override
     {
         editor.exitModalState (0);
     }
 
-    void textEditorEscapeKeyPressed (TextEditor& editor) override
+    void textEditorEscapeKeyPressed (juce::TextEditor& editor) override
     {
         editor.setText (getText());
         editor.exitModalState (0);
     }
 
-    void textEditorFocusLost (TextEditor& editor) override
+    void textEditorFocusLost (juce::TextEditor& editor) override
     {
         editor.exitModalState (0);
     }

--- a/pizjuce/_common/DrawablePad.cpp
+++ b/pizjuce/_common/DrawablePad.cpp
@@ -1,7 +1,7 @@
 #include "DrawablePad.h"
 
 //==============================================================================
-DrawablePad::DrawablePad (const String& name)
+DrawablePad::DrawablePad (const juce::String& name)
     : Button (name),
       //buttonState(buttonNormal),
       normalImage (nullptr),
@@ -14,8 +14,8 @@ DrawablePad::DrawablePad (const String& name)
       disabledImageOn (nullptr)
 {
     setSize (200, 200);
-    backgroundOff = Colour (0xffbbbbff);
-    backgroundOn  = Colour (0xff3333ff);
+    backgroundOff = juce::Colour (0xffbbbbff);
+    backgroundOn  = juce::Colour (0xff3333ff);
     Label         = "Pad";
     setMouseClickGrabsKeyboardFocus (false);
 }
@@ -32,14 +32,14 @@ void DrawablePad::deleteImages()
     disabledImageOn.reset();
 }
 
-void DrawablePad::setImages (const Drawable* normal,
-                             const Drawable* over,
-                             const Drawable* down,
-                             const Drawable* disabled,
-                             const Drawable* normalOn,
-                             const Drawable* overOn,
-                             const Drawable* downOn,
-                             const Drawable* disabledOn)
+void DrawablePad::setImages (const juce::Drawable* normal,
+                             const juce::Drawable* over,
+                             const juce::Drawable* down,
+                             const juce::Drawable* disabled,
+                             const juce::Drawable* normalOn,
+                             const juce::Drawable* overOn,
+                             const juce::Drawable* downOn,
+                             const juce::Drawable* disabledOn)
 {
     deleteImages();
 
@@ -65,24 +65,24 @@ void DrawablePad::setImages (const Drawable* normal,
     repaint();
 }
 
-static std::unique_ptr<Drawable> drawableFromFile (const File& f)
+static std::unique_ptr<juce::Drawable> drawableFromFile (const juce::File& f)
 {
     if (f.exists())
     {
-        return Drawable::createFromImageFile (f);
+        return juce::Drawable::createFromImageFile (f);
     }
 
     return nullptr;
 }
 
-void DrawablePad::setImages (const File normalImage,
-                             const File overImage,
-                             const File downImage,
-                             const File disabledImage,
-                             const File normalImageOn,
-                             const File overImageOn,
-                             const File downImageOn,
-                             const File disabledImageOn)
+void DrawablePad::setImages (const juce::File normalImage,
+                             const juce::File overImage,
+                             const juce::File downImage,
+                             const juce::File disabledImage,
+                             const juce::File normalImageOn,
+                             const juce::File overImageOn,
+                             const juce::File downImageOn,
+                             const juce::File disabledImageOn)
 {
     setImagesFromUptr (drawableFromFile (normalImage),
                        drawableFromFile (overImage),
@@ -94,8 +94,8 @@ void DrawablePad::setImages (const File normalImage,
                        drawableFromFile (disabledImageOn));
 }
 
-void DrawablePad::setBackgroundColours (const Colour& toggledOffColour,
-                                        const Colour& toggledOnColour)
+void DrawablePad::setBackgroundColours (const juce::Colour& toggledOffColour,
+                                        const juce::Colour& toggledOnColour)
 {
     if (backgroundOff != toggledOffColour
         || backgroundOn != toggledOnColour)
@@ -107,31 +107,31 @@ void DrawablePad::setBackgroundColours (const Colour& toggledOffColour,
     }
 }
 
-const Colour& DrawablePad::getBackgroundColour() const throw()
+const juce::Colour& DrawablePad::getBackgroundColour() const throw()
 {
     return getToggleState() ? backgroundOn
                             : backgroundOff;
 }
 
-void DrawablePad::drawButtonBackground (Graphics& g,
+void DrawablePad::drawButtonBackground (juce::Graphics& g,
                                         Button& button,
-                                        const Colour& backgroundColour,
+                                        const juce::Colour& backgroundColour,
                                         bool isMouseOverButton,
                                         bool isButtonDown)
 {
 }
 
-void DrawablePad::paintButton (Graphics& g, bool isMouseOverButton, bool isButtonDown)
+void DrawablePad::paintButton (juce::Graphics& g, bool isMouseOverButton, bool isButtonDown)
 {
-    Rectangle<int> imageSpace;
+    juce::Rectangle<int> imageSpace;
     const int insetX = getWidth() / 100;
     const int insetY = getHeight() / 100;
     imageSpace.setBounds (insetX, insetY, getWidth() - insetX * 2, getHeight() - insetY * 2);
 
-    g.setImageResamplingQuality (Graphics::highResamplingQuality);
+    g.setImageResamplingQuality (juce::Graphics::highResamplingQuality);
     g.setOpacity (1.0f);
 
-    const Drawable* imageToDraw = nullptr;
+    const juce::Drawable* imageToDraw = nullptr;
 
     if (isEnabled())
     {
@@ -151,10 +151,10 @@ void DrawablePad::paintButton (Graphics& g, bool isMouseOverButton, bool isButto
 
     if (imageToDraw != nullptr)
     {
-        g.fillAll (Colours::transparentBlack);
+        g.fillAll (juce::Colours::transparentBlack);
         imageToDraw->drawWithin (g,
                                  imageSpace.toFloat(),
-                                 RectanglePlacement::centred,
+                                 juce::RectanglePlacement::centred,
                                  1.f);
     }
     else
@@ -171,7 +171,7 @@ void DrawablePad::resized()
 {
 }
 
-const Drawable* DrawablePad::getCurrentImage() const throw()
+const juce::Drawable* DrawablePad::getCurrentImage() const throw()
 {
     if (isDown())
         return getDownImage();
@@ -182,15 +182,15 @@ const Drawable* DrawablePad::getCurrentImage() const throw()
     return getNormalImage();
 }
 
-const Drawable* DrawablePad::getNormalImage() const throw()
+const juce::Drawable* DrawablePad::getNormalImage() const throw()
 {
     return (getToggleState() && normalImageOn != nullptr) ? normalImageOn.get()
                                                           : normalImage.get();
 }
 
-const Drawable* DrawablePad::getOverImage() const throw()
+const juce::Drawable* DrawablePad::getOverImage() const throw()
 {
-    const Drawable* d = normalImage.get();
+    const juce::Drawable* d = normalImage.get();
 
     if (getToggleState())
     {
@@ -210,9 +210,9 @@ const Drawable* DrawablePad::getOverImage() const throw()
     return d;
 }
 
-const Drawable* DrawablePad::getDownImage() const throw()
+const juce::Drawable* DrawablePad::getDownImage() const throw()
 {
-    const Drawable* d = normalImage.get();
+    const juce::Drawable* d = normalImage.get();
 
     if (getToggleState())
     {

--- a/pizjuce/_common/DrawablePad.h
+++ b/pizjuce/_common/DrawablePad.h
@@ -3,41 +3,39 @@
 
 #include <memory>
 
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_gui_basics/juce_gui_basics.h>
 
-using namespace juce;
-
-class DrawablePad : public Button
+class DrawablePad : public juce::Button
 {
 public:
     //==============================================================================
-    DrawablePad (const String& buttonName);
+    DrawablePad (const juce::String& buttonName);
 
     //==============================================================================
-    void setImages (File normalImage,
-                    File overImage       = File(),
-                    File downImage       = File(),
-                    File disabledImage   = File(),
-                    File normalImageOn   = File(),
-                    File overImageOn     = File(),
-                    File downImageOn     = File(),
-                    File disabledImageOn = File());
-    void setImages (const Drawable* normalImage,
-                    const Drawable* overImage       = 0,
-                    const Drawable* downImage       = 0,
-                    const Drawable* disabledImage   = 0,
-                    const Drawable* normalImageOn   = 0,
-                    const Drawable* overImageOn     = 0,
-                    const Drawable* downImageOn     = 0,
-                    const Drawable* disabledImageOn = 0);
-    void setImagesFromUptr (std::unique_ptr<Drawable> normalImage,
-                            std::unique_ptr<Drawable> overImage       = nullptr,
-                            std::unique_ptr<Drawable> downImage       = nullptr,
-                            std::unique_ptr<Drawable> disabledImage   = nullptr,
-                            std::unique_ptr<Drawable> normalImageOn   = nullptr,
-                            std::unique_ptr<Drawable> overImageOn     = nullptr,
-                            std::unique_ptr<Drawable> downImageOn     = nullptr,
-                            std::unique_ptr<Drawable> disabledImageOn = nullptr)
+    void setImages (juce::File normalImage,
+                    juce::File overImage       = juce::File(),
+                    juce::File downImage       = juce::File(),
+                    juce::File disabledImage   = juce::File(),
+                    juce::File normalImageOn   = juce::File(),
+                    juce::File overImageOn     = juce::File(),
+                    juce::File downImageOn     = juce::File(),
+                    juce::File disabledImageOn = juce::File());
+    void setImages (const juce::Drawable* normalImage,
+                    const juce::Drawable* overImage       = 0,
+                    const juce::Drawable* downImage       = 0,
+                    const juce::Drawable* disabledImage   = 0,
+                    const juce::Drawable* normalImageOn   = 0,
+                    const juce::Drawable* overImageOn     = 0,
+                    const juce::Drawable* downImageOn     = 0,
+                    const juce::Drawable* disabledImageOn = 0);
+    void setImagesFromUptr (std::unique_ptr<juce::Drawable> normalImage,
+                            std::unique_ptr<juce::Drawable> overImage       = nullptr,
+                            std::unique_ptr<juce::Drawable> downImage       = nullptr,
+                            std::unique_ptr<juce::Drawable> disabledImage   = nullptr,
+                            std::unique_ptr<juce::Drawable> normalImageOn   = nullptr,
+                            std::unique_ptr<juce::Drawable> overImageOn     = nullptr,
+                            std::unique_ptr<juce::Drawable> downImageOn     = nullptr,
+                            std::unique_ptr<juce::Drawable> disabledImageOn = nullptr)
     {
         // TODO: Remove the raw-pointer function, then the additional copies
         //       can easily be eliminated.
@@ -53,49 +51,47 @@ public:
     void deleteImages();
 
     //==============================================================================
-    void setBackgroundColours (const Colour& toggledOffColour,
-                               const Colour& toggledOnColour);
+    void setBackgroundColours (const juce::Colour& toggledOffColour,
+                               const juce::Colour& toggledOnColour);
 
-    const Colour& getBackgroundColour() const throw();
+    const juce::Colour& getBackgroundColour() const throw();
 
     //==============================================================================
     /** Returns the image that the button is currently displaying. */
-    const Drawable* getCurrentImage() const throw();
-    const Drawable* getNormalImage() const throw();
-    const Drawable* getOverImage() const throw();
-    const Drawable* getDownImage() const throw();
+    const juce::Drawable* getCurrentImage() const throw();
+    const juce::Drawable* getNormalImage() const throw();
+    const juce::Drawable* getOverImage() const throw();
+    const juce::Drawable* getDownImage() const throw();
 
-    //==============================================================================
-    juce_UseDebuggingNewOperator
-
-        String Label;
+    juce::String Label;
 
 protected:
     /** @internal */
-    void drawButtonBackground (Graphics& g,
+    void drawButtonBackground (juce::Graphics& g,
                                Button& button,
-                               const Colour& backgroundColour,
+                               const juce::Colour& backgroundColour,
                                bool isMouseOverButton,
                                bool isButtonDown);
 
-    void paintButton (Graphics& g,
+    void paintButton (juce::Graphics& g,
                       bool isMouseOverButton,
                       bool isButtonDown) override;
     void resized() override;
 
 private:
-    //==============================================================================
-    std::unique_ptr<Drawable> normalImage;
-    std::unique_ptr<Drawable> overImage;
-    std::unique_ptr<Drawable> downImage;
-    std::unique_ptr<Drawable> disabledImage;
-    std::unique_ptr<Drawable> normalImageOn;
-    std::unique_ptr<Drawable> overImageOn;
-    std::unique_ptr<Drawable> downImageOn;
-    std::unique_ptr<Drawable> disabledImageOn;
-    Colour backgroundOff, backgroundOn;
+    std::unique_ptr<juce::Drawable> normalImage;
+    std::unique_ptr<juce::Drawable> overImage;
+    std::unique_ptr<juce::Drawable> downImage;
+    std::unique_ptr<juce::Drawable> disabledImage;
+    std::unique_ptr<juce::Drawable> normalImageOn;
+    std::unique_ptr<juce::Drawable> overImageOn;
+    std::unique_ptr<juce::Drawable> downImageOn;
+    std::unique_ptr<juce::Drawable> disabledImageOn;
+    juce::Colour backgroundOff, backgroundOn;
     DrawablePad (const DrawablePad&);
     const DrawablePad& operator= (const DrawablePad&);
+
+    JUCE_LEAK_DETECTOR (DrawablePad)
 };
 
 #endif

--- a/pizjuce/_common/NoteSlider.h
+++ b/pizjuce/_common/NoteSlider.h
@@ -1,8 +1,8 @@
 #ifndef PIZ_NOTE_SLIDER_HEADER
 #define PIZ_NOTE_SLIDER_HEADER
 
-#include "juce_core/juce_core.h"
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_core/juce_core.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
 #include "../_common/midistuff.h"
 

--- a/pizjuce/_common/PizArray.h
+++ b/pizjuce/_common/PizArray.h
@@ -5,7 +5,7 @@
 
 #include <utility>
 
-#include "juce_core/juce_core.h"
+#include <juce_core/juce_core.h>
 
 template <typename ElementType,
           typename TypeOfCriticalSectionToUse = juce::DummyCriticalSection,

--- a/pizjuce/_common/PizAudioProcessor.h
+++ b/pizjuce/_common/PizAudioProcessor.h
@@ -7,17 +7,15 @@
 
 class ReaProject;
 
-#include "juce_audio_processors/juce_audio_processors.h"
+#include <juce_audio_processors/juce_audio_processors.h>
 
-using namespace juce;
-
-class PizAudioProcessor : public AudioProcessor
+class PizAudioProcessor : public juce::AudioProcessor
 {
 public:
     PizAudioProcessor() : AudioProcessor(),
                           bottomOctave (-2),
                           reaper (false),
-                          currentPath (((File::getSpecialLocation (File::currentApplicationFile)).getParentDirectory()).getFullPathName())
+                          currentPath (((juce::File::getSpecialLocation (juce::File::currentApplicationFile)).getParentDirectory()).getFullPathName())
     {
     }
 
@@ -27,7 +25,7 @@ public:
         {
             int szout        = 0;
             int reaperOctave = 0;
-            void* p          = 0;
+            void* p          = nullptr;
             p                = get_config_var ("midioctoffs", &szout);
             if (p)
             {
@@ -41,12 +39,12 @@ public:
     bool loadDefaultFxb()
     {
         //look for a default bank
-        String defaultBank = currentPath + File::getSeparatorString()
-                           + File::getSpecialLocation (File::currentExecutableFile).getFileNameWithoutExtension() + ".fxb";
-        if (File (defaultBank).exists())
+        juce::String defaultBank = currentPath + juce::File::getSeparatorString()
+                                 + juce::File::getSpecialLocation (juce::File::currentExecutableFile).getFileNameWithoutExtension() + ".fxb";
+        if (juce::File (defaultBank).exists())
         {
             juce::MemoryBlock bank = juce::MemoryBlock (0, true);
-            File (defaultBank).loadFileAsData (bank);
+            juce::File (defaultBank).loadFileAsData (bank);
             bank.removeSection (0, 0xA0);
             setStateInformation (bank.getData(), (int) bank.getSize());
             return true;
@@ -54,7 +52,7 @@ public:
         return false;
     }
 
-    bool loadFxbFile (File file)
+    bool loadFxbFile (juce::File file)
     {
         if (file.existsAsFile())
         {
@@ -70,12 +68,12 @@ public:
     bool loadDefaultFxp()
     {
         //look for a default patch
-        String defaultBank = currentPath + File::getSeparatorString()
-                           + File::getSpecialLocation (File::currentApplicationFile).getFileNameWithoutExtension() + ".fxp";
-        if (File (defaultBank).exists())
+        juce::String defaultBank = currentPath + juce::File::getSeparatorString()
+                                 + juce::File::getSpecialLocation (juce::File::currentApplicationFile).getFileNameWithoutExtension() + ".fxp";
+        if (juce::File (defaultBank).exists())
         {
             juce::MemoryBlock bank = juce::MemoryBlock (0, true);
-            File (defaultBank).loadFileAsData (bank);
+            juce::File (defaultBank).loadFileAsData (bank);
             bank.removeSection (0, 0x3C);
             setCurrentProgramStateInformation (bank.getData(), (int) bank.getSize());
             return true;
@@ -83,7 +81,7 @@ public:
         return false;
     }
 
-    bool loadFxpFile (File file)
+    bool loadFxpFile (juce::File file)
     {
         if (file.existsAsFile())
         {
@@ -97,7 +95,7 @@ public:
     }
 
     int bottomOctave;
-    String getCurrentPath() { return currentPath; }
+    juce::String getCurrentPath() { return currentPath; }
 
     double (*TimeMap2_timeToBeats) (ReaProject* proj, double tpos, int* measures, int* cml, double* fullbeats, int* cdenom);
     double (*GetPlayPosition)();
@@ -105,10 +103,10 @@ public:
     double (*GetCursorPosition)();
     void* (*get_config_var) (const char* name, int* szout);
     bool reaper;
-    String hostInfo;
+    juce::String hostInfo;
 
 private:
-    String currentPath;
+    juce::String currentPath;
 };
 
 #endif

--- a/pizjuce/_common/PizButton.cpp
+++ b/pizjuce/_common/PizButton.cpp
@@ -27,7 +27,7 @@
 
 //==============================================================================
 PizButton::PizButton()
-    : Button (juce::String())
+    : juce::Button (juce::String())
 {
     //[Constructor_pre] You can add your own custom stuff here..
     //[/Constructor_pre]

--- a/pizjuce/_common/PizButton.h
+++ b/pizjuce/_common/PizButton.h
@@ -20,7 +20,7 @@
 #pragma once
 
 //[Headers]     -- You can add your own extra header files here --
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_gui_basics/juce_gui_basics.h>
 //[/Headers]
 
 //==============================================================================

--- a/pizjuce/_common/VSTSlider.cpp
+++ b/pizjuce/_common/VSTSlider.cpp
@@ -1,23 +1,23 @@
 #include "VSTSlider.h"
 
-VSTSlider::VSTSlider (String name) : Slider (name)
+VSTSlider::VSTSlider (juce::String name) : Slider (name)
 {
-    this->ownerPlugin = 0;
+    this->ownerPlugin = nullptr;
     this->vstIndex    = -1;
     this->setMouseClickGrabsKeyboardFocus (false);
 };
 
 VSTSlider::~VSTSlider(){};
 
-String VSTSlider::getTextFromValue (double value)
+juce::String VSTSlider::getTextFromValue (double value)
 {
     if (ownerPlugin && vstIndex > -1)
         return ownerPlugin->getParameterText (vstIndex);
     else
-        return String (value) + "?";
+        return juce::String (value) + "?";
 };
 
-void VSTSlider::setOwner (AudioProcessor* owner, int index)
+void VSTSlider::setOwner (juce::AudioProcessor* owner, int index)
 {
     this->ownerPlugin = owner;
     this->vstIndex    = index;
@@ -48,7 +48,7 @@ void VSTSlider::setVSTSlider (float x)
         double min   = this->getMinimum();
         double max   = this->getMaximum();
         double value = min + (double) x * (max - min);
-        this->setValue (value, dontSendNotification);
+        this->setValue (value, juce::dontSendNotification);
     }
     this->updateText();
 };
@@ -62,7 +62,7 @@ void VSTSlider::setVSTSlider()
         double min   = this->getMinimum();
         double max   = this->getMaximum();
         double value = min + (double) x * (max - min);
-        this->setValue (value, dontSendNotification);
+        this->setValue (value, juce::dontSendNotification);
     }
     this->updateText();
 };

--- a/pizjuce/_common/VSTSlider.h
+++ b/pizjuce/_common/VSTSlider.h
@@ -1,19 +1,17 @@
 #ifndef Piz_VSTSlider_h
 #define Piz_VSTSlider_h
 
-#include "juce_audio_processors/juce_audio_processors.h"
-#include "juce_core/juce_core.h"
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_core/juce_core.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
-using namespace juce;
-
-class VSTSlider : public Slider
+class VSTSlider : public juce::Slider
 {
 public:
-    VSTSlider (String name);
+    VSTSlider (juce::String name);
     ~VSTSlider() override;
-    String getTextFromValue (double value) override;
-    void setOwner (AudioProcessor*, int);
+    juce::String getTextFromValue (double value) override;
+    void setOwner (juce::AudioProcessor*, int);
     float mapToVSTRange();
     void setVSTSlider (float x);
 
@@ -22,7 +20,7 @@ public:
     void setIndex (int index);
 
 private:
-    AudioProcessor* ownerPlugin;
+    juce::AudioProcessor* ownerPlugin;
     int vstIndex;
 };
 #endif

--- a/pizjuce/_common/key.h
+++ b/pizjuce/_common/key.h
@@ -2,54 +2,52 @@
 
 #include <memory>
 
-#include "juce_core/juce_core.h"
-#include "juce_cryptography/juce_cryptography.h"
-
-using namespace juce;
+#include <juce_core/juce_core.h>
+#include <juce_cryptography/juce_cryptography.h>
 
 #ifndef MRALIASPRO
 
-static XmlElement::TextFormat getXmlFormat()
+static juce::XmlElement::TextFormat getXmlFormat()
 {
-    XmlElement::TextFormat format{};
+    juce::XmlElement::TextFormat format{};
     format.newLineChars = nullptr; // fit everything on one line
     return format;
 }
 
-static const String encryptXml (const XmlElement* xml,
-                                const String& rsaPrivateKey)
+static const juce::String encryptXml (const juce::XmlElement* xml,
+                                      const juce::String& rsaPrivateKey)
 {
-    BigInteger val;
+    juce::BigInteger val;
 
-    if (xml != 0)
+    if (xml != nullptr)
     {
-        const String s (xml->toString (getXmlFormat()));
-        const MemoryBlock mb (s.toUTF8(), s.length());
+        const juce::String s (xml->toString (getXmlFormat()));
+        const juce::MemoryBlock mb (s.toUTF8(), s.length());
 
         val.loadFromMemoryBlock (mb);
     }
 
-    RSAKey key (rsaPrivateKey);
+    juce::RSAKey key (rsaPrivateKey);
     key.applyToValue (val);
 
     return val.toString (16);
 }
 #endif
 
-static std::unique_ptr<XmlElement> decodeEncryptedXml (const String& hexData,
-                                                       const String& rsaPublicKey)
+static std::unique_ptr<juce::XmlElement> decodeEncryptedXml (const juce::String& hexData,
+                                                             const juce::String& rsaPublicKey)
 {
     if (hexData.isEmpty())
-        return 0;
+        return nullptr;
 
-    BigInteger val;
+    juce::BigInteger val;
     val.parseString (hexData, 16);
 
-    RSAKey key (rsaPublicKey);
+    juce::RSAKey key (rsaPublicKey);
     key.applyToValue (val);
 
-    const MemoryBlock mb (val.toMemoryBlock());
-    XmlDocument doc (mb.toString());
+    const juce::MemoryBlock mb (val.toMemoryBlock());
+    juce::XmlDocument doc (mb.toString());
 
     auto xml = doc.getDocumentElement();
 

--- a/pizjuce/_common/midistuff.h
+++ b/pizjuce/_common/midistuff.h
@@ -1,8 +1,7 @@
 #ifndef PIZ_MIDI_STUFF_H
 #define PIZ_MIDI_STUFF_H
 
-#include "juce_core/juce_core.h"
-using namespace juce;
+#include <juce_core/juce_core.h>
 
 #define NOT_PLAYING  (-999)
 #define ANY_CHANNEL  (0)
@@ -11,10 +10,10 @@ using namespace juce;
 #define midiScaler   ((float) 0.007874015748031496062992125984252)
 #define NOT_A_NOTE   (98765)
 
-const String Flat ("b"); //(L"\x266d");
-const String Natural (L"\x266e");
-const String Sharp ("#");      //(L"\x266f");
-const String Diminished ("o"); //(L"\x0080");
+const juce::String Flat ("b"); //(L"\x266d");
+const juce::String Natural (L"\x266e");
+const juce::String Sharp ("#");      //(L"\x266f");
+const juce::String Diminished ("o"); //(L"\x0080");
 
 enum NoteNames
 {
@@ -35,8 +34,8 @@ enum NoteNames
 inline int floatToMidi (float f, bool learnspace = true)
 {
     if (learnspace)
-        return roundToInt (f * 128.f) - 1;
-    return roundToInt (f * 127.f);
+        return juce::roundToInt (f * 128.f) - 1;
+    return juce::roundToInt (f * 127.f);
 }
 inline float midiToFloat (int n, bool learnspace = true)
 {
@@ -45,10 +44,10 @@ inline float midiToFloat (int n, bool learnspace = true)
     return (float) n * (float) 0.007874015748031496062992125984252;
 }
 
-inline int floatToChannel (float f) { return roundToInt (f * 16.0f); }
+inline int floatToChannel (float f) { return juce::roundToInt (f * 16.0f); }
 inline float channelToFloat (int c) { return (float) c * 0.0625f; }
 
-inline int getNoteValue (String noteName)
+inline int getNoteValue (juce::String noteName)
 {
     if (noteName.equalsIgnoreCase ("C") || noteName.equalsIgnoreCase ("B#") || noteName.equalsIgnoreCase ("Dbb"))
         return nC;
@@ -77,7 +76,7 @@ inline int getNoteValue (String noteName)
     return NOT_A_NOTE;
 }
 
-inline int getNoteValue (String noteName, int bottomOctave, bool& hasOctaveNumber)
+inline int getNoteValue (juce::String noteName, int bottomOctave, bool& hasOctaveNumber)
 {
     int octave = 0;
     if (noteName.containsAnyOf ("-0123456789"))
@@ -115,7 +114,7 @@ inline int getNoteValue (String noteName, int bottomOctave, bool& hasOctaveNumbe
     return NOT_A_NOTE;
 }
 
-inline int getIntervalValue (String intervalName)
+inline int getIntervalValue (juce::String intervalName)
 {
     int result    = NOT_A_NOTE;
     bool inverted = intervalName.startsWith ("-");
@@ -176,9 +175,9 @@ inline int getIntervalValue (String intervalName)
     return result;
 }
 
-inline String getNoteName (int noteNumber, int baseOctave /*=-2*/)
+inline juce::String getNoteName (int noteNumber, int baseOctave /*=-2*/)
 {
-    String Note{};
+    juce::String Note{};
     switch (noteNumber % 12)
     {
         case 0:
@@ -220,12 +219,12 @@ inline String getNoteName (int noteNumber, int baseOctave /*=-2*/)
         default:
             break;
     }
-    return Note + String ((noteNumber / 12) + baseOctave);
+    return Note + juce::String ((noteNumber / 12) + baseOctave);
 }
 
-inline String getNoteNameWithoutOctave (int noteNumber, bool sharps = true)
+inline juce::String getNoteNameWithoutOctave (int noteNumber, bool sharps = true)
 {
-    String Note{};
+    juce::String Note{};
     if (sharps)
     {
         switch (noteNumber % 12)
@@ -321,7 +320,7 @@ inline int mapToRange (float x, float in1, float in2, float out1, float out2)
 {
     float slope = ((float) (out2 - out1)) / ((float) (in2 - in1));
     float b     = out1 - slope * in1;
-    return roundToInt (slope * x + b);
+    return juce::roundToInt (slope * x + b);
 }
 
 inline int CombineBytes (unsigned char lsb, unsigned char msb)

--- a/pizjuce/midiChordAnalyzer/MidiChordAnalyzer.cpp
+++ b/pizjuce/midiChordAnalyzer/MidiChordAnalyzer.cpp
@@ -1,6 +1,8 @@
 #include "MidiChordAnalyzer.h"
 #include "MidiChordAnalyzerEditor.h"
 
+using juce::roundToInt;
+
 //==============================================================================
 /**
     This function must be implemented to create a new instance of your
@@ -17,7 +19,7 @@ MidiChordAnalyzerPrograms::MidiChordAnalyzerPrograms()
 {
     for (int p = 0; p < getNumPrograms(); p++)
     {
-        ValueTree progv ("ProgValues");
+        juce::ValueTree progv ("ProgValues");
     }
 }
 void MidiChordAnalyzerPrograms::loadDefaultValues()
@@ -34,7 +36,7 @@ void MidiChordAnalyzerPrograms::loadDefaultValues()
             set (b, p, "Channel", 0);
             set (b, p, "Flats", false);
 
-            set (b, p, "Name", "Program " + String (p + 1));
+            set (b, p, "Name", "Program " + juce::String (p + 1));
             set (b, p, "lastUIWidth", 600);
             set (b, p, "lastUIHeight", 400);
         }
@@ -64,11 +66,11 @@ MidiChordAnalyzer::~MidiChordAnalyzer()
 {
     DBG ("~MidiChordAnalyzer()");
     if (programs)
-        deleteAndZero (programs);
+        juce::deleteAndZero (programs);
 }
 
 //==============================================================================
-const String MidiChordAnalyzer::getName() const
+const juce::String MidiChordAnalyzer::getName() const
 {
     return JucePlugin_Name;
 }
@@ -123,32 +125,32 @@ void MidiChordAnalyzer::setParameter (int index, float newValue)
     }
 }
 
-const String MidiChordAnalyzer::getParameterName (int index)
+const juce::String MidiChordAnalyzer::getParameterName (int index)
 {
     if (index == kChannel)
         return "Channel";
     if (index == kFlats)
         return "Flats";
-    return String();
+    return juce::String();
 }
 
-const String MidiChordAnalyzer::getParameterText (int index)
+const juce::String MidiChordAnalyzer::getParameterText (int index)
 {
     if (index == kChannel)
-        return channel == 0 ? "Any" : String (channel);
+        return channel == 0 ? "Any" : juce::String (channel);
     if (index == kFlats)
         return flats ? "Yes" : "No";
-    return String();
+    return juce::String();
 }
 
-const String MidiChordAnalyzer::getInputChannelName (const int channelIndex) const
+const juce::String MidiChordAnalyzer::getInputChannelName (const int channelIndex) const
 {
-    return String (channelIndex + 1);
+    return juce::String (channelIndex + 1);
 }
 
-const String MidiChordAnalyzer::getOutputChannelName (const int channelIndex) const
+const juce::String MidiChordAnalyzer::getOutputChannelName (const int channelIndex) const
 {
-    return String (channelIndex + 1);
+    return juce::String (channelIndex + 1);
 }
 
 bool MidiChordAnalyzer::isInputChannelStereoPair (int index) const
@@ -170,8 +172,8 @@ void MidiChordAnalyzer::releaseResources()
 {
 }
 
-void MidiChordAnalyzer::processBlock (AudioSampleBuffer& buffer,
-                                      MidiBuffer& midiMessages)
+void MidiChordAnalyzer::processBlock (juce::AudioSampleBuffer& buffer,
+                                      juce::MidiBuffer& midiMessages)
 {
     chordKbState.processNextMidiBuffer (midiMessages, 0, buffer.getNumSamples(), true);
 
@@ -199,19 +201,19 @@ void MidiChordAnalyzer::processBlock (AudioSampleBuffer& buffer,
 }
 
 //==============================================================================
-AudioProcessorEditor* MidiChordAnalyzer::createEditor()
+juce::AudioProcessorEditor* MidiChordAnalyzer::createEditor()
 {
     return new MidiChordAnalyzerEditor (this);
 }
 
 //==============================================================================
-void MidiChordAnalyzer::getStateInformation (MemoryBlock& destData)
+void MidiChordAnalyzer::getStateInformation (juce::MemoryBlock& destData)
 {
     copySettingsToProgram (curProgram);
     programs->dumpTo (destData);
 }
 
-void MidiChordAnalyzer::getCurrentProgramStateInformation (MemoryBlock& destData)
+void MidiChordAnalyzer::getCurrentProgramStateInformation (juce::MemoryBlock& destData)
 {
     copySettingsToProgram (curProgram);
     programs->dumpProgramTo (0, curProgram, destData);
@@ -219,8 +221,8 @@ void MidiChordAnalyzer::getCurrentProgramStateInformation (MemoryBlock& destData
 
 void MidiChordAnalyzer::setStateInformation (const void* data, int sizeInBytes)
 {
-    MemoryInputStream m (data, sizeInBytes, false);
-    ValueTree vt = ValueTree::readFromStream (m);
+    juce::MemoryInputStream m (data, sizeInBytes, false);
+    juce::ValueTree vt = juce::ValueTree::readFromStream (m);
 
     programs->loadFrom (vt);
     init = true;
@@ -229,8 +231,8 @@ void MidiChordAnalyzer::setStateInformation (const void* data, int sizeInBytes)
 
 void MidiChordAnalyzer::setCurrentProgramStateInformation (const void* data, int sizeInBytes)
 {
-    MemoryInputStream m (data, sizeInBytes, false);
-    ValueTree vt = ValueTree::readFromStream (m);
+    juce::MemoryInputStream m (data, sizeInBytes, false);
+    juce::ValueTree vt = juce::ValueTree::readFromStream (m);
 
     programs->loadNoteMatrixFrom (vt, curProgram);
     init = true;

--- a/pizjuce/midiChordAnalyzer/MidiChordAnalyzer.h
+++ b/pizjuce/midiChordAnalyzer/MidiChordAnalyzer.h
@@ -1,8 +1,8 @@
 #ifndef MidiChordAnalyzerPLUGINFILTER_H
 #define MidiChordAnalyzerPLUGINFILTER_H
 
-#include "juce_data_structures/juce_data_structures.h"
-#include "juce_events/juce_events.h"
+#include <juce_data_structures/juce_data_structures.h>
+#include <juce_events/juce_events.h>
 
 #include "../_common/BankStorage.h"
 #include "../_common/ChordFunctions.h"
@@ -30,7 +30,7 @@ private:
 
 //==============================================================================
 class MidiChordAnalyzer : public PizAudioProcessor,
-                          public ChangeBroadcaster
+                          public juce::ChangeBroadcaster
 {
 public:
     //==============================================================================
@@ -41,14 +41,14 @@ public:
     void prepareToPlay (double sampleRate, int samplesPerBlock) override;
     void releaseResources() override;
 
-    void processBlock (AudioSampleBuffer& buffer,
-                       MidiBuffer& midiMessages) override;
+    void processBlock (juce::AudioSampleBuffer& buffer,
+                       juce::MidiBuffer& midiMessages) override;
 
     //==============================================================================
-    AudioProcessorEditor* createEditor() override;
+    juce::AudioProcessorEditor* createEditor() override;
 
     //==============================================================================
-    const String getName() const override;
+    const juce::String getName() const override;
     bool hasEditor() const override { return true; }
 
     int getNumParameters() override;
@@ -56,11 +56,11 @@ public:
     float getParameter (int index) override;
     void setParameter (int index, float newValue) override;
 
-    const String getParameterName (int index) override;
-    const String getParameterText (int index) override;
+    const juce::String getParameterName (int index) override;
+    const juce::String getParameterText (int index) override;
 
-    const String getInputChannelName (int channelIndex) const override;
-    const String getOutputChannelName (int channelIndex) const override;
+    const juce::String getInputChannelName (int channelIndex) const override;
+    const juce::String getOutputChannelName (int channelIndex) const override;
     bool isInputChannelStereoPair (int index) const override;
     bool isOutputChannelStereoPair (int index) const override;
 
@@ -71,25 +71,24 @@ public:
     int getNumPrograms() override { return numProgs; }
     int getCurrentProgram() override { return curProgram; }
     void setCurrentProgram (int index) override;
-    const String getProgramName (int index) override { return programs->get (0, index, "Name"); }
-    void changeProgramName (int index, const String& newName) override { programs->set (0, index, "Name", newName); }
+    const juce::String getProgramName (int index) override { return programs->get (0, index, "Name"); }
+    void changeProgramName (int index, const juce::String& newName) override { programs->set (0, index, "Name", newName); }
     void copySettingsToProgram (int index);
     double getTailLengthSeconds() const override { return 0; }
 
     //==============================================================================
-    void getStateInformation (MemoryBlock& destData) override;
+    void getStateInformation (juce::MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
-    void getCurrentProgramStateInformation (MemoryBlock& destData) override;
+    void getCurrentProgramStateInformation (juce::MemoryBlock& destData) override;
     void setCurrentProgramStateInformation (const void* data, int sizeInBytes) override;
 
     //==============================================================================
-    MidiKeyboardState chordKbState;
+    juce::MidiKeyboardState chordKbState;
     //String getCurrentChordName();
     int lastUIWidth, lastUIHeight;
-    //==============================================================================
-    juce_UseDebuggingNewOperator
 
-        private : MidiChordAnalyzerPrograms* programs;
+private:
+    MidiChordAnalyzerPrograms* programs;
     int curProgram;
     int curTrigger;
 
@@ -97,7 +96,9 @@ public:
 
     int channel;
     bool flats;
-    AudioPlayHead::CurrentPositionInfo lastPosInfo;
+    juce::AudioPlayHead::CurrentPositionInfo lastPosInfo;
+
+    JUCE_LEAK_DETECTOR (MidiChordAnalyzer)
 };
 
 #endif

--- a/pizjuce/midiChordAnalyzer/MidiChordAnalyzerEditor.cpp
+++ b/pizjuce/midiChordAnalyzer/MidiChordAnalyzerEditor.cpp
@@ -23,6 +23,7 @@
 #include "MidiChordAnalyzerEditor.h"
 
 //[MiscUserDefs] You can add your own user definitions and misc code here...
+using juce::roundToInt;
 //[/MiscUserDefs]
 
 //==============================================================================
@@ -460,9 +461,9 @@ MidiChordAnalyzerEditor::MidiChordAnalyzerEditor (MidiChordAnalyzer* const owner
     learnChanSlider->setMouseClickGrabsKeyboardFocus (false);
     pizButton->setMouseClickGrabsKeyboardFocus (false);
     chordNameLabel->setMouseClickGrabsKeyboardFocus (false);
-    chordNameLabel->setText (" ", dontSendNotification);
+    chordNameLabel->setText (" ", juce::dontSendNotification);
     flatsButton->setMouseClickGrabsKeyboardFocus (false);
-    chordKeyboard->setMouseCursor (MouseCursor::PointingHandCursor);
+    chordKeyboard->setMouseCursor (juce::MouseCursor::PointingHandCursor);
     numHeldNotes = 0;
 
     learnChanSlider->setAllText ("All");
@@ -478,7 +479,7 @@ MidiChordAnalyzerEditor::MidiChordAnalyzerEditor (MidiChordAnalyzer* const owner
     setSize (600, 180);
 
     //[Constructor] You can add your own custom stuff here..
-    versionLabel->setText (JucePlugin_VersionString, dontSendNotification);
+    versionLabel->setText (JucePlugin_VersionString, juce::dontSendNotification);
     ownerFilter->addChangeListener (this);
     updateParametersFromFilter();
     //[/Constructor]
@@ -633,25 +634,25 @@ void MidiChordAnalyzerEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     {
         //[UserButtonCode_copyButton] -- add your button handler code here..
         const int channel = roundToInt (getFilter()->getParameter (kChannel) * 16.f);
-        String chordString; // = String(0) + ":";
+        juce::String chordString;
         for (int n = 0; n < 128; n++)
         {
             for (int c = 1; c <= 16; c++)
             {
                 if ((channel == 0 || channel == c) && getFilter()->chordKbState.isNoteOn (c, n))
                 {
-                    chordString += getNoteName (n, getFilter()->bottomOctave) + "." + String (c) + " ";
+                    chordString += getNoteName (n, getFilter()->bottomOctave) + "." + juce::String (c) + " ";
                 }
             }
         }
-        SystemClipboard::copyTextToClipboard (chordString);
+        juce::SystemClipboard::copyTextToClipboard (chordString);
         //[/UserButtonCode_copyButton]
     }
 
     //[UserbuttonClicked_Post]
     else if (buttonThatWasClicked == pizButton.get())
     {
-        URL ("http://thepiz.org/plugins/?p=midiChordAnalyzer").launchInDefaultBrowser();
+        juce::URL ("http://thepiz.org/plugins/?p=midiChordAnalyzer").launchInDefaultBrowser();
     }
     //[/UserbuttonClicked_Post]
 }
@@ -674,19 +675,19 @@ void MidiChordAnalyzerEditor::sliderValueChanged (juce::Slider* sliderThatWasMov
 
 //[MiscUserCode] You can add your own definitions of your custom methods or any other code here...
 
-void MidiChordAnalyzerEditor::mouseDown (const MouseEvent& e)
+void MidiChordAnalyzerEditor::mouseDown (const juce::MouseEvent& e)
 {
 }
 
-void MidiChordAnalyzerEditor::mouseDoubleClick (const MouseEvent& e)
+void MidiChordAnalyzerEditor::mouseDoubleClick (const juce::MouseEvent& e)
 {
 }
 
-void MidiChordAnalyzerEditor::mouseUp (const MouseEvent& e)
+void MidiChordAnalyzerEditor::mouseUp (const juce::MouseEvent& e)
 {
 }
 
-void MidiChordAnalyzerEditor::changeListenerCallback (ChangeBroadcaster* source)
+void MidiChordAnalyzerEditor::changeListenerCallback (juce::ChangeBroadcaster* source)
 {
     if (source == getFilter())
         updateParametersFromFilter();
@@ -698,8 +699,8 @@ void MidiChordAnalyzerEditor::updateParametersFromFilter()
     const bool flats                = filter->getParameter (kFlats) > 0;
     const int chordChan             = roundToInt (filter->getParameter (kChannel) * 16.f);
 
-    learnChanSlider->setValue (chordChan, dontSendNotification);
-    flatsButton->setToggleState (flats, dontSendNotification);
+    learnChanSlider->setValue (chordChan, juce::dontSendNotification);
+    flatsButton->setToggleState (flats, juce::dontSendNotification);
     if (chordChan == 0)
         chordKeyboard->setMidiChannelsToDisplay (0xffff);
     else
@@ -707,12 +708,12 @@ void MidiChordAnalyzerEditor::updateParametersFromFilter()
 
     if (numHeldNotes < chordKeyboard->getNumHeldNotes (chordChan))
     {
-        chordNameLabel->setText (getCurrentChordName (chordChan), dontSendNotification);
-        Desktop::getInstance().getAnimator().animateComponent (chordNameLabel.get(), chordNameLabel->getBounds(), 1.f, 0, false, 1.0, 1.0);
+        chordNameLabel->setText (getCurrentChordName (chordChan), juce::dontSendNotification);
+        juce::Desktop::getInstance().getAnimator().animateComponent (chordNameLabel.get(), chordNameLabel->getBounds(), 1.f, 0, false, 1.0, 1.0);
     }
     else if (getCurrentChordName (chordChan) == " ")
     {
-        Desktop::getInstance().getAnimator().animateComponent (chordNameLabel.get(), chordNameLabel->getBounds(), 0.f, 500, false, 2.0, 0.5);
+        juce::Desktop::getInstance().getAnimator().animateComponent (chordNameLabel.get(), chordNameLabel->getBounds(), 0.f, 500, false, 2.0, 0.5);
     }
     else
         startTimer (100);
@@ -724,19 +725,19 @@ void MidiChordAnalyzerEditor::timerCallback()
     const int chordChan = roundToInt (getFilter()->getParameter (kChannel) * 16.f);
     if (getCurrentChordName (chordChan) == " ")
     {
-        Desktop::getInstance().getAnimator().animateComponent (chordNameLabel.get(), chordNameLabel->getBounds(), 0.f, 500, false, 2.0, 0.5);
+        juce::Desktop::getInstance().getAnimator().animateComponent (chordNameLabel.get(), chordNameLabel->getBounds(), 0.f, 500, false, 2.0, 0.5);
     }
     else
     {
-        chordNameLabel->setText (getCurrentChordName (chordChan), dontSendNotification);
-        Desktop::getInstance().getAnimator().animateComponent (chordNameLabel.get(), chordNameLabel->getBounds(), 1.f, 0, false, 1.0, 1.0);
+        chordNameLabel->setText (getCurrentChordName (chordChan), juce::dontSendNotification);
+        juce::Desktop::getInstance().getAnimator().animateComponent (chordNameLabel.get(), chordNameLabel->getBounds(), 1.f, 0, false, 1.0, 1.0);
     }
     stopTimer();
 }
 
-String const MidiChordAnalyzerEditor::getCurrentChordName (int channel)
+juce::String const MidiChordAnalyzerEditor::getCurrentChordName (int channel)
 {
-    Array<int> chord;
+    juce::Array<int> chord;
     for (int n = 0; n < 128; n++)
     {
         for (int c = 1; c <= 16; c++)

--- a/pizjuce/midiChordAnalyzer/MidiChordAnalyzerEditor.h
+++ b/pizjuce/midiChordAnalyzer/MidiChordAnalyzerEditor.h
@@ -20,21 +20,19 @@
 #pragma once
 
 //[Headers]     -- You can add your own extra header files here --
-#include "juce_audio_utils/juce_audio_utils.h"
+#include <juce_audio_utils/juce_audio_utils.h>
 
 #include "../_common/ChannelSlider.h"
 #include "../_common/VSTSlider.h"
 #include "MidiChordAnalyzer.h"
 
-using namespace juce;
-
 class MidiChordAnalyzerEditor;
-class ChordAnalyzerKeyboardComponent : public MidiKeyboardComponent
+class ChordAnalyzerKeyboardComponent : public juce::MidiKeyboardComponent
 {
 public:
-    ChordAnalyzerKeyboardComponent (MidiKeyboardState& kbstate, MidiChordAnalyzer* ownerFilter)
+    ChordAnalyzerKeyboardComponent (juce::MidiKeyboardState& kbstate, MidiChordAnalyzer* ownerFilter)
         : MidiKeyboardComponent (kbstate, MidiKeyboardComponent::horizontalKeyboard),
-          owner (0)
+          owner (nullptr)
     {
         owner = ownerFilter;
         s     = &kbstate;
@@ -62,9 +60,9 @@ public:
 
 private:
     MidiChordAnalyzer* owner;
-    MidiKeyboardState* s;
+    juce::MidiKeyboardState* s;
 
-    bool mouseDownOnKey (int midiNoteNumber, const MouseEvent& e) override
+    bool mouseDownOnKey (int midiNoteNumber, const juce::MouseEvent& e) override
     {
         MidiChordAnalyzerEditor* editor = ((MidiChordAnalyzerEditor*) (this->getParentComponent()));
         if (e.mods.isPopupMenu())
@@ -113,11 +111,11 @@ public:
     //==============================================================================
     //[UserMethods]     -- You can add your own custom methods in this section.
     friend class ChordAnalyzerKeyboardComponent;
-    void changeListenerCallback (ChangeBroadcaster* source) override;
-    void mouseDown (const MouseEvent& e) override;
-    void mouseDoubleClick (const MouseEvent& e) override;
-    void mouseUp (const MouseEvent& e) override;
-    String const getCurrentChordName (int channel);
+    void changeListenerCallback (juce::ChangeBroadcaster* source) override;
+    void mouseDown (const juce::MouseEvent& e) override;
+    void mouseDoubleClick (const juce::MouseEvent& e) override;
+    void mouseUp (const juce::MouseEvent& e) override;
+    juce::String const getCurrentChordName (int channel);
     void timerCallback() override;
     //[/UserMethods]
 
@@ -132,7 +130,7 @@ public:
 
 private:
     //[UserVariables]   -- You can add your own custom variables in this section.
-    TooltipWindow tooltipWindow;
+    juce::TooltipWindow tooltipWindow;
     void updateParametersFromFilter();
     int numHeldNotes;
 

--- a/pizjuce/midiChords/GuitarNeckComponent.cpp
+++ b/pizjuce/midiChords/GuitarNeckComponent.cpp
@@ -1,7 +1,12 @@
 #include "GuitarNeckComponent.h"
 
+using juce::jlimit;
+using juce::jmax;
+using juce::jmin;
+using juce::roundToInt;
+
 //==============================================================================
-GuitarNeckComponent::GuitarNeckComponent (MidiKeyboardState& state_)
+GuitarNeckComponent::GuitarNeckComponent (juce::MidiKeyboardState& state_)
     : state (state_),
       xOffset (0),
       midiChannel (1),
@@ -103,14 +108,14 @@ int GuitarNeckComponent::getStringFret (int string)
     return currentlyFrettedFret[string];
 }
 
-FrettedNote GuitarNeckComponent::xyToNote (const Point<int>& pos, float& mousePositionVelocity)
+FrettedNote GuitarNeckComponent::xyToNote (const juce::Point<int>& pos, float& mousePositionVelocity)
 {
     FrettedNote fretString;
 
     if (! reallyContains (pos, false))
         return fretString;
 
-    Point<int> p (pos);
+    juce::Point<int> p (pos);
 
     for (int f = 0; f <= numFrets; f++)
     {
@@ -148,32 +153,32 @@ void GuitarNeckComponent::repaintNote (const int fret)
     }
 }
 
-void GuitarNeckComponent::paint (Graphics& g)
+void GuitarNeckComponent::paint (juce::Graphics& g)
 {
-    g.fillAll (Colours::brown.brighter (0.2f));
+    g.fillAll (juce::Colours::brown.brighter (0.2f));
 
-    const Colour lineColour (findColour (keySeparatorLineColourId));
-    const Colour textColour (findColour (textLabelColourId));
+    const juce::Colour lineColour (findColour (keySeparatorLineColourId));
+    const juce::Colour textColour (findColour (textLabelColourId));
 
     for (int fret = firstFret; fret <= (numFrets - firstFret); fret++)
     {
         if (fret == 0)
         {
-            g.setColour (Colours::ivory);
+            g.setColour (juce::Colours::ivory);
             g.drawLine (0.f, 0.f, 0.f, (float) getHeight(), (float) nutWidth);
         }
         else
         {
-            g.setColour (Colours::grey);
+            g.setColour (juce::Colours::grey);
             g.drawLine (fretPosition[fret] * getWidth() / fretPosition[numFrets], 0.f, fretPosition[fret] * getWidth() / fretPosition[numFrets], (float) getHeight(), 3.f);
             if (fret == 3 || fret == 5 || fret == 7 || fret == 9 || fret == 15 || fret == 17 || fret == 19 || fret == 21)
             {
-                g.setColour (Colours::black.withAlpha (0.2f));
+                g.setColour (juce::Colours::black.withAlpha (0.2f));
                 g.fillEllipse ((getFretPos (fret) - getFretWidth (fret) * 0.5f) - 4.f, (float) getHeight() * 0.5f - 4.f, 8.f, 8.f);
             }
             else if (fret == 12 || fret == 24)
             {
-                g.setColour (Colours::black.withAlpha (0.2f));
+                g.setColour (juce::Colours::black.withAlpha (0.2f));
                 g.fillEllipse ((getFretPos (fret) - getFretWidth (fret) * 0.5f) - 4.f, (float) getHeight() * 0.25f - 4.f, 8.f, 8.f);
                 g.fillEllipse ((getFretPos (fret) - getFretWidth (fret) * 0.5f) - 4.f, (float) getHeight() * 0.75f - 4.f, 8.f, 8.f);
             }
@@ -184,31 +189,31 @@ void GuitarNeckComponent::paint (Graphics& g)
     for (int string = 0; string < numStrings; string++)
     {
         float yStringPos = stringSpacing * 0.5f + stringSpacing * (float) string;
-        g.setColour (Colours::goldenrod);
+        g.setColour (juce::Colours::goldenrod);
         g.drawLine (0.f, yStringPos, (float) getWidth(), yStringPos, 2.f);
 
         if (currentlyFrettedFret[string] >= 0)
         {
             int x, w;
             getFretPos (currentlyFrettedFret[string], x, w);
-            g.setColour (Colours::pink);
+            g.setColour (juce::Colours::pink);
             g.fillEllipse ((float) x - (float) w * 0.5f - dotSize * 0.5f, yStringPos - dotSize * 0.5f, dotSize, dotSize);
-            g.setColour (Colours::black);
+            g.setColour (juce::Colours::black);
             g.drawEllipse ((float) x - (float) w * 0.5f - dotSize * 0.5f, yStringPos - dotSize * 0.5f, dotSize, dotSize, 1.f);
-            g.setFont (Font (12.f, Font::bold));
+            g.setFont (juce::Font (12.f, juce::Font::bold));
             g.drawFittedText (
                 getNoteNameWithoutOctave (currentlyFrettedFret[string] + stringNote[string], ! showFlats),
                 roundToInt (x - w / 2 - dotSize / 2 + 3),
                 roundToInt (yStringPos - dotSize / 2 + 3),
                 roundToInt (dotSize) - 6,
                 roundToInt (dotSize) - 6,
-                Justification::centred,
+                juce::Justification::centred,
                 1,
                 0.4f);
         }
         else
         {
-            g.setColour (Colours::darkred);
+            g.setColour (juce::Colours::darkred);
             g.drawLine (0, yStringPos - dotSize * 0.5f, dotSize, yStringPos + dotSize * 0.5f, 2.f);
             g.drawLine (0, yStringPos + dotSize * 0.5f, dotSize, yStringPos - dotSize * 0.5f, 2.f);
         }
@@ -218,27 +223,27 @@ void GuitarNeckComponent::paint (Graphics& g)
         int x, w;
         float yStringPos = stringSpacing * 0.5f + stringSpacing * (float) noteUnderMouse.string;
         getFretPos (noteUnderMouse.fret, x, w);
-        g.setColour (Colours::green);
+        g.setColour (juce::Colours::green);
         g.fillEllipse ((float) x - (float) w * 0.5f - dotSize * 0.5f, yStringPos - dotSize * 0.5f, dotSize, dotSize);
-        g.setColour (Colours::black);
+        g.setColour (juce::Colours::black);
         g.drawEllipse ((float) x - (float) w * 0.5f - dotSize * 0.5f, yStringPos - dotSize * 0.5f, dotSize, dotSize, 1.f);
 
-        g.setFont (Font (12.f, Font::bold));
+        g.setFont (juce::Font (12.f, juce::Font::bold));
         g.drawFittedText (
             getNoteNameWithoutOctave (noteUnderMouse.fret + stringNote[noteUnderMouse.string], ! showFlats),
             roundToInt (x - w / 2 - dotSize / 2) + 3,
             roundToInt (yStringPos - dotSize / 2) + 3,
             roundToInt (dotSize) - 6,
             roundToInt (dotSize) - 6,
-            Justification::centred,
+            juce::Justification::centred,
             1,
             0.4f);
     }
 }
 
-void GuitarNeckComponent::drawFretString (int fret, int string, Graphics& g, int x, int y, int w, int h, bool isDown, bool isOver, const Colour& lineColour, const Colour& textColour)
+void GuitarNeckComponent::drawFretString (int fret, int string, juce::Graphics& g, int x, int y, int w, int h, bool isDown, bool isOver, const juce::Colour& lineColour, const juce::Colour& textColour)
 {
-    Colour c (Colours::transparentWhite);
+    juce::Colour c (juce::Colours::transparentWhite);
 
     if (isDown)
         c = findColour (keyDownOverlayColourId);
@@ -249,16 +254,16 @@ void GuitarNeckComponent::drawFretString (int fret, int string, Graphics& g, int
     g.setColour (c);
     g.fillRect (x, y, w, h);
 
-    const String text (getNoteText (fret, string));
+    const juce::String text (getNoteText (fret, string));
 
     if (! text.isEmpty())
     {
         g.setColour (textColour);
 
-        Font f (12.0f);
+        juce::Font f (12.0f);
         f.setHorizontalScale (0.8f);
         g.setFont (f);
-        Justification justification (Justification::centredBottom);
+        juce::Justification justification (juce::Justification::centredBottom);
 
         g.drawFittedText (text, x + 2, y + 2, w - 4, h - 4, justification, 1);
     }
@@ -277,11 +282,11 @@ void GuitarNeckComponent::setOctaveForMiddleC (const int octaveNumForMiddleC_)
     repaint();
 }
 
-const String GuitarNeckComponent::getNoteText (const int fret, const int string)
+const juce::String GuitarNeckComponent::getNoteText (const int fret, const int string)
 {
     const int midiNoteNumber = stringNote[string] + fret;
     //if (keyWidth > 14.0f && midiNoteNumber % 12 == 0)
-    return MidiMessage::getMidiNoteName (midiNoteNumber, true, true, octaveNumForMiddleC);
+    return juce::MidiMessage::getMidiNoteName (midiNoteNumber, true, true, octaveNumForMiddleC);
 
     //return String();
 }
@@ -358,12 +363,12 @@ void GuitarNeckComponent::resized()
 }
 
 //==============================================================================
-void GuitarNeckComponent::handleNoteOn (MidiKeyboardState*, int /*midiChannel*/, int /*midiNoteNumber*/, float /*velocity*/)
+void GuitarNeckComponent::handleNoteOn (juce::MidiKeyboardState*, int /*midiChannel*/, int /*midiNoteNumber*/, float /*velocity*/)
 {
     triggerAsyncUpdate();
 }
 
-void GuitarNeckComponent::handleNoteOff (MidiKeyboardState*, int /*midiChannel*/, int /*midiNoteNumber*/, float /*velocity*/)
+void GuitarNeckComponent::handleNoteOff (juce::MidiKeyboardState*, int /*midiChannel*/, int /*midiNoteNumber*/, float /*velocity*/)
 {
     triggerAsyncUpdate();
 }
@@ -401,7 +406,7 @@ void GuitarNeckComponent::resetAnyKeysInUse()
     }
 }
 
-void GuitarNeckComponent::updateNoteUnderMouse (const Point<int>& pos)
+void GuitarNeckComponent::updateNoteUnderMouse (const juce::Point<int>& pos)
 {
     float mousePositionVelocity = 0.0f;
     const FrettedNote newNote   = (mouseDragging || isMouseOver())
@@ -441,13 +446,13 @@ void GuitarNeckComponent::updateNoteUnderMouse (const Point<int>& pos)
     }
 }
 
-void GuitarNeckComponent::mouseMove (const MouseEvent& e)
+void GuitarNeckComponent::mouseMove (const juce::MouseEvent& e)
 {
     updateNoteUnderMouse (e.getPosition());
     stopTimer();
 }
 
-void GuitarNeckComponent::mouseDrag (const MouseEvent& e)
+void GuitarNeckComponent::mouseDrag (const juce::MouseEvent& e)
 {
     float mousePositionVelocity;
     const FrettedNote newNote = xyToNote (e.getPosition(), mousePositionVelocity);
@@ -459,16 +464,16 @@ void GuitarNeckComponent::mouseDrag (const MouseEvent& e)
     repaint();
 }
 
-bool GuitarNeckComponent::mouseDownOnKey (int /*fret*/, int /*string*/, const MouseEvent&)
+bool GuitarNeckComponent::mouseDownOnKey (int /*fret*/, int /*string*/, const juce::MouseEvent&)
 {
     return true;
 }
 
-void GuitarNeckComponent::mouseDraggedToKey (int /*fret*/, int /*string*/, const MouseEvent&)
+void GuitarNeckComponent::mouseDraggedToKey (int /*fret*/, int /*string*/, const juce::MouseEvent&)
 {
 }
 
-void GuitarNeckComponent::mouseDown (const MouseEvent& e)
+void GuitarNeckComponent::mouseDown (const juce::MouseEvent& e)
 {
     float mousePositionVelocity;
     const FrettedNote newNote = xyToNote (e.getPosition(), mousePositionVelocity);
@@ -487,7 +492,7 @@ void GuitarNeckComponent::mouseDown (const MouseEvent& e)
     }
 }
 
-void GuitarNeckComponent::mouseUp (const MouseEvent& e)
+void GuitarNeckComponent::mouseUp (const juce::MouseEvent& e)
 {
     mouseDragging = false;
     updateNoteUnderMouse (e.getPosition());
@@ -495,12 +500,12 @@ void GuitarNeckComponent::mouseUp (const MouseEvent& e)
     stopTimer();
 }
 
-void GuitarNeckComponent::mouseEnter (const MouseEvent& e)
+void GuitarNeckComponent::mouseEnter (const juce::MouseEvent& e)
 {
     updateNoteUnderMouse (e.getPosition());
 }
 
-void GuitarNeckComponent::mouseExit (const MouseEvent& e)
+void GuitarNeckComponent::mouseExit (const juce::MouseEvent& e)
 {
     updateNoteUnderMouse (e.getPosition());
 }

--- a/pizjuce/midiChords/GuitarNeckComponent.h
+++ b/pizjuce/midiChords/GuitarNeckComponent.h
@@ -1,9 +1,10 @@
 #ifndef GUITAR_NECK_COMPONENT_H
 #define GUITAR_NECK_COMPONENT_H
 
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+
 #include "../_common/midistuff.h"
-#include "juce_audio_basics/juce_audio_basics.h"
-#include "juce_gui_basics/juce_gui_basics.h"
 
 #define maxFrets   (32)
 #define maxStrings (16)
@@ -38,14 +39,14 @@ public:
     int string;
 };
 
-class GuitarNeckComponent : public Component,
-                            public MidiKeyboardStateListener,
-                            public ChangeBroadcaster,
-                            private Timer,
-                            private AsyncUpdater
+class GuitarNeckComponent : public juce::Component,
+                            public juce::MidiKeyboardStateListener,
+                            public juce::ChangeBroadcaster,
+                            private juce::Timer,
+                            private juce::AsyncUpdater
 {
 public:
-    GuitarNeckComponent (MidiKeyboardState& state);
+    GuitarNeckComponent (juce::MidiKeyboardState& state);
     ~GuitarNeckComponent() override;
 
     void setNumStrings (int n);
@@ -76,9 +77,9 @@ public:
     void setLowestVisibleFret (int fretNumber);
     int getLowestVisibleFret() const noexcept { return firstFret; }
 
-    void drawNote (int fret, int string, Graphics& g, int x, int y, int w, int h, bool isDown, bool isOver, const Colour& lineColour, const Colour& textColour);
+    void drawNote (int fret, int string, juce::Graphics& g, int x, int y, int w, int h, bool isDown, bool isOver, const juce::Colour& lineColour, const juce::Colour& textColour);
 
-    const String getNoteText (const int fret, const int string);
+    const juce::String getNoteText (const int fret, const int string);
     //==============================================================================
     /** A set of colour IDs to use to change the colour of various aspects of the keyboard.
 
@@ -129,29 +130,29 @@ public:
 
     //==============================================================================
     /** @internal */
-    void paint (Graphics& g) override;
+    void paint (juce::Graphics& g) override;
     /** @internal */
     void resized() override;
     /** @internal */
-    void mouseMove (const MouseEvent& e) override;
+    void mouseMove (const juce::MouseEvent& e) override;
     /** @internal */
-    void mouseDrag (const MouseEvent& e) override;
+    void mouseDrag (const juce::MouseEvent& e) override;
     /** @internal */
-    void mouseDown (const MouseEvent& e) override;
+    void mouseDown (const juce::MouseEvent& e) override;
     /** @internal */
-    void mouseUp (const MouseEvent& e) override;
+    void mouseUp (const juce::MouseEvent& e) override;
     /** @internal */
-    void mouseEnter (const MouseEvent& e) override;
+    void mouseEnter (const juce::MouseEvent& e) override;
     /** @internal */
-    void mouseExit (const MouseEvent& e) override;
+    void mouseExit (const juce::MouseEvent& e) override;
     /** @internal */
     void timerCallback() override;
     /** @internal */
     void focusLost (FocusChangeType cause) override;
     /** @internal */
-    void handleNoteOn (MidiKeyboardState* source, int midiChannel, int midiNoteNumber, float velocity) override;
+    void handleNoteOn (juce::MidiKeyboardState* source, int midiChannel, int midiNoteNumber, float velocity) override;
     /** @internal */
-    void handleNoteOff (MidiKeyboardState* source, int midiChannel, int midiNoteNumber, float velocity) override;
+    void handleNoteOff (juce::MidiKeyboardState* source, int midiChannel, int midiNoteNumber, float velocity) override;
     /** @internal */
     void handleAsyncUpdate() override;
     /** @internal */
@@ -159,19 +160,19 @@ public:
 
 protected:
     //==============================================================================
-    virtual void drawFretString (int fret, int string, Graphics& g, int x, int y, int w, int h, bool isDown, bool isOver, const Colour& lineColour, const Colour& textColour);
+    virtual void drawFretString (int fret, int string, juce::Graphics& g, int x, int y, int w, int h, bool isDown, bool isOver, const juce::Colour& lineColour, const juce::Colour& textColour);
 
-    virtual bool mouseDownOnKey (int fret, int string, const MouseEvent& e);
-    virtual void mouseDraggedToKey (int fret, int string, const MouseEvent& e);
+    virtual bool mouseDownOnKey (int fret, int string, const juce::MouseEvent& e);
+    virtual void mouseDraggedToKey (int fret, int string, const juce::MouseEvent& e);
 
 private:
     //==============================================================================
-    MidiKeyboardState& state;
+    juce::MidiKeyboardState& state;
     int xOffset;
 
     int midiChannel, midiInChannelMask;
     float velocity;
-    BigInteger keysPressed, keysCurrentlyDrawnDown;
+    juce::BigInteger keysPressed, keysCurrentlyDrawnDown;
 
     int numStrings, numFrets;
     int stringNote[maxStrings];
@@ -187,9 +188,9 @@ private:
     int octaveNumForMiddleC;
 
     FrettedNote noteUnderMouse, mouseDownNote;
-    FrettedNote xyToNote (const Point<int>& pos, float& mousePositionVelocity);
+    FrettedNote xyToNote (const juce::Point<int>& pos, float& mousePositionVelocity);
     void resetAnyKeysInUse();
-    void updateNoteUnderMouse (const Point<int>& pos);
+    void updateNoteUnderMouse (const juce::Point<int>& pos);
     void repaintNote (const int fret);
     bool showFlats;
 

--- a/pizjuce/midiChords/MidiChords.cpp
+++ b/pizjuce/midiChords/MidiChords.cpp
@@ -1,6 +1,10 @@
 #include "MidiChords.h"
 #include "MidiChordsEditor.h"
 
+using juce::jlimit;
+using juce::jmax;
+using juce::roundToInt;
+
 //==============================================================================
 /**
     This function must be implemented to create a new instance of your
@@ -48,7 +52,7 @@ void MidiChordsPrograms::loadDefaults()
             set (p, "VelRamp", 0.5f);
             set (p, "Accel", 0.5f);
 
-            set (p, "Name", "Program " + String (p + 1));
+            set (p, "Name", "Program " + juce::String (p + 1));
             set (p, "lastUIWidth", 600);
             set (p, "lastUIHeight", 400);
             set (p, "lastTrigger", 60);
@@ -75,9 +79,9 @@ void MidiChordsPrograms::loadDefaults()
 
             for (int t = 0; t < 128; t++)
             {
-                set (p, "Bypassed" + String (t), false);
-                set (p, "StrumUp" + String (t), true);
-                ValueTree noteMatrix ("NoteMatrix_T" + String (t));
+                set (p, "Bypassed" + juce::String (t), false);
+                set (p, "StrumUp" + juce::String (t), true);
+                juce::ValueTree noteMatrix ("NoteMatrix_T" + juce::String (t));
                 //for (int c=0;c<16;c++) {
                 //	noteMatrix.setProperty("Ch"+String(c)+"_0-31", 0, 0);
                 //	noteMatrix.setProperty("Ch"+String(c)+"_32-63", 0, 0);
@@ -95,15 +99,15 @@ MidiChords::MidiChords() : programs (0), curProgram (0)
 {
     DBG ("MidiChords()");
 
-    dataPath = getCurrentPath() + File::getSeparatorString() + "midiChords";
-    if (! File (dataPath).exists())
+    dataPath = getCurrentPath() + juce::File::getSeparatorString() + "midiChords";
+    if (! juce::File (dataPath).exists())
     {
-        dataPath = File::getSpecialLocation (File::userApplicationDataDirectory).getFullPathName()
-                 + File::getSeparatorString() + "pizmidi" + File::getSeparatorString() + "midiChords";
-        if (! File (dataPath).exists())
+        dataPath = juce::File::getSpecialLocation (juce::File::userApplicationDataDirectory).getFullPathName()
+                 + juce::File::getSeparatorString() + "pizmidi" + juce::File::getSeparatorString() + "midiChords";
+        if (! juce::File (dataPath).exists())
         {
-            dataPath = File::getSpecialLocation (File::commonApplicationDataDirectory).getFullPathName()
-                     + File::getSeparatorString() + "pizmidi" + File::getSeparatorString() + "midiChords";
+            dataPath = juce::File::getSpecialLocation (juce::File::commonApplicationDataDirectory).getFullPathName()
+                     + juce::File::getSeparatorString() + "pizmidi" + juce::File::getSeparatorString() + "midiChords";
         }
     }
 
@@ -158,11 +162,11 @@ MidiChords::~MidiChords()
 {
     DBG ("~MidiChords()");
     if (programs)
-        deleteAndZero (programs);
+        juce::deleteAndZero (programs);
 }
 
 //==============================================================================
-const String MidiChords::getName() const
+const juce::String MidiChords::getName() const
 {
     return JucePlugin_Name;
 }
@@ -389,7 +393,7 @@ void MidiChords::setParameter (int index, float newValue)
     }
 }
 
-const String MidiChords::getParameterName (int index)
+const juce::String MidiChords::getParameterName (int index)
 {
     if (index == kChannel)
         return "Channel";
@@ -429,17 +433,17 @@ const String MidiChords::getParameterName (int index)
         return "VelRamp";
     if (index == kAccel)
         return "Accel";
-    return String();
+    return juce::String();
 }
 
-const String MidiChords::getParameterText (int index)
+const juce::String MidiChords::getParameterText (int index)
 {
     if (index == kChannel)
-        return channel == 0 ? "Any" : String (channel);
+        return channel == 0 ? "Any" : juce::String (channel);
     if (index == kLearnChannel)
-        return learnchan == 0 ? "All" : String (learnchan);
+        return learnchan == 0 ? "All" : juce::String (learnchan);
     if (index == kOutChannel)
-        return outchan == 0 ? "Multi" : String (outchan);
+        return outchan == 0 ? "Multi" : juce::String (outchan);
     if (index == kUseProgCh)
         return usepc ? "Yes" : "No";
     if (index == kLearnChord)
@@ -449,8 +453,8 @@ const String MidiChords::getParameterText (int index)
     if (index == kTranspose)
     {
         if (transpose > 0)
-            return "+" + String (transpose);
-        return String (transpose);
+            return "+" + juce::String (transpose);
+        return juce::String (transpose);
     }
     if (index == kMode)
     {
@@ -462,13 +466,13 @@ const String MidiChords::getParameterText (int index)
             return "Global";
     }
     if (index == kRoot)
-        return String (root);
+        return juce::String (root);
     if (index == kGuess)
         return guess ? "Yes" : "No";
     if (index == kFlats)
         return flats ? "Yes" : "No";
     if (index == kVelocity)
-        return String (previewVel);
+        return juce::String (previewVel);
     if (index == kInputTranspose)
         return inputtranspose ? "Yes" : "No";
     if (index == kToAllChannels)
@@ -476,34 +480,34 @@ const String MidiChords::getParameterText (int index)
     if (index == kStrum)
         return strum ? "On" : "Off";
     if (index == kSpeed)
-        return String (roundToInt (fSpeed * 100.f)) + "%";
+        return juce::String (roundToInt (fSpeed * 100.f)) + "%";
     if (index == kMaxDelay)
-        return String (roundToInt (1000.f * (0.1f + 2.9f * fMaxDelay))) + " ms";
+        return juce::String (roundToInt (1000.f * (0.1f + 2.9f * fMaxDelay))) + " ms";
     if (index == kVelRamp)
     {
         const int ramp = roundToInt (fVelRamp * 200.f) - 100;
         if (ramp > 0)
-            return "+" + String (ramp);
-        return String (ramp);
+            return "+" + juce::String (ramp);
+        return juce::String (ramp);
     }
     if (index == kAccel)
     {
         const int accel = roundToInt (fAccel * 200.f) - 100;
         if (accel > 0)
-            return "+" + String (accel);
-        return String (accel);
+            return "+" + juce::String (accel);
+        return juce::String (accel);
     }
-    return String();
+    return juce::String();
 }
 
-const String MidiChords::getInputChannelName (const int channelIndex) const
+const juce::String MidiChords::getInputChannelName (const int channelIndex) const
 {
-    return String (channelIndex + 1);
+    return juce::String (channelIndex + 1);
 }
 
-const String MidiChords::getOutputChannelName (const int channelIndex) const
+const juce::String MidiChords::getOutputChannelName (const int channelIndex) const
 {
-    return String (channelIndex + 1);
+    return juce::String (channelIndex + 1);
 }
 
 bool MidiChords::isInputChannelStereoPair (int index) const
@@ -526,11 +530,11 @@ void MidiChords::releaseResources()
     delayBuffer.clear();
 }
 
-void MidiChords::processBlock (AudioSampleBuffer& buffer,
-                               MidiBuffer& midiMessages)
+void MidiChords::processBlock (juce::AudioSampleBuffer& buffer,
+                               juce::MidiBuffer& midiMessages)
 {
     bool wasplaying;
-    AudioPlayHead::CurrentPositionInfo pos;
+    juce::AudioPlayHead::CurrentPositionInfo pos;
     if (getPlayHead() != 0 && getPlayHead()->getCurrentPosition (pos))
         wasplaying = lastPosInfo.isPlaying || lastPosInfo.isRecording;
     else
@@ -549,13 +553,13 @@ void MidiChords::processBlock (AudioSampleBuffer& buffer,
     if (delayBuffer.getNumEvents() == 0)
         expectingDelayedNotes = false;
 
-    MidiBuffer output;
+    juce::MidiBuffer output;
     if ((playFromGUI != playingFromGUI) || stopPlayingFromGUI)
     {
         int ch = jmax (channel, 1);
         if (playFromGUI && ! playingFromGUI)
         {
-            midiMessages.addEvent (MidiMessage::noteOn (ch, curTrigger, (uint8) previewVel), 0);
+            midiMessages.addEvent (juce::MidiMessage::noteOn (ch, curTrigger, (juce::uint8) previewVel), 0);
             playingFromGUI    = true;
             playFromGUI       = false;
             playButtonTrigger = curTrigger;
@@ -563,7 +567,7 @@ void MidiChords::processBlock (AudioSampleBuffer& buffer,
 
         else if (stopPlayingFromGUI)
         {
-            midiMessages.addEvent (MidiMessage::noteOff (ch, playButtonTrigger), 0);
+            midiMessages.addEvent (juce::MidiMessage::noteOff (ch, playButtonTrigger), 0);
             playingFromGUI     = false;
             playFromGUI        = false;
             stopPlayingFromGUI = false;
@@ -593,10 +597,10 @@ void MidiChords::processBlock (AudioSampleBuffer& buffer,
                 }
                 else
                 {
-                    blockOriginalEvent = true;
-                    const int ch       = m.getChannel() - 1;
-                    const int tnote    = inputtranspose ? (m.getNoteNumber() - transpose) : m.getNoteNumber();
-                    const uint8 v      = m.getVelocity();
+                    blockOriginalEvent  = true;
+                    const int ch        = m.getChannel() - 1;
+                    const int tnote     = inputtranspose ? (m.getNoteNumber() - transpose) : m.getNoteNumber();
+                    const juce::uint8 v = m.getVelocity();
                     if (! learn)
                     {
                         bool triggered = false;
@@ -639,7 +643,7 @@ void MidiChords::processBlock (AudioSampleBuffer& buffer,
                                     {
                                         if (! strum)
                                         {
-                                            output.addEvent (MidiMessage::noteOn (outputChannel, newNote, v), sample);
+                                            output.addEvent (juce::MidiMessage::noteOn (outputChannel, newNote, v), sample);
                                             noteDelay[outputChannel - 1][newNote]        = 0;
                                             noteOrigPos[outputChannel - 1][newNote]      = totalSamples + sample;
                                             chordNotePlaying[outputChannel - 1][newNote] = true;
@@ -653,7 +657,7 @@ void MidiChords::processBlock (AudioSampleBuffer& buffer,
                         {
                             int chordpos   = 0;
                             int heldnotes  = playingChord[tnote].size();
-                            bool upstroke  = programs->get (curProgram, "StrumUp" + String (trigger));
+                            bool upstroke  = programs->get (curProgram, "StrumUp" + juce::String (trigger));
                             float accel    = (2.f * fAccel - 1.f);
                             float maxmax   = (float) getSampleRate() * (0.1f + 2.9f * fMaxDelay);
                             float maxdelay = (1.f - fSpeed) * maxmax;
@@ -668,7 +672,7 @@ void MidiChords::processBlock (AudioSampleBuffer& buffer,
                                 if (playingChord[tnote].size() > 1)
                                 {
                                     const float x = (float) (chordpos) / (float) (heldnotes - 1);
-                                    delay         = roundToInt ((accel * 0.3f * sin (MathConstants<float>::pi * x) + x) * maxdelay);
+                                    delay         = roundToInt ((accel * 0.3f * sin (juce::MathConstants<float>::pi * x) + x) * maxdelay);
                                     velocity += roundToInt ((2.f * fVelRamp - 1.f) * (x * 127.f - 64.f));
                                     velocity = jlimit (1, 127, velocity);
                                     //float veldelay = 1.f-(fVelToSpeed)*MIDI_TO_FLOAT(strumvel);
@@ -677,8 +681,8 @@ void MidiChords::processBlock (AudioSampleBuffer& buffer,
                                 if (delay > 0)
                                 {
                                     if (chordNotePlaying[c - 1][n])
-                                        delayBuffer.addEvent (MidiMessage::noteOff (c, n), sample + delay - 1);
-                                    delayBuffer.addEvent (MidiMessage::noteOn (c, n, (uint8) velocity), sample + delay);
+                                        delayBuffer.addEvent (juce::MidiMessage::noteOff (c, n), sample + delay - 1);
+                                    delayBuffer.addEvent (juce::MidiMessage::noteOn (c, n, (juce::uint8) velocity), sample + delay);
                                     expectingDelayedNotes = true;
                                 }
                                 else
@@ -691,9 +695,9 @@ void MidiChords::processBlock (AudioSampleBuffer& buffer,
                                             s2 += 1;
                                         if (sample == buffer.getNumSamples() - 1)
                                             s -= 1;
-                                        output.addEvent (MidiMessage::noteOff (c, n), s);
+                                        output.addEvent (juce::MidiMessage::noteOff (c, n), s);
                                     }
-                                    output.addEvent (MidiMessage::noteOn (c, n, (uint8) velocity), s2);
+                                    output.addEvent (juce::MidiMessage::noteOn (c, n, (juce::uint8) velocity), s2);
                                     chordNotePlaying[c - 1][n] = true;
                                     sample                     = s2;
                                 }
@@ -723,7 +727,7 @@ void MidiChords::processBlock (AudioSampleBuffer& buffer,
                     {
                         if (outputNote[ch][note] != -1)
                         {
-                            output.addEvent (MidiMessage::noteOff (ch + 1, outputNote[ch][note]), sample);
+                            output.addEvent (juce::MidiMessage::noteOff (ch + 1, outputNote[ch][note]), sample);
                             outputNote[ch][note] = -1;
                         }
                     }
@@ -750,11 +754,11 @@ void MidiChords::processBlock (AudioSampleBuffer& buffer,
                             {
                                 if (delay > 0)
                                 {
-                                    delayBuffer.addEvent (MidiMessage::noteOff (c + 1, chordNote), sample + delay);
+                                    delayBuffer.addEvent (juce::MidiMessage::noteOff (c + 1, chordNote), sample + delay);
                                 }
                                 else
                                 {
-                                    output.addEvent (MidiMessage::noteOff (c + 1, chordNote), sample);
+                                    output.addEvent (juce::MidiMessage::noteOff (c + 1, chordNote), sample);
                                     chordNotePlaying[c][chordNote] = false;
                                 }
                             }
@@ -789,10 +793,10 @@ void MidiChords::processBlock (AudioSampleBuffer& buffer,
         {
             if (m.isNoteOn())
             {
-                blockOriginalEvent = true;
-                const int ch       = m.getChannel();
-                const int tnote    = m.getNoteNumber();
-                const uint8 v      = m.getVelocity();
+                blockOriginalEvent  = true;
+                const int ch        = m.getChannel();
+                const int tnote     = m.getNoteNumber();
+                const juce::uint8 v = m.getVelocity();
                 if (learn)
                 {
                     if (learning == 0)
@@ -809,7 +813,7 @@ void MidiChords::processBlock (AudioSampleBuffer& buffer,
                         newNote += 12 * (tnote % 12);
                     if (newNote < 128 && newNote >= 0)
                     {
-                        output.addEvent (MidiMessage::noteOn (ch, newNote, v), sample);
+                        output.addEvent (juce::MidiMessage::noteOn (ch, newNote, v), sample);
                         outputNote[ch][tnote] = newNote;
                     }
                 }
@@ -824,7 +828,7 @@ void MidiChords::processBlock (AudioSampleBuffer& buffer,
                     learning--;
                     if (outputNote[ch][note] < 128 && outputNote[ch][note] >= 0)
                     {
-                        output.addEvent (MidiMessage::noteOff (ch, outputNote[ch][note]), sample);
+                        output.addEvent (juce::MidiMessage::noteOff (ch, outputNote[ch][note]), sample);
                         outputNote[ch][note] = -1;
                     }
                     if (learning < 1)
@@ -838,7 +842,7 @@ void MidiChords::processBlock (AudioSampleBuffer& buffer,
 
     //process delay buffer----------------------------------------------------------
     expectingDelayedNotes = false;
-    MidiBuffer newBuffer;
+    juce::MidiBuffer newBuffer;
     for (auto&& msgMetadata : delayBuffer)
     {
         auto m      = msgMetadata.getMessage();
@@ -852,7 +856,7 @@ void MidiChords::processBlock (AudioSampleBuffer& buffer,
                 if (chordNotePlaying[m.getChannel() - 1][m.getNoteNumber()])
                 {
                     ignoreNextNoteOff[m.getChannel() - 1].add (m.getNoteNumber());
-                    output.addEvent (MidiMessage::noteOff (m.getChannel(), m.getNoteNumber()), sample);
+                    output.addEvent (juce::MidiMessage::noteOff (m.getChannel(), m.getNoteNumber()), sample);
                 }
                 output.addEvent (m, sample);
                 chordNotePlaying[m.getChannel() - 1][m.getNoteNumber()] = true;
@@ -896,19 +900,19 @@ void MidiChords::processBlock (AudioSampleBuffer& buffer,
 }
 
 //==============================================================================
-AudioProcessorEditor* MidiChords::createEditor()
+juce::AudioProcessorEditor* MidiChords::createEditor()
 {
     return new MidiChordsEditor (this);
 }
 
 //==============================================================================
-void MidiChords::getStateInformation (MemoryBlock& destData)
+void MidiChords::getStateInformation (juce::MemoryBlock& destData)
 {
     copySettingsToProgram (curProgram);
     programs->dumpTo (destData);
 }
 
-void MidiChords::getCurrentProgramStateInformation (MemoryBlock& destData)
+void MidiChords::getCurrentProgramStateInformation (juce::MemoryBlock& destData)
 {
     copySettingsToProgram (curProgram);
     programs->dumpProgramTo (0, curProgram, destData);
@@ -916,8 +920,8 @@ void MidiChords::getCurrentProgramStateInformation (MemoryBlock& destData)
 
 void MidiChords::setStateInformation (const void* data, int sizeInBytes)
 {
-    MemoryInputStream m (data, sizeInBytes, false);
-    ValueTree vt = ValueTree::readFromStream (m);
+    juce::MemoryInputStream m (data, sizeInBytes, false);
+    juce::ValueTree vt = juce::ValueTree::readFromStream (m);
 
     programs->loadFrom (vt);
     if (vt.isValid())
@@ -954,28 +958,28 @@ void MidiChords::setStateInformation (const void* data, int sizeInBytes)
                         {
                             if (n < 32)
                             {
-                                int state = vt.getChild (index).getChild (ch).getProperty ("T" + String (trigger) + "_0-31", 0);
+                                int state = vt.getChild (index).getChild (ch).getProperty ("T" + juce::String (trigger) + "_0-31", 0);
                                 if ((state & (1 << n)) != 0)
                                     programs->setChordNote (index, trigger, ch + 1, n, true);
                             }
                             else if (n < 64)
                             {
                                 int note  = n - 32;
-                                int state = vt.getChild (index).getChild (ch).getProperty ("T" + String (trigger) + "_32-63", 0);
+                                int state = vt.getChild (index).getChild (ch).getProperty ("T" + juce::String (trigger) + "_32-63", 0);
                                 if ((state & (1 << note)) != 0)
                                     programs->setChordNote (index, trigger, ch + 1, n, true);
                             }
                             else if (n < 96)
                             {
                                 int note  = n - 64;
-                                int state = vt.getChild (index).getChild (ch).getProperty ("T" + String (trigger) + "_64-95", 0);
+                                int state = vt.getChild (index).getChild (ch).getProperty ("T" + juce::String (trigger) + "_64-95", 0);
                                 if ((state & (1 << note)) != 0)
                                     programs->setChordNote (index, trigger, ch + 1, n, true);
                             }
                             else if (n < 128)
                             {
                                 int note  = n - 96;
-                                int state = vt.getChild (index).getChild (ch).getProperty ("T" + String (trigger) + "_96-127", 0);
+                                int state = vt.getChild (index).getChild (ch).getProperty ("T" + juce::String (trigger) + "_96-127", 0);
                                 if ((state & (1 << note)) != 0)
                                     programs->setChordNote (index, trigger, ch + 1, n, true);
                             }
@@ -991,8 +995,8 @@ void MidiChords::setStateInformation (const void* data, int sizeInBytes)
 
 void MidiChords::setCurrentProgramStateInformation (const void* data, int sizeInBytes)
 {
-    MemoryInputStream m (data, sizeInBytes, false);
-    ValueTree vt = ValueTree::readFromStream (m);
+    juce::MemoryInputStream m (data, sizeInBytes, false);
+    juce::ValueTree vt = juce::ValueTree::readFromStream (m);
     if ((int) vt.getProperty ("Velocity") == 0)
         vt.setProperty ("Velocity", 100, 0);
 
@@ -1024,28 +1028,28 @@ void MidiChords::setCurrentProgramStateInformation (const void* data, int sizeIn
                 {
                     if (n < 32)
                     {
-                        int state = vt.getChild (curProgram).getChild (ch).getProperty ("T" + String (trigger) + "_0-31", 0);
+                        int state = vt.getChild (curProgram).getChild (ch).getProperty ("T" + juce::String (trigger) + "_0-31", 0);
                         if ((state & (1 << n)) != 0)
                             programs->setChordNote (curProgram, trigger, ch + 1, n, true);
                     }
                     else if (n < 64)
                     {
                         int note  = n - 32;
-                        int state = vt.getChild (curProgram).getChild (ch).getProperty ("T" + String (trigger) + "_32-63", 0);
+                        int state = vt.getChild (curProgram).getChild (ch).getProperty ("T" + juce::String (trigger) + "_32-63", 0);
                         if ((state & (1 << note)) != 0)
                             programs->setChordNote (curProgram, trigger, ch + 1, n, true);
                     }
                     else if (n < 96)
                     {
                         int note  = n - 64;
-                        int state = vt.getChild (curProgram).getChild (ch).getProperty ("T" + String (trigger) + "_64-95", 0);
+                        int state = vt.getChild (curProgram).getChild (ch).getProperty ("T" + juce::String (trigger) + "_64-95", 0);
                         if ((state & (1 << note)) != 0)
                             programs->setChordNote (curProgram, trigger, ch + 1, n, true);
                     }
                     else if (n < 128)
                     {
                         int note  = n - 96;
-                        int state = vt.getChild (curProgram).getChild (ch).getProperty ("T" + String (trigger) + "_96-127", 0);
+                        int state = vt.getChild (curProgram).getChild (ch).getProperty ("T" + juce::String (trigger) + "_96-127", 0);
                         if ((state & (1 << note)) != 0)
                             programs->setChordNote (curProgram, trigger, ch + 1, n, true);
                     }
@@ -1416,9 +1420,9 @@ void MidiChords::applyChannelToChord()
     }
 }
 
-void MidiChords::savePreset (String name)
+void MidiChords::savePreset (juce::String name)
 {
-    String contents = "Mode:";
+    juce::String contents = "Mode:";
     switch (mode)
     {
         case Global:
@@ -1443,25 +1447,25 @@ void MidiChords::savePreset (String name)
                 {
                     if (! usingTrigger)
                     {
-                        contents += String (t) + ":";
+                        contents += juce::String (t) + ":";
                         if (getGuitarView())
                             contents += " guitar";
                         usingTrigger = true;
                     }
-                    contents += String (" ") + String (n - t) + "." + String (c);
+                    contents += juce::String (" ") + juce::String (n - t) + "." + juce::String (c);
                 }
             }
         }
         if (usingTrigger)
             contents += "\n";
     }
-    File chordFile (dataPath + File::getSeparatorString() + "mappings" + File::getSeparatorString() + name + ".chords");
+    juce::File chordFile (dataPath + juce::File::getSeparatorString() + "mappings" + juce::File::getSeparatorString() + name + ".chords");
 
-    FileChooser myChooser ("Save preset...", chordFile, "*.chords");
+    juce::FileChooser myChooser ("Save preset...", chordFile, "*.chords");
 
     if (myChooser.browseForFileToSave (true))
     {
-        File file (myChooser.getResult());
+        juce::File file (myChooser.getResult());
         if (! file.hasFileExtension ("chords"))
             file = file.withFileExtension ("chords");
 
@@ -1470,7 +1474,7 @@ void MidiChords::savePreset (String name)
     }
 }
 
-bool MidiChords::readKeyFile (File file)
+bool MidiChords::readKeyFile (juce::File file)
 {
     DBG ("readKeyFile()");
     bool copy = false;
@@ -1480,9 +1484,9 @@ bool MidiChords::readKeyFile (File file)
     }
     else
     {
-        file = File (dataPath + File::getSeparatorString() + "midiChordsKey.txt");
+        file = juce::File (dataPath + juce::File::getSeparatorString() + "midiChordsKey.txt");
         if (! file.exists())
-            file = File (getCurrentPath() + File::getSeparatorString() + "midiChordsKey.txt");
+            file = juce::File (getCurrentPath() + juce::File::getSeparatorString() + "midiChordsKey.txt");
         //if (!file.exists())
         //	file = File(folderPath+File::getSeparatorString()+"midiChordsKey.txt");
     }
@@ -1491,8 +1495,8 @@ bool MidiChords::readKeyFile (File file)
     {
         if (file.hasFileExtension ("zip"))
         {
-            if (ZipFile (file).uncompressTo (File (dataPath)))
-                file = File (dataPath + File::getSeparatorString() + "midiChordsKey.txt");
+            if (juce::ZipFile (file).uncompressTo (juce::File (dataPath)))
+                file = juce::File (dataPath + juce::File::getSeparatorString() + "midiChordsKey.txt");
         }
         auto xmlKey = decodeEncryptedXml (file.loadFileAsString(), "3,5097efd7266b329e878e65129df0c8fe3ffc188abd24625e3709c65b304f5e2bdfa157e6c3cc6de5c29e36138c29f2516b56c55827aa238135bf1e23b6cab4f7");
         if (! xmlKey->getStringAttribute ("product").compare ("midiChords 1.x")
@@ -1502,7 +1506,7 @@ bool MidiChords::readKeyFile (File file)
             demo = false;
             //infoString = "Registered to " + xmlKey->getStringAttribute("username");
             if (copy)
-                file.copyFileTo (File (dataPath + File::getSeparatorString() + "midiChordsKey.txt"));
+                file.copyFileTo (juce::File (dataPath + juce::File::getSeparatorString() + "midiChordsKey.txt"));
             sendChangeMessage();
         }
         else
@@ -1515,33 +1519,33 @@ bool MidiChords::readKeyFile (File file)
     return false;
 }
 
-void MidiChords::readChorderPreset (File file)
+void MidiChords::readChorderPreset (juce::File file)
 {
-    XmlDocument xmlDoc (file);
+    juce::XmlDocument xmlDoc (file);
     auto e (xmlDoc.getDocumentElement());
     if (e != nullptr)
     {
-        MemoryBlock data;
+        juce::MemoryBlock data;
         data.loadFromHexString (e->getAllSubText());
 
         struct ChorderMapping
         {
-            uint32 header0;
-            uint8 kbSect0[16];
-            uint32 header1;
-            uint8 kbSect1[16];
-            uint32 header2;
-            uint8 kbSect2[16];
-            uint32 header3;
-            uint8 kbSect3[16];
-            uint32 header4;
-            uint8 kbSect4[16];
-            uint32 header5;
-            uint8 kbSect5[16];
-            uint32 header6;
-            uint8 kbSect6[16];
-            uint32 header7;
-            uint8 kbSect7[16];
+            juce::uint32 header0;
+            juce::uint8 kbSect0[16];
+            juce::uint32 header1;
+            juce::uint8 kbSect1[16];
+            juce::uint32 header2;
+            juce::uint8 kbSect2[16];
+            juce::uint32 header3;
+            juce::uint8 kbSect3[16];
+            juce::uint32 header4;
+            juce::uint8 kbSect4[16];
+            juce::uint32 header5;
+            juce::uint8 kbSect5[16];
+            juce::uint32 header6;
+            juce::uint8 kbSect6[16];
+            juce::uint32 header7;
+            juce::uint8 kbSect7[16];
         };
 
         int ch = jmax (learnchan, 1);
@@ -1630,8 +1634,8 @@ void MidiChords::translateToGuitarChord (bool force)
     memset (tempState, 0, sizeof (tempState));
     const int numFrets   = (int) programs->get (curProgram, "NumFrets");
     const int numStrings = (int) programs->get (curProgram, "NumStrings");
-    Array<int> unusedNotes;
-    Array<int> unusedStrings;
+    juce::Array<int> unusedNotes;
+    juce::Array<int> unusedStrings;
     for (int s = 0; s < numStrings; s++)
         unusedStrings.add (s);
 
@@ -1644,7 +1648,7 @@ void MidiChords::translateToGuitarChord (bool force)
             int s            = 0;
             while (s < numStrings && ! foundString)
             {
-                zeroFretNote = (int) programs->get (curProgram, "String" + String (s));
+                zeroFretNote = (int) programs->get (curProgram, "String" + juce::String (s));
                 if (n >= zeroFretNote && n <= zeroFretNote + numFrets && unusedStrings.contains (s))
                 {
                     tempState[s][n] = true;
@@ -1666,7 +1670,7 @@ void MidiChords::translateToGuitarChord (bool force)
         {
             for (int i = 0; i < unusedStrings.size(); i++)
             {
-                int zeroFretNote = (int) programs->get (curProgram, "String" + String (unusedStrings[i]));
+                int zeroFretNote = (int) programs->get (curProgram, "String" + juce::String (unusedStrings[i]));
                 if (n >= zeroFretNote && n <= zeroFretNote + numFrets && unusedStrings.contains (0))
                 {
                     tempState[unusedStrings[i]][n] = true;
@@ -1699,12 +1703,12 @@ void MidiChords::translateToGuitarChord (bool force)
 void MidiChords::fillGuitarPresetList()
 {
     guitarPresets.clearQuick();
-    File chordPath (dataPath + File::getSeparatorString() + "guitars");
-    Array<File> files;
-    chordPath.findChildFiles (files, File::findFiles, true);
+    juce::File chordPath (dataPath + juce::File::getSeparatorString() + "guitars");
+    juce::Array<juce::File> files;
+    chordPath.findChildFiles (files, juce::File::findFiles, true);
     for (int i = 0; i < files.size(); i++)
     {
-        StringArray lines;
+        juce::StringArray lines;
         lines.addLines (files[i].loadFileAsString());
         lines.sort (true);
         for (int line = 0; line < lines.size(); line++)
@@ -1713,9 +1717,9 @@ void MidiChords::fillGuitarPresetList()
             {
                 if (! lines[line].startsWithChar (';'))
                 {
-                    StringArray s;
+                    juce::StringArray s;
                     s.addTokens (lines[line], ",", "\"");
-                    Array<int> notes;
+                    juce::Array<int> notes;
                     for (int n = 3; n < s.size(); n++)
                         notes.add (s[n].trim().getIntValue());
                     guitarPresets.add (GuitarDefinition (s[0].trim().removeCharacters ("\""), s[1].trim(), s[2].trim().upToFirstOccurrenceOf (" frets", false, true).getIntValue(), notes));

--- a/pizjuce/midiChords/MidiChords.h
+++ b/pizjuce/midiChords/MidiChords.h
@@ -1,16 +1,14 @@
 #ifndef MidiChordsPLUGINFILTER_H
 #define MidiChordsPLUGINFILTER_H
 
-#include "juce_core/juce_core.h"
-#include "juce_data_structures/juce_data_structures.h"
+#include <juce_core/juce_core.h>
+#include <juce_data_structures/juce_data_structures.h>
 
 #include "../_common/BankStorage.h"
 #include "../_common/ChordFunctions.h"
 #include "../_common/key.h"
 #include "../_common/midistuff.h"
 #include "../_common/PizAudioProcessor.h"
-
-using namespace juce;
 
 enum parameters
 {
@@ -71,13 +69,13 @@ class GuitarDefinition
 public:
     GuitarDefinition()
     {
-        guitarName = String();
+        guitarName = juce::String();
         chordFile  = "Chords.txt";
         numFrets   = 0;
         numStrings = 0;
     }
 
-    GuitarDefinition (String name, String file, int frets, Array<int>& notes)
+    GuitarDefinition (juce::String name, juce::String file, int frets, juce::Array<int>& notes)
     {
         guitarName = name;
         chordFile  = file;
@@ -87,11 +85,11 @@ public:
     }
     ~GuitarDefinition() {}
 
-    String guitarName;
+    juce::String guitarName;
     int numStrings;
     int numFrets;
-    Array<int> stringNotes;
-    String chordFile;
+    juce::Array<int> stringNotes;
+    juce::String chordFile;
 };
 
 class MidiChordsPrograms : public BankStorage
@@ -99,7 +97,7 @@ class MidiChordsPrograms : public BankStorage
 public:
     MidiChordsPrograms();
 
-    void set (int prog, const Identifier& name, const var& newValue)
+    void set (int prog, const juce::Identifier& name, const juce::var& newValue)
     {
         BankStorage::set (0, prog, name.toString(), newValue);
     }
@@ -108,7 +106,7 @@ public:
     {
         auto noteMatrix = values_.getChild (0).getChild (prog).getChild (trigger);
         if (noteMatrix.isValid())
-            noteMatrix.removeAllProperties (0);
+            noteMatrix.removeAllProperties (nullptr);
     }
 
     void setChordNote (int prog, int trigger, int channel, int note, const bool& newValue)
@@ -118,51 +116,51 @@ public:
 
         if (! triggerProp.isValid())
         {
-            ValueTree noteMatrix ("NoteMatrix_T" + String (trigger));
-            values_.getChild (0).getChild (prog).addChild (noteMatrix, trigger, 0);
+            juce::ValueTree noteMatrix ("NoteMatrix_T" + juce::String (trigger));
+            values_.getChild (0).getChild (prog).addChild (noteMatrix, trigger, nullptr);
         }
         if (note < 32)
         {
-            int state = triggerProp.getProperty ("Ch" + String (channel) + "_0-31", 0);
+            int state = triggerProp.getProperty ("Ch" + juce::String (channel) + "_0-31", 0);
             if (newValue)
                 state |= 1 << note;
             else
                 state &= ~(1 << note);
-            triggerProp.setProperty ("Ch" + String (channel) + "_0-31", state, 0);
+            triggerProp.setProperty ("Ch" + juce::String (channel) + "_0-31", state, nullptr);
         }
         else if (note < 64)
         {
             note -= 32;
-            int state = triggerProp.getProperty ("Ch" + String (channel) + "_32-63", 0);
+            int state = triggerProp.getProperty ("Ch" + juce::String (channel) + "_32-63", 0);
             if (newValue)
                 state |= 1 << note;
             else
                 state &= ~(1 << note);
-            triggerProp.setProperty ("Ch" + String (channel) + "_32-63", state, 0);
+            triggerProp.setProperty ("Ch" + juce::String (channel) + "_32-63", state, nullptr);
         }
         else if (note < 96)
         {
             note -= 64;
-            int state = triggerProp.getProperty ("Ch" + String (channel) + "_64-95", 0);
+            int state = triggerProp.getProperty ("Ch" + juce::String (channel) + "_64-95", 0);
             if (newValue)
                 state |= 1 << note;
             else
                 state &= ~(1 << note);
-            triggerProp.setProperty ("Ch" + String (channel) + "_64-95", state, 0);
+            triggerProp.setProperty ("Ch" + juce::String (channel) + "_64-95", state, nullptr);
         }
         else if (note < 128)
         {
             note -= 96;
-            int state = triggerProp.getProperty ("Ch" + String (channel) + "_96-127", 0);
+            int state = triggerProp.getProperty ("Ch" + juce::String (channel) + "_96-127", 0);
             if (newValue)
                 state |= 1 << note;
             else
                 state &= ~(1 << note);
-            triggerProp.setProperty ("Ch" + String (channel) + "_96-127", state, 0);
+            triggerProp.setProperty ("Ch" + juce::String (channel) + "_96-127", state, nullptr);
         }
     }
 
-    const var get (int prog, const Identifier& name)
+    const juce::var get (int prog, const juce::Identifier& name)
     {
         return BankStorage::get (0, prog, name.toString());
     }
@@ -176,25 +174,25 @@ public:
             return false;
         if (note < 32)
         {
-            int state = triggerProp.getProperty ("Ch" + String (ch) + "_0-31", 0);
+            int state = triggerProp.getProperty ("Ch" + juce::String (ch) + "_0-31", 0);
             return (state & (1 << note)) != 0;
         }
         else if (note < 64)
         {
             note -= 32;
-            int state = triggerProp.getProperty ("Ch" + String (ch) + "_32-63", 0);
+            int state = triggerProp.getProperty ("Ch" + juce::String (ch) + "_32-63", 0);
             return (state & (1 << note)) != 0;
         }
         else if (note < 96)
         {
             note -= 64;
-            int state = triggerProp.getProperty ("Ch" + String (ch) + "_64-95", 0);
+            int state = triggerProp.getProperty ("Ch" + juce::String (ch) + "_64-95", 0);
             return (state & (1 << note)) != 0;
         }
         else if (note < 128)
         {
             note -= 96;
-            int state = triggerProp.getProperty ("Ch" + String (ch) + "_96-127", 0);
+            int state = triggerProp.getProperty ("Ch" + juce::String (ch) + "_96-127", 0);
             return (state & (1 << note)) != 0;
         }
         return false;
@@ -207,7 +205,7 @@ public:
             auto bank = values_.getChild (b);
             for (int p = 0; p < bank.getNumChildren(); p++)
             {
-                if (BankStorage::get (b, p, "Velocity") == var (0))
+                if (BankStorage::get (b, p, "Velocity") == juce::var (0))
                 {
                     BankStorage::set (b, p, "Velocity", 100);
                 }
@@ -221,7 +219,7 @@ private:
 
 //==============================================================================
 class MidiChords : public PizAudioProcessor,
-                   public ChangeBroadcaster
+                   public juce::ChangeBroadcaster
 {
 public:
     //==============================================================================
@@ -232,14 +230,14 @@ public:
     void prepareToPlay (double sampleRate, int samplesPerBlock) override;
     void releaseResources() override;
 
-    void processBlock (AudioSampleBuffer& buffer,
-                       MidiBuffer& midiMessages) override;
+    void processBlock (juce::AudioSampleBuffer& buffer,
+                       juce::MidiBuffer& midiMessages) override;
 
     //==============================================================================
-    AudioProcessorEditor* createEditor() override;
+    juce::AudioProcessorEditor* createEditor() override;
 
     //==============================================================================
-    const String getName() const override;
+    const juce::String getName() const override;
     bool hasEditor() const override { return true; }
 
     int getNumParameters() override;
@@ -247,11 +245,11 @@ public:
     float getParameter (int index) override;
     void setParameter (int index, float newValue) override;
 
-    const String getParameterName (int index) override;
-    const String getParameterText (int index) override;
+    const juce::String getParameterName (int index) override;
+    const juce::String getParameterText (int index) override;
 
-    const String getInputChannelName (int channelIndex) const override;
-    const String getOutputChannelName (int channelIndex) const override;
+    const juce::String getInputChannelName (int channelIndex) const override;
+    const juce::String getOutputChannelName (int channelIndex) const override;
     bool isInputChannelStereoPair (int index) const override;
     bool isOutputChannelStereoPair (int index) const override;
 
@@ -262,21 +260,21 @@ public:
     int getNumPrograms() override { return numProgs; }
     int getCurrentProgram() override { return curProgram; }
     void setCurrentProgram (int index) override;
-    const String getProgramName (int index) override { return programs->get (index, "Name"); }
-    void changeProgramName (int index, const String& newName) override { programs->set (index, "Name", newName); }
+    const juce::String getProgramName (int index) override { return programs->get (index, "Name"); }
+    void changeProgramName (int index, const juce::String& newName) override { programs->set (index, "Name", newName); }
     double getTailLengthSeconds() const override { return 0; }
 
     //==============================================================================
-    void getStateInformation (MemoryBlock& destData) override;
+    void getStateInformation (juce::MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
-    void getCurrentProgramStateInformation (MemoryBlock& destData) override;
+    void getCurrentProgramStateInformation (juce::MemoryBlock& destData) override;
     void setCurrentProgramStateInformation (const void* data, int sizeInBytes) override;
 
     //==============================================================================
-    MidiKeyboardState progKbState[numProgs][128];
-    MidiKeyboardState chordKbState;
-    MidiKeyboardState triggerKbState;
-    MidiKeyboardState* getCurrentKbState() { return &(progKbState[curProgram][curTrigger]); }
+    juce::MidiKeyboardState progKbState[numProgs][128];
+    juce::MidiKeyboardState chordKbState;
+    juce::MidiKeyboardState triggerKbState;
+    juce::MidiKeyboardState* getCurrentKbState() { return &(progKbState[curProgram][curTrigger]); }
     void selectTrigger (int index);
     void selectChordNote (int index, int note, bool on, int ch = -1);
     int getCurrentTrigger() { return curTrigger; }
@@ -291,11 +289,11 @@ public:
     int getLearnChannel() { return learnchan; }
     void setNoteBypassed (int note, bool bypass)
     {
-        programs->set (curProgram, "Bypassed" + String (note), bypass);
+        programs->set (curProgram, "Bypassed" + juce::String (note), bypass);
     }
     bool isNoteBypassed (int note)
     {
-        return programs->get (curProgram, "Bypassed" + String (note));
+        return programs->get (curProgram, "Bypassed" + juce::String (note));
     }
     void clearAllChords();
     void resetAllChords();
@@ -306,8 +304,8 @@ public:
     void transposeChord (int trigger, bool up);
     void transposeCurrentChordByOctave (bool up);
     void applyChannelToChord();
-    String getCurrentChordName();
-    void savePreset (String name);
+    juce::String getCurrentChordName();
+    void savePreset (juce::String name);
     void playCurrentChord (bool on)
     {
         if (on)
@@ -337,13 +335,13 @@ public:
     }
     void setStringValue (int string, int note, bool translate)
     {
-        programs->set (curProgram, "String" + String (string), note);
+        programs->set (curProgram, "String" + juce::String (string), note);
         if (translate)
             translateToGuitarChord();
     }
     int getStringValue (int string)
     {
-        return programs->get (curProgram, "String" + String (string));
+        return programs->get (curProgram, "String" + juce::String (string));
     }
     void setNumFrets (int frets, bool translate)
     {
@@ -380,28 +378,27 @@ public:
     }
     void setStrumDirection (bool up)
     {
-        programs->set (curProgram, "StrumUp" + String (curTrigger), up);
+        programs->set (curProgram, "StrumUp" + juce::String (curTrigger), up);
         sendChangeMessage();
     }
     bool getStrumDirection()
     {
-        return programs->get (curProgram, "StrumUp" + String (curTrigger));
+        return programs->get (curProgram, "StrumUp" + juce::String (curTrigger));
     }
-    void readChorderPreset (File file);
-    bool readKeyFile (File file = File());
+    void readChorderPreset (juce::File file);
+    bool readKeyFile (juce::File file = juce::File());
     bool demo;
 
-    Array<GuitarDefinition> guitarPresets;
+    juce::Array<GuitarDefinition> guitarPresets;
     void fillGuitarPresetList();
 
     void toggleUsePC (bool use);
 
-    String dataPath;
+    juce::String dataPath;
     int lastUIWidth, lastUIHeight;
-    //==============================================================================
-    juce_UseDebuggingNewOperator
 
-        private : MidiChordsPrograms* programs;
+private:
+    MidiChordsPrograms* programs;
     int curProgram;
     int curTrigger;
     //StringArray chordNames;
@@ -438,19 +435,21 @@ public:
     int outputNote[16][128];
     int numChordNotes[numProgs][128];
 
-    Array<ChordNote> playingChord[128];
+    juce::Array<ChordNote> playingChord[128];
     bool chordNotePlaying[16][128];
     bool chordNotePlaying2[16][128];
-    Array<int> ignoreNextNoteOff[16];
+    juce::Array<int> ignoreNextNoteOff[16];
 
     void copySettingsToProgram (int index);
 
-    MidiBuffer delayBuffer;
+    juce::MidiBuffer delayBuffer;
     int noteDelay[16][128];
-    uint64 noteOrigPos[16][128];
-    uint64 totalSamples;
+    juce::uint64 noteOrigPos[16][128];
+    juce::uint64 totalSamples;
     bool expectingDelayedNotes;
-    AudioPlayHead::CurrentPositionInfo lastPosInfo;
+    juce::AudioPlayHead::CurrentPositionInfo lastPosInfo;
+
+    JUCE_LEAK_DETECTOR (MidiChords)
 };
 
 #endif

--- a/pizjuce/midiChords/MidiChordsEditor.cpp
+++ b/pizjuce/midiChords/MidiChordsEditor.cpp
@@ -23,6 +23,7 @@
 #include "MidiChordsEditor.h"
 
 //[MiscUserDefs] You can add your own user definitions and misc code here...
+using juce::roundToInt;
 //[/MiscUserDefs]
 
 //==============================================================================
@@ -613,15 +614,15 @@ MidiChordsEditor::MidiChordsEditor (MidiChords* const ownerFilter)
 
     fretsSlider = new FretsSlider (L"new slider");
     fretsSlider->setRange (5, maxFrets, 1);
-    fretsSlider->setSliderStyle (Slider::LinearHorizontal);
-    fretsSlider->setTextBoxStyle (Slider::TextBoxLeft, false, 80, 20);
+    fretsSlider->setSliderStyle (juce::Slider::LinearHorizontal);
+    fretsSlider->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 80, 20);
     fretsSlider->addListener (this);
     fretsSlider->setMouseClickGrabsKeyboardFocus (false);
 
     stringsSlider = new StringsSlider (L"new slider");
     stringsSlider->setRange (1, maxStrings, 1);
-    stringsSlider->setSliderStyle (Slider::LinearHorizontal);
-    stringsSlider->setTextBoxStyle (Slider::TextBoxLeft, false, 80, 20);
+    stringsSlider->setSliderStyle (juce::Slider::LinearHorizontal);
+    stringsSlider->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 80, 20);
     stringsSlider->addListener (this);
     stringsSlider->setMouseClickGrabsKeyboardFocus (false);
 
@@ -629,8 +630,8 @@ MidiChordsEditor::MidiChordsEditor (MidiChords* const ownerFilter)
     {
         stringSlider[i] = new NoteSlider (L"new slider");
         stringSlider[i]->setRange (-1, 127, 1);
-        stringSlider[i]->setSliderStyle (Slider::LinearHorizontal);
-        stringSlider[i]->setTextBoxStyle (Slider::TextBoxLeft, false, 80, 20);
+        stringSlider[i]->setSliderStyle (juce::Slider::LinearHorizontal);
+        stringSlider[i]->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 80, 20);
         stringSlider[i]->addListener (this);
         stringSlider[i]->setBottomOctave (ownerFilter->bottomOctave);
         stringSlider[i]->setMouseClickGrabsKeyboardFocus (false);
@@ -682,17 +683,17 @@ MidiChordsEditor::MidiChordsEditor (MidiChords* const ownerFilter)
     speedSlider->setOwner (ownerFilter, kSpeed);
     maxTimeSlider->setOwner (ownerFilter, kMaxDelay);
 
-    guitar->setMouseCursor (MouseCursor::PointingHandCursor);
-    chordKeyboard->setMouseCursor (MouseCursor::PointingHandCursor);
-    triggerKeyboard->setMouseCursor (MouseCursor::PointingHandCursor);
+    guitar->setMouseCursor (juce::MouseCursor::PointingHandCursor);
+    chordKeyboard->setMouseCursor (juce::MouseCursor::PointingHandCursor);
+    triggerKeyboard->setMouseCursor (juce::MouseCursor::PointingHandCursor);
 
     //channelSlider->setAllText("Any");
     learnChanSlider->setAllText ("All");
     outputChannelSlider->setAllText ("Multi");
     chordSaveEditor->addListener (this);
-    chordSaveEditor->setTextToShowWhenEmpty ("Save chord (type a name)", Colours::grey);
+    chordSaveEditor->setTextToShowWhenEmpty ("Save chord (type a name)", juce::Colours::grey);
     tuningSaveEditor->addListener (this);
-    tuningSaveEditor->setTextToShowWhenEmpty ("Save tuning (type name)", Colours::grey);
+    tuningSaveEditor->setTextToShowWhenEmpty ("Save tuning (type name)", juce::Colours::grey);
     pizButton->addListener (this);
     pizButton->setTooltip ("http://thepiz.org/plugins");
     previewButton->addMouseListener (this, false);
@@ -705,17 +706,17 @@ MidiChordsEditor::MidiChordsEditor (MidiChords* const ownerFilter)
     transposeUpButton->setVisible (false);
     guitar->setVisible (false);
 
-    File chordPath (getFilter()->dataPath + File::getSeparatorString() + "mappings");
-    browser = new FileBrowserComponent (FileBrowserComponent::openMode | FileBrowserComponent::useTreeView | FileBrowserComponent::canSelectFiles,
-                                        chordPath,
-                                        &fileFilter,
-                                        0);
+    juce::File chordPath (getFilter()->dataPath + juce::File::getSeparatorString() + "mappings");
+    browser = new juce::FileBrowserComponent (juce::FileBrowserComponent::openMode | juce::FileBrowserComponent::useTreeView | juce::FileBrowserComponent::canSelectFiles,
+                                              chordPath,
+                                              &fileFilter,
+                                              0);
     browser->addListener (this);
 
-    Font const defaultFont = infoBox->getFont();
+    juce::Font const defaultFont = infoBox->getFont();
     infoBox->setVisible (false);
-    infoBox->setFont (Font (18.f, Font::bold));
-    infoBox->insertTextAtCaret ("Insert Piz Here-> midiChords v." + String (JucePlugin_VersionString) + "\n\n");
+    infoBox->setFont (juce::Font (18.f, juce::Font::bold));
+    infoBox->insertTextAtCaret ("Insert Piz Here-> midiChords v." + juce::String (JucePlugin_VersionString) + "\n\n");
     infoBox->setFont (defaultFont.boldened());
     infoBox->insertTextAtCaret ("== Host Info ==\n");
     infoBox->setFont (defaultFont);
@@ -723,7 +724,7 @@ MidiChordsEditor::MidiChordsEditor (MidiChords* const ownerFilter)
     infoBox->setFont (defaultFont.boldened());
     infoBox->insertTextAtCaret ("== Documentation ==\n");
     infoBox->setFont (defaultFont);
-    infoBox->insertTextAtCaret (File (getFilter()->dataPath + File::getSeparatorString() + "readme.txt").loadFileAsString());
+    infoBox->insertTextAtCaret (juce::File (getFilter()->dataPath + juce::File::getSeparatorString() + "readme.txt").loadFileAsString());
 
     const int middleC = getFilter()->getBottomOctave() + 5;
     chordKeyboard->setOctaveForMiddleC (middleC);
@@ -736,7 +737,7 @@ MidiChordsEditor::MidiChordsEditor (MidiChords* const ownerFilter)
     setSize (640, 420);
 
     //[Constructor] You can add your own custom stuff here..
-    versionLabel->setText (JucePlugin_VersionString, dontSendNotification);
+    versionLabel->setText (JucePlugin_VersionString, juce::dontSendNotification);
     ownerFilter->addChangeListener (this);
     if (! ownerFilter->demo)
         demoLabel->setVisible (false);
@@ -1161,9 +1162,9 @@ void MidiChordsEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     else if (buttonThatWasClicked == chordMenuButton.get())
     {
         //[UserButtonCode_chordMenuButton] -- add your button handler code here..
-        StringArray list;
+        juce::StringArray list;
         listChordFiles (list);
-        PopupMenu menu;
+        juce::PopupMenu menu;
         menu.addCustomItem (-1, *chordSaveEditor, 150, 24, false);
         menu.addSeparator();
         for (int i = 0; i < list.size(); i++)
@@ -1198,7 +1199,7 @@ void MidiChordsEditor::buttonClicked (juce::Button* buttonThatWasClicked)
         //listPresetFiles(list);
         browser->refresh();
 
-        PopupMenu menu;
+        juce::PopupMenu menu;
         menu.addItem (-1, "Save...");
         menu.addSeparator();
         menu.addCustomItem (-2, *browser, 250, 300, false);
@@ -1222,23 +1223,23 @@ void MidiChordsEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     else if (buttonThatWasClicked == copyButton.get())
     {
         //[UserButtonCode_copyButton] -- add your button handler code here..
-        const int t        = getFilter()->getCurrentTrigger();
-        String chordString = String (t) + ":";
+        const int t              = getFilter()->getCurrentTrigger();
+        juce::String chordString = juce::String (t) + ":";
         for (int n = 0; n < 128; n++)
         {
             for (int c = 1; c <= 16; c++)
             {
                 if (getFilter()->progKbState[getFilter()->getCurrentProgram()][t].isNoteOn (c, n))
-                    chordString += " " + String (n - t) + "." + String (c);
+                    chordString += " " + juce::String (n - t) + "." + juce::String (c);
             }
         }
-        SystemClipboard::copyTextToClipboard (chordString);
+        juce::SystemClipboard::copyTextToClipboard (chordString);
         //[/UserButtonCode_copyButton]
     }
     else if (buttonThatWasClicked == pasteButton.get())
     {
         //[UserButtonCode_pasteButton] -- add your button handler code here..
-        chordFromString (SystemClipboard::getTextFromClipboard());
+        chordFromString (juce::SystemClipboard::getTextFromClipboard());
         //[/UserButtonCode_pasteButton]
     }
     else if (buttonThatWasClicked == pcButton.get())
@@ -1276,17 +1277,17 @@ void MidiChordsEditor::buttonClicked (juce::Button* buttonThatWasClicked)
         //[UserButtonCode_infoButton] -- add your button handler code here..
         infoBox->moveCaretToTop (false);
         if (infoButton->getToggleState())
-            Desktop::getInstance().getAnimator().fadeOut (infoBox.get(), 150);
+            juce::Desktop::getInstance().getAnimator().fadeOut (infoBox.get(), 150);
         else
-            Desktop::getInstance().getAnimator().fadeIn (infoBox.get(), 100);
+            juce::Desktop::getInstance().getAnimator().fadeIn (infoBox.get(), 100);
         //infoBox->setVisible(!infoBox->isVisible());
-        infoButton->setToggleState (! infoButton->getToggleState(), dontSendNotification);
+        infoButton->setToggleState (! infoButton->getToggleState(), juce::dontSendNotification);
         //[/UserButtonCode_infoButton]
     }
     else if (buttonThatWasClicked == specialMenuButton.get())
     {
         //[UserButtonCode_specialMenuButton] -- add your button handler code here..
-        PopupMenu m;
+        juce::PopupMenu m;
         m.addItem (1, "Clear all chords");
         m.addItem (2, "Reset all chords");
         m.addItem (3, "Copy to all triggers (absolute)");
@@ -1329,7 +1330,7 @@ void MidiChordsEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     {
         //[UserButtonCode_setupButton] -- add your button handler code here..
         getFilter()->fillGuitarPresetList();
-        PopupMenu m, custom, chordfiles;
+        juce::PopupMenu m, custom, chordfiles;
         for (int i = 0; i < getFilter()->guitarPresets.size(); i++)
             m.addItem (i + 1, getFilter()->guitarPresets[i].guitarName, true, isGuitarPreset (i));
 
@@ -1382,7 +1383,7 @@ void MidiChordsEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     //[UserbuttonClicked_Post]
     else if (buttonThatWasClicked == pizButton.get())
     {
-        URL ("http://thepiz.org/plugins/?p=midiChords").launchInDefaultBrowser();
+        juce::URL ("http://thepiz.org/plugins/?p=midiChords").launchInDefaultBrowser();
     }
     //[/UserbuttonClicked_Post]
 }
@@ -1593,18 +1594,18 @@ void MidiChordsEditor::chordMenuCallback (int result, MidiChordsEditor* editor)
     }
 }
 
-void MidiChordsEditor::mouseDown (const MouseEvent& e)
+void MidiChordsEditor::mouseDown (const juce::MouseEvent& e)
 {
     if (e.eventComponent == previewButton.get() && ! e.mods.isPopupMenu())
         getFilter()->playCurrentChord (true);
     if (e.eventComponent != infoBox.get() && infoBox->isVisible())
     {
         infoBox->setVisible (false);
-        infoButton->setToggleState (false, dontSendNotification);
+        infoButton->setToggleState (false, juce::dontSendNotification);
     }
 }
 
-void MidiChordsEditor::mouseDoubleClick (const MouseEvent& e)
+void MidiChordsEditor::mouseDoubleClick (const juce::MouseEvent& e)
 {
     if (e.eventComponent == triggerKeyboard.get() && (e.mods.isShiftDown() || e.mods.isPopupMenu()))
     {
@@ -1614,7 +1615,7 @@ void MidiChordsEditor::mouseDoubleClick (const MouseEvent& e)
     }
 }
 
-void MidiChordsEditor::mouseUp (const MouseEvent& e)
+void MidiChordsEditor::mouseUp (const juce::MouseEvent& e)
 {
     if (e.eventComponent == previewButton.get())
     {
@@ -1623,41 +1624,41 @@ void MidiChordsEditor::mouseUp (const MouseEvent& e)
             if (getFilter()->isPreviewChordPlaying())
             {
                 getFilter()->playCurrentChord (false);
-                previewButton->setToggleState (false, dontSendNotification);
+                previewButton->setToggleState (false, juce::dontSendNotification);
             }
             else
             {
                 getFilter()->playCurrentChord (true);
-                previewButton->setToggleState (true, dontSendNotification);
+                previewButton->setToggleState (true, juce::dontSendNotification);
             }
         }
         else
         {
             getFilter()->playCurrentChord (false);
-            previewButton->setToggleState (false, dontSendNotification);
+            previewButton->setToggleState (false, juce::dontSendNotification);
         }
     }
 }
 
-void MidiChordsEditor::chordFromString (String chordString)
+void MidiChordsEditor::chordFromString (juce::String chordString)
 {
     const int root = chordString.upToFirstOccurrenceOf (":", false, false).getIntValue();
     const int t    = getFilter()->getCurrentTrigger();
-    StringArray sa;
+    juce::StringArray sa;
     if (chordString.contains (":"))
         chordString = chordString.fromLastOccurrenceOf (":", false, false);
     if (chordString.containsAnyOf ("abcdefgABCDEFGmMrRopP#+") /* || !chordString.contains("0")*/)
         chordString = getIntervalStringFromNoteNames (t, chordString, getFilter()->bottomOctave);
 
-    sa.addTokens (chordString, " ,", String());
+    sa.addTokens (chordString, " ,", juce::String());
     if (sa.size() > 0)
         getFilter()->clearChord (t);
-    if (ModifierKeys::getCurrentModifiers().isCommandDown())
+    if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
     {
         //absolute
         for (int i = 0; i < sa.size(); i++)
         {
-            String s = sa[i].trim();
+            juce::String s = sa[i].trim();
             if (s.isNotEmpty())
             {
                 if (s.contains ("."))
@@ -1672,7 +1673,7 @@ void MidiChordsEditor::chordFromString (String chordString)
         //relative
         for (int i = 0; i < sa.size(); i++)
         {
-            String s = sa[i].trim();
+            juce::String s = sa[i].trim();
             if (s.isNotEmpty())
             {
                 if (s.contains ("."))
@@ -1686,7 +1687,7 @@ void MidiChordsEditor::chordFromString (String chordString)
         getFilter()->translateToGuitarChord();
 }
 
-void MidiChordsEditor::changeListenerCallback (ChangeBroadcaster* source)
+void MidiChordsEditor::changeListenerCallback (juce::ChangeBroadcaster* source)
 {
     if (source == getFilter())
         updateParametersFromFilter();
@@ -1706,10 +1707,10 @@ void MidiChordsEditor::updateParametersFromFilter()
 
     guitar->setVisible (filter->getGuitarView());
     setupButton->setEnabled (filter->getGuitarView());
-    fretsSlider->setValue (filter->getNumFrets(), dontSendNotification);
+    fretsSlider->setValue (filter->getNumFrets(), juce::dontSendNotification);
     guitar->setNumFrets (filter->getNumFrets());
 
-    stringsSlider->setValue (s, dontSendNotification);
+    stringsSlider->setValue (s, juce::dontSendNotification);
     guitar->setNumStrings (s);
 
     guitarPreset = -1;
@@ -1725,29 +1726,29 @@ void MidiChordsEditor::updateParametersFromFilter()
     for (int i = 0; i < maxStrings; i++)
     {
         stringSlider[i]->setEnabled (i < s);
-        stringSlider[i]->setValue (filter->getStringValue (i), dontSendNotification);
+        stringSlider[i]->setValue (filter->getStringValue (i), juce::dontSendNotification);
         guitar->setStringNote (i, filter->getStringValue (i));
     }
 
-    channelSlider->setValue (filter->getParameter (kChannel) * 16.f, dontSendNotification);
-    learnChanSlider->setValue (chordChan, dontSendNotification);
-    outputChannelSlider->setValue (outChan, dontSendNotification);
-    velocitySlider->setValue (previewVel, dontSendNotification);
-    transposeSlider->setValue (transpose, dontSendNotification);
-    chordLearnButton->setToggleState (filter->getParameter (kLearnChord) > 0, dontSendNotification);
-    triggerLearnButton->setToggleState (filter->getParameter (kFollowInput) > 0, dontSendNotification);
-    toggleButton->setToggleState (filter->getParameter (kGuess) > 0, dontSendNotification);
-    flatsButton->setToggleState (flats, dontSendNotification);
+    channelSlider->setValue (filter->getParameter (kChannel) * 16.f, juce::dontSendNotification);
+    learnChanSlider->setValue (chordChan, juce::dontSendNotification);
+    outputChannelSlider->setValue (outChan, juce::dontSendNotification);
+    velocitySlider->setValue (previewVel, juce::dontSendNotification);
+    transposeSlider->setValue (transpose, juce::dontSendNotification);
+    chordLearnButton->setToggleState (filter->getParameter (kLearnChord) > 0, juce::dontSendNotification);
+    triggerLearnButton->setToggleState (filter->getParameter (kFollowInput) > 0, juce::dontSendNotification);
+    toggleButton->setToggleState (filter->getParameter (kGuess) > 0, juce::dontSendNotification);
+    flatsButton->setToggleState (flats, juce::dontSendNotification);
     guitar->setFlats (flats);
-    pcButton->setToggleState (filter->getParameter (kUseProgCh) > 0, dontSendNotification);
-    transposeInputButton->setToggleState (filter->getParameter (kInputTranspose) > 0, dontSendNotification);
-    toAllChannelsButton->setToggleState (filter->getParameter (kToAllChannels) > 0, dontSendNotification);
+    pcButton->setToggleState (filter->getParameter (kUseProgCh) > 0, juce::dontSendNotification);
+    transposeInputButton->setToggleState (filter->getParameter (kInputTranspose) > 0, juce::dontSendNotification);
+    toAllChannelsButton->setToggleState (filter->getParameter (kToAllChannels) > 0, juce::dontSendNotification);
 
     accelSlider->setVSTSlider();
     velRampSlider->setVSTSlider();
     speedSlider->setVSTSlider();
     maxTimeSlider->setVSTSlider();
-    strumButton->setToggleState (filter->getParameter (kStrum) > 0, dontSendNotification);
+    strumButton->setToggleState (filter->getParameter (kStrum) > 0, juce::dontSendNotification);
     strumDirectionButton->setEnabled (strumButton->getToggleState());
     accelSlider->setEnabled (strumButton->getToggleState());
     velRampSlider->setEnabled (strumButton->getToggleState());
@@ -1763,75 +1764,75 @@ void MidiChordsEditor::updateParametersFromFilter()
     else
         chordKeyboard->setMidiChannelsToDisplay (1 << (chordChan - 1));
 
-    normalButton->setToggleState (newMode == Normal, dontSendNotification);
-    octaveButton->setToggleState (newMode == Octave, dontSendNotification);
-    globalButton->setToggleState (newMode == Global, dontSendNotification);
+    normalButton->setToggleState (newMode == Normal, juce::dontSendNotification);
+    octaveButton->setToggleState (newMode == Octave, juce::dontSendNotification);
+    globalButton->setToggleState (newMode == Global, juce::dontSendNotification);
 
-    chordNameLabel->setText (getCurrentChordName(), dontSendNotification);
+    chordNameLabel->setText (getCurrentChordName(), juce::dontSendNotification);
 
     if (guitar->isVisible())
         guitar->handleAsyncUpdate();
 
     const int t = getFilter()->getCurrentTrigger();
-    String chordString; // = String(t) + ":";
+    juce::String chordString; // = String(t) + ":";
     for (int n = 0; n < 128; n++)
     {
         for (int c = 1; c <= 16; c++)
         {
             if (getFilter()->progKbState[p][t].isNoteOn (c, n))
-                chordString += String (n - t) /*+"."+String(c)*/ + " ";
+                chordString += juce::String (n - t) /*+"."+String(c)*/ + " ";
         }
     }
-    chordEditor->setText (chordString.trimEnd(), dontSendNotification);
+    chordEditor->setText (chordString.trimEnd(), juce::dontSendNotification);
 
     if (mode != newMode)
     {
         if (newMode == Global)
         {
-            triggerLabel->setText ("Root Note:", dontSendNotification);
+            triggerLabel->setText ("Root Note:", juce::dontSendNotification);
             triggerKeyboard->setKeyWidth (16.f);
             triggerKeyboard->setAvailableRange (0, 127);
             triggerKeyboard->setLowestVisibleKey (36);
-            triggerNoteLabel->setText (getNoteName (t, getFilter()->bottomOctave) + " (" + String (t) + ")", dontSendNotification);
+            triggerNoteLabel->setText (getNoteName (t, getFilter()->bottomOctave) + " (" + juce::String (t) + ")", juce::dontSendNotification);
         }
         else if (newMode == Octave)
         {
-            triggerLabel->setText ("Trigger Note:", dontSendNotification);
+            triggerLabel->setText ("Trigger Note:", juce::dontSendNotification);
             triggerKeyboard->setAvailableRange (60, 71);
             triggerKeyboard->setKeyWidth ((float) triggerKeyboard->getWidth() / 7.f);
-            triggerNoteLabel->setText (getNoteNameWithoutOctave (t, ! flats), dontSendNotification);
+            triggerNoteLabel->setText (getNoteNameWithoutOctave (t, ! flats), juce::dontSendNotification);
         }
         else
         {
-            triggerLabel->setText ("Trigger Note:", dontSendNotification);
+            triggerLabel->setText ("Trigger Note:", juce::dontSendNotification);
             triggerKeyboard->setKeyWidth (16.f);
             triggerKeyboard->setAvailableRange (0, 127);
             triggerKeyboard->setLowestVisibleKey (36);
-            triggerNoteLabel->setText (getNoteName (t, getFilter()->bottomOctave) + " (" + String (t) + ")", dontSendNotification);
+            triggerNoteLabel->setText (getNoteName (t, getFilter()->bottomOctave) + " (" + juce::String (t) + ")", juce::dontSendNotification);
         }
         mode = newMode;
     }
     else
     {
         if (newMode != Octave)
-            triggerNoteLabel->setText (getNoteName (t, getFilter()->bottomOctave) + " (" + String (t) + ")", dontSendNotification);
+            triggerNoteLabel->setText (getNoteName (t, getFilter()->bottomOctave) + " (" + juce::String (t) + ")", juce::dontSendNotification);
         else
-            triggerNoteLabel->setText (getNoteNameWithoutOctave (t), dontSendNotification);
+            triggerNoteLabel->setText (getNoteNameWithoutOctave (t), juce::dontSendNotification);
     }
 
     if (presetNameLabel->getText() != getFilter()->getProgramName (p))
-        presetNameLabel->setText (getFilter()->getProgramName (p), dontSendNotification);
+        presetNameLabel->setText (getFilter()->getProgramName (p), juce::dontSendNotification);
 
     triggerKeyboard->repaint();
     chordKeyboard->repaint();
 }
 
-String const MidiChordsEditor::getCurrentChordName()
+juce::String const MidiChordsEditor::getCurrentChordName()
 {
     if (getFilter()->getParameter (kGuess) == 0.f)
-        return String();
+        return juce::String();
 
-    Array<int> chord;
+    juce::Array<int> chord;
     for (int n = 0; n < 128; n++)
     {
         for (int c = 1; c <= 16; c++)
@@ -1843,20 +1844,20 @@ String const MidiChordsEditor::getCurrentChordName()
     return getFirstRecognizedChord (chord, getFilter()->getParameter (kFlats) > 0.f);
 }
 
-void MidiChordsEditor::listChordFiles (StringArray& list)
+void MidiChordsEditor::listChordFiles (juce::StringArray& list)
 {
-    String chordPath = getFilter()->dataPath + File::getSeparatorString() + "chords";
+    juce::String chordPath = getFilter()->dataPath + juce::File::getSeparatorString() + "chords";
 
     if (guitarPreset >= 0 && guitar->isVisible())
-        chordPath += File::getSeparatorString() + getFilter()->guitarPresets[guitarPreset].chordFile;
+        chordPath += juce::File::getSeparatorString() + getFilter()->guitarPresets[guitarPreset].chordFile;
     else
-        chordPath += File::getSeparatorString() + "Chords.txt";
+        chordPath += juce::File::getSeparatorString() + "Chords.txt";
 
-    File chordFile = File (chordPath);
+    juce::File chordFile = juce::File (chordPath);
     if (! chordFile.exists())
-        chordFile = getFilter()->dataPath + File::getSeparatorString() + "chords" + File::getSeparatorString() + "Chords.txt";
+        chordFile = getFilter()->dataPath + juce::File::getSeparatorString() + "chords" + juce::File::getSeparatorString() + "Chords.txt";
 
-    StringArray s;
+    juce::StringArray s;
     s.addLines (chordFile.loadFileAsString());
     for (int line = 0; line < s.size(); line++)
     {
@@ -1864,7 +1865,7 @@ void MidiChordsEditor::listChordFiles (StringArray& list)
             list.add (s[line]);
     }
 
-    chordFile = getFilter()->dataPath + File::getSeparatorString() + "chords" + File::getSeparatorString() + "User.txt";
+    chordFile = getFilter()->dataPath + juce::File::getSeparatorString() + "chords" + juce::File::getSeparatorString() + "User.txt";
     s.clear();
     s.addLines (chordFile.loadFileAsString());
     for (int line = 0; line < s.size(); line++)
@@ -1874,11 +1875,11 @@ void MidiChordsEditor::listChordFiles (StringArray& list)
     }
 }
 
-void MidiChordsEditor::listPresetFiles (Array<File>& list)
+void MidiChordsEditor::listPresetFiles (juce::Array<juce::File>& list)
 {
-    File mappingsPath (getFilter()->dataPath + File::getSeparatorString() + "mappings");
-    Array<File> files;
-    mappingsPath.findChildFiles (files, File::findFiles, true);
+    juce::File mappingsPath (getFilter()->dataPath + juce::File::getSeparatorString() + "mappings");
+    juce::Array<juce::File> files;
+    mappingsPath.findChildFiles (files, juce::File::findFiles, true);
     for (int i = 0; i < files.size(); i++)
     {
         if (files[i].hasFileExtension ("chords") || files[i].hasFileExtension ("fxp") || files[i].hasFileExtension ("xml"))
@@ -1886,12 +1887,12 @@ void MidiChordsEditor::listPresetFiles (Array<File>& list)
     }
 }
 
-void MidiChordsEditor::loadChord (String chorddef)
+void MidiChordsEditor::loadChord (juce::String chorddef)
 {
     const int t = getFilter()->getCurrentTrigger();
     getFilter()->clearChord (t);
-    StringArray sa;
-    sa.addTokens (chorddef.fromLastOccurrenceOf (":", false, true), " ", String());
+    juce::StringArray sa;
+    sa.addTokens (chorddef.fromLastOccurrenceOf (":", false, true), " ", juce::String());
     for (int i = 0; i < sa.size(); i++)
     {
         if (sa[i].trim().isNotEmpty())
@@ -1906,7 +1907,7 @@ void MidiChordsEditor::loadChord (String chorddef)
         getFilter()->translateToGuitarChord();
 }
 
-void MidiChordsEditor::loadPreset (File file)
+void MidiChordsEditor::loadPreset (juce::File file)
 {
     if (file.hasFileExtension ("fxp"))
         getFilter()->loadFxpFile (file);
@@ -1920,7 +1921,7 @@ void MidiChordsEditor::loadPreset (File file)
 
         getFilter()->clearAllChords();
 
-        StringArray lines;
+        juce::StringArray lines;
         lines.addLines (file.loadFileAsString());
         for (int ln = 0; ln < lines.size(); ln++)
         {
@@ -1928,7 +1929,7 @@ void MidiChordsEditor::loadPreset (File file)
             {
                 if (lines[ln].upToFirstOccurrenceOf (":", false, false).equalsIgnoreCase ("Mode"))
                 {
-                    String s = lines[ln].fromLastOccurrenceOf (":", false, true);
+                    juce::String s = lines[ln].fromLastOccurrenceOf (":", false, true);
                     if (s.equalsIgnoreCase ("Full"))
                         getFilter()->setParameterNotifyingHost (kMode, ((float) Normal) / (float) (numModes - 1));
                     if (s.equalsIgnoreCase ("Octave"))
@@ -1940,8 +1941,8 @@ void MidiChordsEditor::loadPreset (File file)
                 {
                     int t = lines[ln].upToFirstOccurrenceOf (":", false, false).getIntValue();
                     //getFilter()->clearChord(t);
-                    StringArray sa;
-                    sa.addTokens (lines[ln].fromLastOccurrenceOf (":", false, true), " ", String());
+                    juce::StringArray sa;
+                    sa.addTokens (lines[ln].fromLastOccurrenceOf (":", false, true), " ", juce::String());
                     for (int i = 0; i < sa.size(); i++)
                     {
                         if (sa[i].trim().isNotEmpty())
@@ -1955,81 +1956,81 @@ void MidiChordsEditor::loadPreset (File file)
                 }
             }
         }
-        presetNameLabel->setText (file.getFileNameWithoutExtension(), dontSendNotification);
+        presetNameLabel->setText (file.getFileNameWithoutExtension(), juce::dontSendNotification);
         getFilter()->changeProgramName (getFilter()->getCurrentProgram(), file.getFileNameWithoutExtension());
         getFilter()->updateHostDisplay();
     }
 }
 
-void MidiChordsEditor::saveChord (String name)
+void MidiChordsEditor::saveChord (juce::String name)
 {
-    const int curProgram = getFilter()->getCurrentProgram();
-    const int t          = getFilter()->getCurrentTrigger();
-    String chordString   = name + ":";
+    const int curProgram     = getFilter()->getCurrentProgram();
+    const int t              = getFilter()->getCurrentTrigger();
+    juce::String chordString = name + ":";
     for (int c = 1; c <= 16; c++)
     {
         for (int n = 0; n < 128; n++)
         {
             if (getFilter()->progKbState[curProgram][t].isNoteOn (c, n))
-                chordString += " " + String (n - t) + "." + String (c);
+                chordString += " " + juce::String (n - t) + "." + juce::String (c);
         }
     }
-    File chordFile (getFilter()->dataPath + File::getSeparatorString() + "chords" + File::getSeparatorString() + "User.txt");
+    juce::File chordFile (getFilter()->dataPath + juce::File::getSeparatorString() + "chords" + juce::File::getSeparatorString() + "User.txt");
     if (chordFile.create())
         chordFile.appendText (chordString + "\n");
 }
 
-void MidiChordsEditor::textEditorTextChanged (TextEditor& editor)
+void MidiChordsEditor::textEditorTextChanged (juce::TextEditor& editor)
 {
 }
 
-void MidiChordsEditor::textEditorReturnKeyPressed (TextEditor& editor)
+void MidiChordsEditor::textEditorReturnKeyPressed (juce::TextEditor& editor)
 {
     if (&editor == chordSaveEditor.get())
     {
         saveChord (chordSaveEditor->getText());
-        PopupMenu::dismissAllActiveMenus();
+        juce::PopupMenu::dismissAllActiveMenus();
         chordSaveEditor->clear();
     }
     else if (&editor == tuningSaveEditor.get())
     {
-        String tuningString = "\"" + tuningSaveEditor->getText() + "\", "
-                            + String ("Chords.txt, ")
-                            + String (roundToInt (fretsSlider->getValue())) + " frets, ";
+        juce::String tuningString = "\"" + tuningSaveEditor->getText() + "\", "
+                                  + juce::String ("Chords.txt, ")
+                                  + juce::String (roundToInt (fretsSlider->getValue())) + " frets, ";
         for (int i = 0; i < roundToInt (stringsSlider->getValue()); i++)
         {
             if (i > 0)
                 tuningString += ",";
-            tuningString += String (roundToInt (stringSlider[i]->getValue()));
+            tuningString += juce::String (roundToInt (stringSlider[i]->getValue()));
         }
-        File tuningFile (getFilter()->dataPath + File::getSeparatorString() + "guitars" + File::getSeparatorString() + "GuitarPresets.txt");
+        juce::File tuningFile (getFilter()->dataPath + juce::File::getSeparatorString() + "guitars" + juce::File::getSeparatorString() + "GuitarPresets.txt");
         if (tuningFile.create())
             tuningFile.appendText (tuningString + "\n");
 
         getFilter()->fillGuitarPresetList();
-        PopupMenu::dismissAllActiveMenus();
+        juce::PopupMenu::dismissAllActiveMenus();
         tuningSaveEditor->clear();
     }
 }
 
-void MidiChordsEditor::textEditorEscapeKeyPressed (TextEditor& editor)
+void MidiChordsEditor::textEditorEscapeKeyPressed (juce::TextEditor& editor)
 {
-    PopupMenu::dismissAllActiveMenus();
+    juce::PopupMenu::dismissAllActiveMenus();
 }
 
-void MidiChordsEditor::textEditorFocusLost (TextEditor& editor)
+void MidiChordsEditor::textEditorFocusLost (juce::TextEditor& editor)
 {
 }
 
-void MidiChordsEditor::filesDropped (const StringArray& filenames, int mouseX, int mouseY)
+void MidiChordsEditor::filesDropped (const juce::StringArray& filenames, int mouseX, int mouseY)
 {
-    File file = File (filenames[0]);
+    juce::File file = juce::File (filenames[0]);
     if (file.hasFileExtension ("chords") || file.hasFileExtension ("fxp") || file.hasFileExtension ("fxb")
         || file.hasFileExtension ("xml"))
         loadPreset (file);
     else if (file.getFileName() == "midiChordsKey.txt" || file.getFileName() == "midiChordsKey.zip")
     {
-        getFilter()->readKeyFile (File (filenames[0]));
+        getFilter()->readKeyFile (juce::File (filenames[0]));
         if (! getFilter()->demo)
         {
             demoLabel->setVisible (false);
@@ -2037,9 +2038,9 @@ void MidiChordsEditor::filesDropped (const StringArray& filenames, int mouseX, i
     }
 }
 
-bool MidiChordsEditor::isInterestedInFileDrag (const StringArray& files)
+bool MidiChordsEditor::isInterestedInFileDrag (const juce::StringArray& files)
 {
-    File file = File (files[0]);
+    juce::File file = juce::File (files[0]);
     if (file.hasFileExtension ("chords") || file.hasFileExtension ("fxp") || file.hasFileExtension ("fxb") || file.hasFileExtension ("xml"))
         return true;
     if (file.getFileName() == "midiChordsKey.txt" || file.getFileName() == "midiChordsKey.zip")
@@ -2053,16 +2054,16 @@ void MidiChordsEditor::fileClicked (const juce::File& file, const juce::MouseEve
         loadPreset (file);
 }
 
-void MidiChordsEditor::fileDoubleClicked (const File& file)
+void MidiChordsEditor::fileDoubleClicked (const juce::File& file)
 {
     if (file.existsAsFile())
     {
         //loadPreset(file);
-        PopupMenu::dismissAllActiveMenus();
+        juce::PopupMenu::dismissAllActiveMenus();
     }
 }
 
-void MidiChordsEditor::browserRootChanged (const File& newRoot)
+void MidiChordsEditor::browserRootChanged (const juce::File& newRoot)
 {
 }
 

--- a/pizjuce/midiChords/MidiChordsEditor.h
+++ b/pizjuce/midiChords/MidiChordsEditor.h
@@ -20,9 +20,9 @@
 #pragma once
 
 //[Headers]     -- You can add your own extra header files here --
-#include "juce_audio_utils/juce_audio_utils.h"
-#include "juce_core/juce_core.h"
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_audio_utils/juce_audio_utils.h>
+#include <juce_core/juce_core.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
 #include "../_common/ChannelSlider.h"
 #include "../_common/NoteSlider.h"
@@ -31,29 +31,31 @@
 #include "GuitarNeckComponent.h"
 #include "MidiChords.h"
 
+using juce::jmin;
+
 class FretsSlider : public juce::Slider
 {
 public:
-    FretsSlider (String name) : juce::Slider (name){};
+    FretsSlider (juce::String name) : juce::Slider (name){};
     ~FretsSlider() override{};
 
-    String getTextFromValue (double value) override
+    juce::String getTextFromValue (double value) override
     {
-        const int n = roundToInt (value);
-        return "Frets: " + String (n);
+        const int n = juce::roundToInt (value);
+        return "Frets: " + juce::String (n);
     }
 };
 
 class StringsSlider : public juce::Slider
 {
 public:
-    StringsSlider (String name) : juce::Slider (name){};
+    StringsSlider (juce::String name) : juce::Slider (name){};
     ~StringsSlider() override{};
 
-    String getTextFromValue (double value) override
+    juce::String getTextFromValue (double value) override
     {
-        const int n = roundToInt (value);
-        return "Strings: " + String (n);
+        const int n = juce::roundToInt (value);
+        return "Strings: " + juce::String (n);
     }
 };
 
@@ -63,13 +65,13 @@ public:
     ChordPresetFileFilter()
         : juce::FileFilter ("midiChords presets") {}
     ~ChordPresetFileFilter() override {}
-    bool isFileSuitable (const File& file) const override
+    bool isFileSuitable (const juce::File& file) const override
     {
         return (file.hasFileExtension ("chords")
                 || file.hasFileExtension ("fxp")
                 || file.hasFileExtension ("xml"));
     }
-    bool isDirectorySuitable (const File& file) const override
+    bool isDirectorySuitable (const juce::File& file) const override
     {
         return true;
     }
@@ -78,9 +80,9 @@ public:
 class ChordsGuitar : public GuitarNeckComponent
 {
 public:
-    ChordsGuitar (MidiKeyboardState& state, MidiChords* ownerFilter)
+    ChordsGuitar (juce::MidiKeyboardState& state, MidiChords* ownerFilter)
         : GuitarNeckComponent (state),
-          owner (0),
+          owner (nullptr),
           erasing (false)
     {
         owner = ownerFilter;
@@ -89,11 +91,11 @@ public:
 
 private:
     MidiChords* owner;
-    MidiKeyboardState* s;
+    juce::MidiKeyboardState* s;
     FrettedNote lastDraggedNote;
     bool erasing;
 
-    void mouseDraggedToKey (int fret, int string, const MouseEvent& e) override
+    void mouseDraggedToKey (int fret, int string, const juce::MouseEvent& e) override
     {
         FrettedNote n (fret, string);
         if (n != lastDraggedNote)
@@ -115,7 +117,7 @@ private:
         lastDraggedNote = n;
     }
 
-    bool mouseDownOnKey (int fret, int string, const MouseEvent& e) override
+    bool mouseDownOnKey (int fret, int string, const juce::MouseEvent& e) override
     {
         FrettedNote n (fret, string);
         int midiNoteNumber  = getNote (n);
@@ -140,7 +142,7 @@ private:
 class ChordsKeyboardComponent : public juce::MidiKeyboardComponent
 {
 public:
-    ChordsKeyboardComponent (MidiKeyboardState& state, MidiChords* ownerFilter)
+    ChordsKeyboardComponent (juce::MidiKeyboardState& state, MidiChords* ownerFilter)
         : juce::MidiKeyboardComponent (state, MidiKeyboardComponent::horizontalKeyboard),
           owner (nullptr)
     {
@@ -149,15 +151,15 @@ public:
         this->setMidiChannel (1);
         this->setLowestVisibleKey (36);
     }
-    void drawBlackNote (int midiNoteNumber, Graphics& g, int x, int y, int w, int h, bool isDown, bool isOver, const Colour& textColour)
+    void drawBlackNote (int midiNoteNumber, juce::Graphics& g, int x, int y, int w, int h, bool isDown, bool isOver, const juce::Colour& textColour)
     {
-        Colour c (textColour);
+        juce::Colour c (textColour);
         const bool isReallyReallyDown = owner->getCurrentKbState()->isNoteOnForChannels (0xffff, midiNoteNumber);
 
         if (isReallyReallyDown)
             c = c.overlaidWith (findColour (keyDownOverlayColourId));
         else if (s->isNoteOnForChannels (0xffff, midiNoteNumber))
-            c = c.overlaidWith (Colours::brown.withAlpha (0.4f));
+            c = c.overlaidWith (juce::Colours::brown.withAlpha (0.4f));
 
         if (isOver)
             c = c.overlaidWith (findColour (mouseOverKeyOverlayColourId));
@@ -172,22 +174,22 @@ public:
         }
         else
         {
-            const int xIndent = jmax (1, jmin (w, h) / 8);
+            const int xIndent = juce::jmax (1, jmin (w, h) / 8);
 
             g.setColour (c.brighter());
             g.fillRect (x + xIndent, y, w - xIndent * 2, 7 * h / 8);
         }
-        Font f (jmin (12.0f, w * 0.9f));
+        juce::Font f (jmin (12.0f, w * 0.9f));
         f.setHorizontalScale (0.8f);
         g.setFont (f);
-        g.setColour (Colours::white);
-        g.drawFittedText (String (midiNoteNumber), x + 2, y + 2, w - 4, h - 4, Justification::centredBottom, 1);
+        g.setColour (juce::Colours::white);
+        g.drawFittedText (juce::String (midiNoteNumber), x + 2, y + 2, w - 4, h - 4, juce::Justification::centredBottom, 1);
     }
 
-    void drawWhiteNote (int midiNoteNumber, Graphics& g, int x, int y, int w, int h, bool isDown, bool isOver, const Colour& lineColour, const Colour& textColour)
+    void drawWhiteNote (int midiNoteNumber, juce::Graphics& g, int x, int y, int w, int h, bool isDown, bool isOver, const juce::Colour& lineColour, const juce::Colour& textColour)
     {
         //const int chordChan = roundToInt(owner->getParameter(kLearnChannel)*16.f);
-        Colour c (Colours::transparentWhite);
+        juce::Colour c (juce::Colours::transparentWhite);
         const bool isReallyReallyDown = owner->getCurrentKbState()->isNoteOnForChannels (0xffff, midiNoteNumber);
 
         if (isReallyReallyDown)
@@ -200,15 +202,15 @@ public:
 
         g.setColour (textColour);
 
-        Font f (jmin (12.0f, getKeyWidth() * 0.9f));
+        juce::Font f (jmin (12.0f, getKeyWidth() * 0.9f));
         f.setHorizontalScale (0.8f);
         f.setBold (midiNoteNumber == 60);
         g.setFont (f);
-        Justification justification (Justification::centredBottom);
+        juce::Justification justification (juce::Justification::centredBottom);
 
-        g.drawFittedText (String (midiNoteNumber), x + 2, y + 2, w - 4, h - 16, Justification::centredBottom, 1);
+        g.drawFittedText (juce::String (midiNoteNumber), x + 2, y + 2, w - 4, h - 16, juce::Justification::centredBottom, 1);
 
-        const String text (getWhiteNoteText (midiNoteNumber));
+        const juce::String text (getWhiteNoteText (midiNoteNumber));
         if (! text.isEmpty())
             g.drawFittedText (text, x + 2, y + 2, w - 4, h - 4, justification, 1);
         g.setColour (lineColour);
@@ -242,17 +244,17 @@ public:
 
 protected:
     MidiChords* owner;
-    MidiKeyboardState* s;
+    juce::MidiKeyboardState* s;
 
-    bool mouseDownOnKey (int midiNoteNumber, const MouseEvent& e) override
+    bool mouseDownOnKey (int midiNoteNumber, const juce::MouseEvent& e) override
     {
         if (e.mods.isPopupMenu())
         {
-            PopupMenu m;
-            m.addSectionHeader (getNoteName (midiNoteNumber, owner->bottomOctave) + " (" + String (midiNoteNumber) + ")");
+            juce::PopupMenu m;
+            m.addSectionHeader (getNoteName (midiNoteNumber, owner->bottomOctave) + " (" + juce::String (midiNoteNumber) + ")");
             for (int i = 1; i <= 16; i++)
             {
-                m.addItem (i, "Ch " + String (i), true, s->isNoteOn (i, midiNoteNumber));
+                m.addItem (i, "Ch " + juce::String (i), true, s->isNoteOn (i, midiNoteNumber));
             }
             int result = m.show();
             if (result != 0)
@@ -272,7 +274,7 @@ protected:
         }
         else
         {
-            const int chordChan = roundToInt (owner->getParameter (kLearnChannel) * 16.f);
+            const int chordChan = juce::roundToInt (owner->getParameter (kLearnChannel) * 16.f);
             if (chordChan == 0)
             {
                 if (s->isNoteOnForChannels (0xffff, midiNoteNumber))
@@ -308,7 +310,7 @@ protected:
         return false;
     }
 
-    void mouseUpOnKey (int midiNoteNumber, const MouseEvent& e) override
+    void mouseUpOnKey (int midiNoteNumber, const juce::MouseEvent& e) override
     {
         // In any case, a mouse up event leads to the key being switched off.
         // But if that key was just toggled to "on", we have to send a note on message again.
@@ -319,21 +321,21 @@ protected:
     }
 };
 
-class TriggerKeySelectorKeyboard : public MidiKeyboardComponent
+class TriggerKeySelectorKeyboard : public juce::MidiKeyboardComponent
 {
 public:
-    TriggerKeySelectorKeyboard (MidiKeyboardState& state, MidiChords* ownerFilter)
-        : MidiKeyboardComponent (state, MidiKeyboardComponent::horizontalKeyboard), owner (0)
+    TriggerKeySelectorKeyboard (juce::MidiKeyboardState& state, MidiChords* ownerFilter)
+        : MidiKeyboardComponent (state, MidiKeyboardComponent::horizontalKeyboard), owner (nullptr)
     {
         s     = &state;
         owner = ownerFilter;
         this->setMidiChannel (1);
         this->setLowestVisibleKey (36);
     }
-    void drawBlackNote (int midiNoteNumber, Graphics& g, int x, int y, int w, int h, bool isDown, bool isOver, const Colour& textColour)
+    void drawBlackNote (int midiNoteNumber, juce::Graphics& g, int x, int y, int w, int h, bool isDown, bool isOver, const juce::Colour& textColour)
     {
-        const int mode = roundToInt (owner->getParameter (kMode) * (numModes - 1));
-        Colour c (textColour);
+        const int mode = juce::roundToInt (owner->getParameter (kMode) * (numModes - 1));
+        juce::Colour c (textColour);
 
         if (isDown || owner->getCurrentTrigger() == midiNoteNumber)
             c = c.overlaidWith (findColour (keyDownOverlayColourId));
@@ -342,7 +344,7 @@ public:
             c = c.overlaidWith (findColour (mouseOverKeyOverlayColourId));
 
         if (owner->isNoteBypassed (midiNoteNumber))
-            c = c.overlaidWith (Colours::orange.withAlpha (0.6f));
+            c = c.overlaidWith (juce::Colours::orange.withAlpha (0.6f));
 
         if (mode == Octave)
         {
@@ -350,14 +352,14 @@ public:
             while (n < 128)
             {
                 if (owner->isTriggerNotePlaying (n))
-                    c = c.overlaidWith (Colours::green.withAlpha (0.6f));
+                    c = c.overlaidWith (juce::Colours::green.withAlpha (0.6f));
                 n += 12;
             }
         }
         else
         {
             if (owner->isTriggerNotePlaying (midiNoteNumber))
-                c = c.overlaidWith (Colours::green.withAlpha (0.6f));
+                c = c.overlaidWith (juce::Colours::green.withAlpha (0.6f));
         }
 
         g.setColour (c);
@@ -370,45 +372,45 @@ public:
         }
         else
         {
-            const int xIndent = jmax (1, jmin (w, h) / 8);
+            const int xIndent = juce::jmax (1, jmin (w, h) / 8);
 
             g.setColour (c.brighter());
             g.fillRect (x + xIndent, y, w - xIndent * 2, 7 * h / 8);
         }
-        if (roundToInt (owner->getParameter (kMode) * (numModes - 1)) != Octave)
+        if (juce::roundToInt (owner->getParameter (kMode) * (numModes - 1)) != Octave)
         {
-            Font f (jmin (12.0f, w * 0.9f));
+            juce::Font f (jmin (12.0f, w * 0.9f));
             f.setHorizontalScale (0.8f);
             g.setFont (f);
-            g.setColour (Colours::white);
-            g.drawFittedText (String (midiNoteNumber), x + 2, y + 2, w - 4, h - 4, Justification::centredBottom, 1);
+            g.setColour (juce::Colours::white);
+            g.drawFittedText (juce::String (midiNoteNumber), x + 2, y + 2, w - 4, h - 4, juce::Justification::centredBottom, 1);
         }
     }
-    void drawWhiteNote (int midiNoteNumber, Graphics& g, int x, int y, int w, int h, bool isDown, bool isOver, const Colour& lineColour, const Colour& textColour)
+    void drawWhiteNote (int midiNoteNumber, juce::Graphics& g, int x, int y, int w, int h, bool isDown, bool isOver, const juce::Colour& lineColour, const juce::Colour& textColour)
     {
-        const int mode = roundToInt (owner->getParameter (kMode) * (numModes - 1));
-        Colour c (Colours::transparentWhite);
+        const int mode = juce::roundToInt (owner->getParameter (kMode) * (numModes - 1));
+        juce::Colour c (juce::Colours::transparentWhite);
 
         if (isDown || owner->getCurrentTrigger() == midiNoteNumber)
             c = findColour (keyDownOverlayColourId);
         if (isOver)
             c = c.overlaidWith (findColour (mouseOverKeyOverlayColourId));
         if (owner->isNoteBypassed (midiNoteNumber))
-            c = c.overlaidWith (Colours::orange.withAlpha (0.6f));
+            c = c.overlaidWith (juce::Colours::orange.withAlpha (0.6f));
         if (mode == Octave)
         {
             int n = midiNoteNumber % 12;
             while (n < 128)
             {
                 if (owner->isTriggerNotePlaying (n))
-                    c = c.overlaidWith (Colours::green.withAlpha (0.6f));
+                    c = c.overlaidWith (juce::Colours::green.withAlpha (0.6f));
                 n += 12;
             }
         }
         else
         {
             if (owner->isTriggerNotePlaying (midiNoteNumber))
-                c = c.overlaidWith (Colours::green.withAlpha (0.6f));
+                c = c.overlaidWith (juce::Colours::green.withAlpha (0.6f));
         }
 
         g.setColour (c);
@@ -418,21 +420,21 @@ public:
         {
             g.setColour (textColour);
 
-            Font f (jmin (12.0f, getKeyWidth() * 0.9f));
+            juce::Font f (jmin (12.0f, getKeyWidth() * 0.9f));
             f.setHorizontalScale (0.8f);
             f.setBold (midiNoteNumber == 60);
             g.setFont (f);
-            Justification justification (Justification::centredBottom);
+            juce::Justification justification (juce::Justification::centredBottom);
 
-            g.drawFittedText (String (midiNoteNumber), x + 2, y + 2, w - 4, h - 16, Justification::centredBottom, 1);
+            g.drawFittedText (juce::String (midiNoteNumber), x + 2, y + 2, w - 4, h - 16, juce::Justification::centredBottom, 1);
 
-            const String text (getWhiteNoteText (midiNoteNumber));
+            const juce::String text (getWhiteNoteText (midiNoteNumber));
             if (! text.isEmpty())
                 g.drawFittedText (text, x + 2, y + 2, w - 4, h - 4, justification, 1);
         }
 
         if (mode == Global)
-            g.setColour (Colours::red);
+            g.setColour (juce::Colours::red);
         else
             g.setColour (lineColour);
 
@@ -445,11 +447,11 @@ public:
     }
 
 private:
-    MidiKeyboardState* s;
+    juce::MidiKeyboardState* s;
     MidiChords* owner;
     bool bypassing;
 
-    bool mouseDownOnKey (int midiNoteNumber, const MouseEvent& e) override
+    bool mouseDownOnKey (int midiNoteNumber, const juce::MouseEvent& e) override
     {
         if (e.mods.isShiftDown() || e.mods.isPopupMenu())
         {
@@ -459,7 +461,7 @@ private:
         }
         else
         {
-            if (roundToInt (owner->getParameter (kMode) * (numModes - 1)) == Global)
+            if (juce::roundToInt (owner->getParameter (kMode) * (numModes - 1)) == Global)
                 owner->setParameterNotifyingHost (kRoot, midiNoteNumber / 127.f);
             else
                 owner->selectTrigger (midiNoteNumber);
@@ -467,7 +469,7 @@ private:
         return false;
     }
 
-    void mouseUpOnKey (int midiNoteNumber, const MouseEvent& e) override
+    void mouseUpOnKey (int midiNoteNumber, const juce::MouseEvent& e) override
     {
         // In any case, a mouse up event leads to the key being switched off.
         // But if that key was just toggled to "on", we have to send a note on message again.
@@ -477,7 +479,7 @@ private:
         }
     }
 
-    bool mouseDraggedToKey (int midiNoteNumber, const MouseEvent& e) override
+    bool mouseDraggedToKey (int midiNoteNumber, const juce::MouseEvent& e) override
     {
         if (e.mods.isShiftDown() || e.mods.isPopupMenu())
         {
@@ -486,7 +488,7 @@ private:
         }
         else
         {
-            if (roundToInt (owner->getParameter (kMode) * (numModes - 1)) == Global)
+            if (juce::roundToInt (owner->getParameter (kMode) * (numModes - 1)) == Global)
                 owner->setParameterNotifyingHost (kRoot, midiNoteNumber / 127.f);
             else
                 owner->selectTrigger (midiNoteNumber);
@@ -527,20 +529,20 @@ public:
     friend class ChordsKeyboardComponent;
     friend class TriggerKeySelectorKeyboard;
     static void chordMenuCallback (int result, MidiChordsEditor* editor);
-    void textEditorTextChanged (TextEditor&) override;
-    void textEditorReturnKeyPressed (TextEditor&) override;
-    void textEditorEscapeKeyPressed (TextEditor&) override;
-    void textEditorFocusLost (TextEditor&) override;
-    void changeListenerCallback (ChangeBroadcaster* source) override;
-    bool isInterestedInFileDrag (const StringArray& files) override;
-    void filesDropped (const StringArray& filenames, int mouseX, int mouseY) override;
-    void mouseDown (const MouseEvent& e) override;
-    void mouseDoubleClick (const MouseEvent& e) override;
-    void mouseUp (const MouseEvent& e) override;
+    void textEditorTextChanged (juce::TextEditor&) override;
+    void textEditorReturnKeyPressed (juce::TextEditor&) override;
+    void textEditorEscapeKeyPressed (juce::TextEditor&) override;
+    void textEditorFocusLost (juce::TextEditor&) override;
+    void changeListenerCallback (juce::ChangeBroadcaster* source) override;
+    bool isInterestedInFileDrag (const juce::StringArray& files) override;
+    void filesDropped (const juce::StringArray& filenames, int mouseX, int mouseY) override;
+    void mouseDown (const juce::MouseEvent& e) override;
+    void mouseDoubleClick (const juce::MouseEvent& e) override;
+    void mouseUp (const juce::MouseEvent& e) override;
     void selectionChanged() override{};
     void fileClicked (const juce::File& file, const juce::MouseEvent&) override;
-    void fileDoubleClicked (const File& file) override;
-    void browserRootChanged (const File& newRoot) override;
+    void fileDoubleClicked (const juce::File& file) override;
+    void browserRootChanged (const juce::File& newRoot) override;
     //[/UserMethods]
 
     void paint (juce::Graphics& g) override;
@@ -555,15 +557,15 @@ public:
 
 private:
     //[UserVariables]   -- You can add your own custom variables in this section.
-    TooltipWindow tooltipWindow;
+    juce::TooltipWindow tooltipWindow;
     void updateParametersFromFilter();
-    String const getCurrentChordName();
-    void listChordFiles (StringArray& list);
-    void listPresetFiles (Array<File>& list);
-    void loadChord (String chorddef);
-    void saveChord (String name);
-    void loadPreset (File file);
-    void chordFromString (String chordString);
+    juce::String const getCurrentChordName();
+    void listChordFiles (juce::StringArray& list);
+    void listPresetFiles (juce::Array<juce::File>& list);
+    void loadChord (juce::String chorddef);
+    void saveChord (juce::String name);
+    void loadPreset (juce::File file);
+    void chordFromString (juce::String chordString);
 
     bool isGuitarPreset (int index)
     {
@@ -606,7 +608,7 @@ private:
     MidiChords* getFilter() const throw() { return (MidiChords*) getAudioProcessor(); }
     int mode;
     ChordPresetFileFilter fileFilter;
-    FileBrowserComponent* browser;
+    juce::FileBrowserComponent* browser;
 
     FretsSlider* fretsSlider;
     StringsSlider* stringsSlider;

--- a/pizjuce/midiChs/MidiChsEditor.cpp
+++ b/pizjuce/midiChs/MidiChsEditor.cpp
@@ -6,44 +6,44 @@ MidiChsEditor::MidiChsEditor (MidiChsProcessor* const ownerFilter)
 {
     setMouseClickGrabsKeyboardFocus (false);
 
-    bgcolor = Colour (getFilter()->getParameter (18), getFilter()->getParameter (19), getFilter()->getParameter (20), 1.0f);
-    fgcolor = Colour (bgcolor.contrasting (getFilter()->getParameter (21)));
+    bgcolor = juce::Colour (getFilter()->getParameter (18), getFilter()->getParameter (19), getFilter()->getParameter (20), 1.0f);
+    fgcolor = juce::Colour (bgcolor.contrasting (getFilter()->getParameter (21)));
 
-    addAndMakeVisible (resetButton = new TextButton ("reset"));
+    addAndMakeVisible (resetButton = new juce::TextButton ("reset"));
     resetButton->setButtonText ("Reset");
     resetButton->addListener (this);
-    resetButton->setColour (TextButton::buttonColourId, bgcolor);
-    resetButton->setColour (TextButton::textColourOnId, fgcolor);
-    resetButton->setColour (TextButton::textColourOffId, fgcolor);
+    resetButton->setColour (juce::TextButton::buttonColourId, bgcolor);
+    resetButton->setColour (juce::TextButton::textColourOnId, fgcolor);
+    resetButton->setColour (juce::TextButton::textColourOffId, fgcolor);
     resetButton->setMouseClickGrabsKeyboardFocus (false);
 
-    addAndMakeVisible (clearButton = new TextButton ("clear"));
+    addAndMakeVisible (clearButton = new juce::TextButton ("clear"));
     clearButton->setButtonText ("Clear");
     clearButton->addListener (this);
-    clearButton->setColour (TextButton::buttonColourId, bgcolor);
-    clearButton->setColour (TextButton::textColourOnId, fgcolor);
-    clearButton->setColour (TextButton::textColourOffId, fgcolor);
+    clearButton->setColour (juce::TextButton::buttonColourId, bgcolor);
+    clearButton->setColour (juce::TextButton::textColourOnId, fgcolor);
+    clearButton->setColour (juce::TextButton::textColourOffId, fgcolor);
     clearButton->setMouseClickGrabsKeyboardFocus (false);
 
     for (int i = 0; i < 16; i++)
     {
-        addAndMakeVisible (slider[i] = new Slider ("new slider"));
+        addAndMakeVisible (slider[i] = new juce::Slider ("new slider"));
         slider[i]->setRange (0, 16, 1);
-        slider[i]->setSliderStyle (Slider::LinearBar);
-        slider[i]->setTextBoxStyle (Slider::TextBoxLeft, false, 80, 20);
-        slider[i]->setColour (Slider::thumbColourId, Colour (0x5effff));
-        slider[i]->setColour (Slider::trackColourId, Colour (0x5e2b2b));
-        slider[i]->setColour (Slider::textBoxTextColourId, fgcolor);
-        slider[i]->setColour (Slider::textBoxOutlineColourId, Colour (0xff808080));
+        slider[i]->setSliderStyle (juce::Slider::LinearBar);
+        slider[i]->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 80, 20);
+        slider[i]->setColour (juce::Slider::thumbColourId, juce::Colour (0x5effff));
+        slider[i]->setColour (juce::Slider::trackColourId, juce::Colour (0x5e2b2b));
+        slider[i]->setColour (juce::Slider::textBoxTextColourId, fgcolor);
+        slider[i]->setColour (juce::Slider::textBoxOutlineColourId, juce::Colour (0xff808080));
         slider[i]->setValue ((getFilter()->getParameter (i)) * 16.0);
         slider[i]->addListener (this);
         slider[i]->setMouseClickGrabsKeyboardFocus (false);
 
-        addAndMakeVisible (label[i] = new Label ("new label", String (i + 1)));
-        label[i]->setFont (Font (15.0000f, Font::plain));
-        label[i]->setJustificationType (Justification::centred);
+        addAndMakeVisible (label[i] = new juce::Label ("new label", juce::String (i + 1)));
+        label[i]->setFont (juce::Font (15.0000f, juce::Font::plain));
+        label[i]->setJustificationType (juce::Justification::centred);
         label[i]->setEditable (false, false, false);
-        label[i]->setColour (Label::textColourId, fgcolor);
+        label[i]->setColour (juce::Label::textColourId, fgcolor);
         label[i]->setMouseClickGrabsKeyboardFocus (false);
     }
 
@@ -65,7 +65,7 @@ MidiChsEditor::~MidiChsEditor()
 }
 
 //==============================================================================
-void MidiChsEditor::paint (Graphics& g)
+void MidiChsEditor::paint (juce::Graphics& g)
 {
     g.fillAll (bgcolor);
 }
@@ -88,7 +88,7 @@ void MidiChsEditor::resized()
     getFilter()->lastUIHeight = getHeight();
 }
 
-void MidiChsEditor::buttonClicked (Button* buttonThatWasClicked)
+void MidiChsEditor::buttonClicked (juce::Button* buttonThatWasClicked)
 {
     if (buttonThatWasClicked == resetButton)
     {
@@ -105,7 +105,7 @@ void MidiChsEditor::buttonClicked (Button* buttonThatWasClicked)
         }
     }
 }
-void MidiChsEditor::sliderValueChanged (Slider* sliderThatWasMoved)
+void MidiChsEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
 {
     for (int i = 0; i < 16; i++)
     {
@@ -116,7 +116,7 @@ void MidiChsEditor::sliderValueChanged (Slider* sliderThatWasMoved)
     }
 }
 //==============================================================================
-void MidiChsEditor::changeListenerCallback (ChangeBroadcaster* source)
+void MidiChsEditor::changeListenerCallback (juce::ChangeBroadcaster* source)
 {
     // this is the filter telling us that it's changed, so we'll update our
     // display of the time, midi message, etc.
@@ -149,14 +149,14 @@ void MidiChsEditor::updateParametersFromFilter()
 
     // ..and after releasing the lock, we're free to do the time-consuming UI stuff..
 
-    bgcolor = Colour (hue, sat, bri, 1.0f);
-    fgcolor = Colour (bgcolor.contrasting (contrast));
+    bgcolor = juce::Colour (hue, sat, bri, 1.0f);
+    fgcolor = juce::Colour (bgcolor.contrasting (contrast));
 
     for (int i = 0; i < 16; i++)
     {
-        slider[i]->setValue ((float) ((int) (ch[i] * 16.0)), dontSendNotification);
-        slider[i]->setColour (Slider::textBoxTextColourId, fgcolor);
-        label[i]->setColour (Label::textColourId, fgcolor);
+        slider[i]->setValue ((float) ((int) (ch[i] * 16.0)), juce::dontSendNotification);
+        slider[i]->setColour (juce::Slider::textBoxTextColourId, fgcolor);
+        label[i]->setColour (juce::Label::textColourId, fgcolor);
     }
     if (reset == 1.0f)
     {
@@ -170,10 +170,10 @@ void MidiChsEditor::updateParametersFromFilter()
         getFilter()->setParameterNotifyingHost (17, 0.0f);
         clearButton->triggerClick();
     }
-    resetButton->setColour (TextButton::textColourOnId, fgcolor);
-    resetButton->setColour (TextButton::buttonColourId, bgcolor);
-    clearButton->setColour (TextButton::textColourOnId, fgcolor);
-    clearButton->setColour (TextButton::buttonColourId, bgcolor);
+    resetButton->setColour (juce::TextButton::textColourOnId, fgcolor);
+    resetButton->setColour (juce::TextButton::buttonColourId, bgcolor);
+    clearButton->setColour (juce::TextButton::textColourOnId, fgcolor);
+    clearButton->setColour (juce::TextButton::buttonColourId, bgcolor);
     repaint();
     setSize (filter->lastUIWidth, filter->lastUIHeight);
 }

--- a/pizjuce/midiChs/MidiChsEditor.h
+++ b/pizjuce/midiChs/MidiChsEditor.h
@@ -1,7 +1,7 @@
 #ifndef MIDICHSPLUGINEDITOR_H
 #define MIDICHSPLUGINEDITOR_H
 
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_gui_basics/juce_gui_basics.h>
 
 #include "MidiChsProcessor.h"
 
@@ -18,10 +18,10 @@
     when it's destroyed. When the filter's parameters are changed, it broadcasts
     a message and this editor responds by updating its display.
 */
-class MidiChsEditor : public AudioProcessorEditor,
-                      public ChangeListener,
-                      public Slider::Listener,
-                      public Button::Listener
+class MidiChsEditor : public juce::AudioProcessorEditor,
+                      public juce::ChangeListener,
+                      public juce::Slider::Listener,
+                      public juce::Button::Listener
 {
 public:
     /** Constructor.
@@ -38,27 +38,27 @@ public:
     /** Our demo filter is a ChangeBroadcaster, and will call us back when one of
         its parameters changes.
     */
-    void changeListenerCallback (ChangeBroadcaster* source) override;
+    void changeListenerCallback (juce::ChangeBroadcaster* source) override;
 
     //==============================================================================
     /** Standard Juce paint callback. */
-    void paint (Graphics& g) override;
+    void paint (juce::Graphics& g) override;
 
     /** Standard Juce resize callback. */
     void resized() override;
 
-    void buttonClicked (Button*) override;
-    void sliderValueChanged (Slider* sliderThatWasMoved) override;
+    void buttonClicked (juce::Button*) override;
+    void sliderValueChanged (juce::Slider* sliderThatWasMoved) override;
 
 private:
     //==============================================================================
     //Label* infoLabel[16];
-    Colour bgcolor, fgcolor;
-    TextButton* resetButton;
-    TextButton* clearButton;
-    Slider* slider[16];
-    Label* label[16];
-    TooltipWindow tooltipWindow;
+    juce::Colour bgcolor, fgcolor;
+    juce::TextButton* resetButton;
+    juce::TextButton* clearButton;
+    juce::Slider* slider[16];
+    juce::Label* label[16];
+    juce::TooltipWindow tooltipWindow;
 
     void updateParametersFromFilter();
 

--- a/pizjuce/midiChs/MidiChsProcessor.cpp
+++ b/pizjuce/midiChs/MidiChsProcessor.cpp
@@ -210,167 +210,167 @@ void MidiChsProcessor::setParameter (int index, float newValue)
     sendChangeMessage();
 }
 
-const String MidiChsProcessor::getParameterName (int index)
+const juce::String MidiChsProcessor::getParameterName (int index)
 {
     switch (index)
     {
         case 0:
-            return String ("1");
+            return juce::String ("1");
             break;
         case 1:
-            return String ("2");
+            return juce::String ("2");
             break;
         case 2:
-            return String ("3");
+            return juce::String ("3");
             break;
         case 3:
-            return String ("4");
+            return juce::String ("4");
             break;
         case 4:
-            return String ("5");
+            return juce::String ("5");
             break;
         case 5:
-            return String ("6");
+            return juce::String ("6");
             break;
         case 6:
-            return String ("7");
+            return juce::String ("7");
             break;
         case 7:
-            return String ("8");
+            return juce::String ("8");
             break;
         case 8:
-            return String ("9");
+            return juce::String ("9");
             break;
         case 9:
-            return String ("10");
+            return juce::String ("10");
             break;
         case 10:
-            return String ("11");
+            return juce::String ("11");
             break;
         case 11:
-            return String ("12");
+            return juce::String ("12");
             break;
         case 12:
-            return String ("13");
+            return juce::String ("13");
             break;
         case 13:
-            return String ("14");
+            return juce::String ("14");
             break;
         case 14:
-            return String ("15");
+            return juce::String ("15");
             break;
         case 15:
-            return String ("16");
+            return juce::String ("16");
             break;
         case 16:
-            return String ("Reset");
+            return juce::String ("Reset");
             break;
         case 17:
-            return String ("Clear");
+            return juce::String ("Clear");
             break;
         case 18:
-            return String ("Hue");
+            return juce::String ("Hue");
             break;
         case 19:
-            return String ("Saturation");
+            return juce::String ("Saturation");
             break;
         case 20:
-            return String ("Brightness");
+            return juce::String ("Brightness");
             break;
         case 21:
-            return String ("Contrast");
+            return juce::String ("Contrast");
             break;
 
         default:
-            return String();
+            return juce::String();
             break;
     }
 }
 
-const String MidiChsProcessor::getParameterText (int index)
+const juce::String MidiChsProcessor::getParameterText (int index)
 {
     switch (index)
     {
         case 0:
-            return String ((int) (fChannel1 * 16.0));
+            return juce::String ((int) (fChannel1 * 16.0));
             break;
         case 1:
-            return String ((int) (fChannel2 * 16.0));
+            return juce::String ((int) (fChannel2 * 16.0));
             break;
         case 2:
-            return String ((int) (fChannel3 * 16.0));
+            return juce::String ((int) (fChannel3 * 16.0));
             break;
         case 3:
-            return String ((int) (fChannel4 * 16.0));
+            return juce::String ((int) (fChannel4 * 16.0));
             break;
         case 4:
-            return String ((int) (fChannel5 * 16.0));
+            return juce::String ((int) (fChannel5 * 16.0));
             break;
         case 5:
-            return String ((int) (fChannel6 * 16.0));
+            return juce::String ((int) (fChannel6 * 16.0));
             break;
         case 6:
-            return String ((int) (fChannel7 * 16.0));
+            return juce::String ((int) (fChannel7 * 16.0));
             break;
         case 7:
-            return String ((int) (fChannel8 * 16.0));
+            return juce::String ((int) (fChannel8 * 16.0));
             break;
         case 8:
-            return String ((int) (fChannel9 * 16.0));
+            return juce::String ((int) (fChannel9 * 16.0));
             break;
         case 9:
-            return String ((int) (fChannel10 * 16.0));
+            return juce::String ((int) (fChannel10 * 16.0));
             break;
         case 10:
-            return String ((int) (fChannel11 * 16.0));
+            return juce::String ((int) (fChannel11 * 16.0));
             break;
         case 11:
-            return String ((int) (fChannel12 * 16.0));
+            return juce::String ((int) (fChannel12 * 16.0));
             break;
         case 12:
-            return String ((int) (fChannel13 * 16.0));
+            return juce::String ((int) (fChannel13 * 16.0));
             break;
         case 13:
-            return String ((int) (fChannel14 * 16.0));
+            return juce::String ((int) (fChannel14 * 16.0));
             break;
         case 14:
-            return String ((int) (fChannel15 * 16.0));
+            return juce::String ((int) (fChannel15 * 16.0));
             break;
         case 15:
-            return String ((int) (fChannel16 * 16.0));
+            return juce::String ((int) (fChannel16 * 16.0));
             break;
         case 16:
-            return String (fReset);
+            return juce::String (fReset);
             break;
         case 17:
-            return String (fClear);
+            return juce::String (fClear);
             break;
         case 18:
-            return String (bghue);
+            return juce::String (bghue);
             break;
         case 19:
-            return String (bgsat);
+            return juce::String (bgsat);
             break;
         case 20:
-            return String (bgbri);
+            return juce::String (bgbri);
             break;
         case 21:
-            return String (contrast);
+            return juce::String (contrast);
             break;
 
         default:
-            return String();
+            return juce::String();
             break;
     }
 }
-const String MidiChsProcessor::getInputChannelName (const int channelIndex) const
+const juce::String MidiChsProcessor::getInputChannelName (const int channelIndex) const
 {
-    return String (channelIndex + 1);
+    return juce::String (channelIndex + 1);
 }
 
-const String MidiChsProcessor::getOutputChannelName (const int channelIndex) const
+const juce::String MidiChsProcessor::getOutputChannelName (const int channelIndex) const
 {
-    return String (channelIndex + 1);
+    return juce::String (channelIndex + 1);
 }
 
 bool MidiChsProcessor::isInputChannelStereoPair (int index) const
@@ -395,22 +395,22 @@ void MidiChsProcessor::releaseResources()
     // spare memory, etc.
 }
 
-void MidiChsProcessor::processBlock (AudioSampleBuffer& buffer,
-                                     MidiBuffer& midiMessages)
+void MidiChsProcessor::processBlock (juce::AudioSampleBuffer& buffer,
+                                     juce::MidiBuffer& midiMessages)
 {
     for (int i = getNumInputChannels(); i < getNumOutputChannels(); ++i)
     {
         buffer.clear (i, 0, buffer.getNumSamples());
     }
 
-    MidiBuffer midiout;
+    juce::MidiBuffer midiout;
     bool discard = false;
     for (auto&& msgMetadata : midiMessages)
     {
         auto midi_message  = msgMetadata.getMessage();
         auto sample_number = msgMetadata.samplePosition;
 
-        MidiMessage out_message = midi_message;
+        juce::MidiMessage out_message = midi_message;
         short ch[16];
         ch[0]  = (short int) (fChannel1 * 16);
         ch[1]  = (short int) (fChannel2 * 16);
@@ -450,13 +450,13 @@ void MidiChsProcessor::processBlock (AudioSampleBuffer& buffer,
 }
 
 //==============================================================================
-AudioProcessorEditor* MidiChsProcessor::createEditor()
+juce::AudioProcessorEditor* MidiChsProcessor::createEditor()
 {
     return new MidiChsEditor (this);
 }
 
 //==============================================================================
-void MidiChsProcessor::getStateInformation (MemoryBlock& destData)
+void MidiChsProcessor::getStateInformation (juce::MemoryBlock& destData)
 {
     // you can store your parameters as binary data if you want to or if you've got
     // a load of binary to put in there, but if you're not doing anything too heavy,
@@ -464,7 +464,7 @@ void MidiChsProcessor::getStateInformation (MemoryBlock& destData)
     // params as XML..
 
     // create an outer XML element..
-    XmlElement xmlState ("MYPLUGINSETTINGS");
+    juce::XmlElement xmlState ("MYPLUGINSETTINGS");
 
     // add some attributes to it..
     xmlState.setAttribute ("1", fChannel1);

--- a/pizjuce/midiChs/MidiChsProcessor.h
+++ b/pizjuce/midiChs/MidiChsProcessor.h
@@ -1,13 +1,13 @@
 #ifndef MIDICHSPLUGINFILTER_H
 #define MIDICHSPLUGINFILTER_H
 
-#include "juce_events/juce_events.h"
+#include <juce_events/juce_events.h>
 
 #include "../_common/PizAudioProcessor.h"
 
 //==============================================================================
 class MidiChsProcessor : public PizAudioProcessor,
-                         public ChangeBroadcaster
+                         public juce::ChangeBroadcaster
 {
 public:
     //==============================================================================
@@ -18,14 +18,14 @@ public:
     void prepareToPlay (double sampleRate, int samplesPerBlock) override;
     void releaseResources() override;
 
-    void processBlock (AudioSampleBuffer& buffer,
-                       MidiBuffer& midiMessages) override;
+    void processBlock (juce::AudioSampleBuffer& buffer,
+                       juce::MidiBuffer& midiMessages) override;
 
     //==============================================================================
-    AudioProcessorEditor* createEditor() override;
+    juce::AudioProcessorEditor* createEditor() override;
 
     //==============================================================================
-    const String getName() const override { return JucePlugin_Name; }
+    const juce::String getName() const override { return JucePlugin_Name; }
     bool hasEditor() const override { return true; }
     bool acceptsMidi() const override
     {
@@ -49,11 +49,11 @@ public:
     float getParameter (int index) override;
     void setParameter (int index, float newValue) override;
 
-    const String getParameterName (int index) override;
-    const String getParameterText (int index) override;
+    const juce::String getParameterName (int index) override;
+    const juce::String getParameterText (int index) override;
 
-    const String getInputChannelName (int channelIndex) const override;
-    const String getOutputChannelName (int channelIndex) const override;
+    const juce::String getInputChannelName (int channelIndex) const override;
+    const juce::String getOutputChannelName (int channelIndex) const override;
     bool isInputChannelStereoPair (int index) const override;
     bool isOutputChannelStereoPair (int index) const override;
 
@@ -61,12 +61,12 @@ public:
     int getNumPrograms() override { return 0; }
     int getCurrentProgram() override { return 0; }
     void setCurrentProgram (int index) override {}
-    const String getProgramName (int index) override { return String(); }
-    void changeProgramName (int index, const String& newName) override {}
+    const juce::String getProgramName (int index) override { return juce::String(); }
+    void changeProgramName (int index, const juce::String& newName) override {}
     double getTailLengthSeconds() const override { return 0; }
 
     //==============================================================================
-    void getStateInformation (MemoryBlock& destData) override;
+    void getStateInformation (juce::MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
 
     //==============================================================================
@@ -78,12 +78,9 @@ public:
     // resized.
     int lastUIWidth, lastUIHeight;
 
-    //==============================================================================
-    juce_UseDebuggingNewOperator
-
-        private :
-        //parameters
-        float fChannel1;
+private:
+    //parameters
+    float fChannel1;
     float fChannel2;
     float fChannel3;
     float fChannel4;
@@ -105,6 +102,8 @@ public:
     float bgsat;
     float bgbri;
     float contrast;
+
+    JUCE_LEAK_DETECTOR (MidiChsProcessor)
 };
 
 #endif

--- a/pizjuce/midiCurve/MidiEnvelope.cpp
+++ b/pizjuce/midiCurve/MidiEnvelope.cpp
@@ -1,33 +1,37 @@
 #include "MidiEnvelope.h"
 
+using juce::jmax;
+using juce::jmin;
+using juce::roundToInt;
+
 //==============================================================================
 MidiEnvelope::MidiEnvelope (const int envelopeType_,
-                            AudioProcessorEditor* owner_,
+                            juce::AudioProcessorEditor* owner_,
                             MidiCurve* plugin_)
     : owner (owner_),
       plugin (plugin_),
       draggingPoint (-1),
       hoveringPoint (-1),
-      labelX (0),
-      labelY (0)
+      labelX (nullptr),
+      labelY (nullptr)
 {
-    addAndMakeVisible (labelX = new Label ("x label",
-                                           "x: --"));
-    labelX->setFont (Font (15.0000f, Font::plain));
-    labelX->setJustificationType (Justification::centredLeft);
+    addAndMakeVisible (labelX = new juce::Label ("x label",
+                                                 "x: --"));
+    labelX->setFont (juce::Font (15.0000f, juce::Font::plain));
+    labelX->setJustificationType (juce::Justification::centredLeft);
     labelX->setEditable (false, false, false);
-    labelX->setColour (TextEditor::textColourId, Colours::black);
-    labelX->setColour (TextEditor::backgroundColourId, Colour (0x0));
+    labelX->setColour (juce::TextEditor::textColourId, juce::Colours::black);
+    labelX->setColour (juce::TextEditor::backgroundColourId, juce::Colour (0x0));
     labelX->setOpaque (false);
     labelX->setInterceptsMouseClicks (false, false);
 
-    addAndMakeVisible (labelY = new Label ("y label",
-                                           "y: --"));
-    labelY->setFont (Font (15.0000f, Font::plain));
-    labelY->setJustificationType (Justification::centredLeft);
+    addAndMakeVisible (labelY = new juce::Label ("y label",
+                                                 "y: --"));
+    labelY->setFont (juce::Font (15.0000f, juce::Font::plain));
+    labelY->setJustificationType (juce::Justification::centredLeft);
     labelY->setEditable (false, false, false);
-    labelY->setColour (TextEditor::textColourId, Colours::black);
-    labelY->setColour (TextEditor::backgroundColourId, Colour (0x0));
+    labelY->setColour (juce::TextEditor::textColourId, juce::Colours::black);
+    labelY->setColour (juce::TextEditor::backgroundColourId, juce::Colour (0x0));
     labelY->setOpaque (false);
     labelY->setInterceptsMouseClicks (false, false);
 
@@ -54,25 +58,25 @@ void MidiEnvelope::resized()
 }
 
 //==============================================================================
-void MidiEnvelope::paint (Graphics& g)
+void MidiEnvelope::paint (juce::Graphics& g)
 {
     const int dotSize     = MAX_ENVELOPE_DOT_SIZE;
     const int halfDotSize = dotSize / 2;
 
-    g.fillAll (Colour (0xffffffff));
+    g.fillAll (juce::Colour (0xffffffff));
 
     for (int grid = 1; grid < 127; grid++)
     {
         float inc = 1.f / 127.f;
         if (grid == 64)
         { //center line
-            g.setColour (Colours::blueviolet);
+            g.setColour (juce::Colours::blueviolet);
             g.drawHorizontalLine ((int) (((float) (127 - grid) * inc) * (float) getHeight()), 0, (float) getWidth());
             g.drawVerticalLine ((int) (((float) grid * inc) * (float) getWidth()), 0, (float) getHeight());
         }
         else if (grid % 16 == 0)
         {
-            g.setColour (Colours::lightgrey);
+            g.setColour (juce::Colours::lightgrey);
             g.drawHorizontalLine ((int) (((float) (127 - grid) * inc) * (float) getHeight()), 0, (float) getWidth());
             g.drawVerticalLine ((int) (((float) grid * inc) * (float) getWidth()), 0, (float) getHeight());
         }
@@ -86,12 +90,12 @@ void MidiEnvelope::paint (Graphics& g)
         //	g.setPixel(((float)grid*inc)*getWidth(),((float)(127-grid)*inc)*getHeight());
         //}
     }
-    Path myPath = plugin->path;
-    myPath.applyTransform (AffineTransform::scale ((float) getWidth(), (float) getHeight()));
-    g.setColour (Colours::black);
-    g.strokePath (myPath, PathStrokeType (2.0f));
+    juce::Path myPath = plugin->path;
+    myPath.applyTransform (juce::AffineTransform::scale ((float) getWidth(), (float) getHeight()));
+    g.setColour (juce::Colours::black);
+    g.strokePath (myPath, juce::PathStrokeType (2.0f));
 
-    g.setColour (Colours::black);
+    g.setColour (juce::Colours::black);
     g.drawEllipse ((float) getWidth() * (float) roundToInt (127.0 * (mouseDownPoint.getX() / (double) getWidth())) / 127.f - 2,
                    (float) getHeight() * (float) roundToInt (127.0 * (mouseDownPoint.getY() / (double) getHeight())) / 127.f - 2,
                    4,
@@ -104,28 +108,28 @@ void MidiEnvelope::paint (Graphics& g)
 
         if (isPointActive (i))
         {
-            g.setColour (Colours::white);
+            g.setColour (juce::Colours::white);
             g.fillEllipse ((float) (x - halfDotSize), (float) (y - halfDotSize), (float) dotSize, (float) dotSize);
             if (draggingPoint == i)
             {
-                g.setColour (Colours::red);
+                g.setColour (juce::Colours::red);
                 g.drawHorizontalLine (y, 0, (float) getWidth());
                 g.drawVerticalLine (x, 0, (float) getHeight());
-                g.setColour (Colours::black);
+                g.setColour (juce::Colours::black);
                 g.fillEllipse ((float) (x - halfDotSize), (float) (y - halfDotSize), (float) dotSize, (float) dotSize);
-                g.setColour (Colours::red);
+                g.setColour (juce::Colours::red);
                 g.drawEllipse ((float) (x - halfDotSize), (float) (y - halfDotSize), (float) dotSize, (float) dotSize, 2.f);
             }
             else if (hoveringPoint == i)
             {
-                g.setColour (Colours::green);
+                g.setColour (juce::Colours::green);
                 g.drawHorizontalLine (y, 0, (float) getWidth());
                 g.drawVerticalLine (x, 0, (float) getHeight());
                 g.fillEllipse ((float) (x - halfDotSize), (float) (y - halfDotSize), (float) dotSize, (float) dotSize);
             }
             else
             {
-                g.setColour (Colours::black);
+                g.setColour (juce::Colours::black);
                 if (i == 0 || i == (MAX_ENVELOPE_POINTS - 1))
                     g.drawEllipse ((float) (x - halfDotSize), (float) (y - halfDotSize), (float) dotSize, (float) dotSize, 3.f);
                 else
@@ -133,7 +137,7 @@ void MidiEnvelope::paint (Graphics& g)
             }
             if (isPointControl (i))
             {
-                g.setColour (Colours::blue);
+                g.setColour (juce::Colours::blue);
                 g.drawEllipse ((float) (x - dotSize), (float) (y - dotSize), (float) (dotSize * 2), (float) (dotSize * 2), 1.f);
                 //g.setColour (Colours::lightblue);
                 //float dashes[2] = {2.f,2.f};
@@ -164,7 +168,7 @@ void MidiEnvelope::paint (Graphics& g)
 }
 
 //==============================================================================
-void MidiEnvelope::mouseDown (const MouseEvent& e)
+void MidiEnvelope::mouseDown (const juce::MouseEvent& e)
 {
     draggingPoint = findPointByMousePos (e.x, e.y);
     if (draggingPoint != -1)
@@ -190,10 +194,10 @@ void MidiEnvelope::mouseDown (const MouseEvent& e)
         }
         else
         {
-            labelX->setColour (Label::textColourId, Colours::red);
-            labelY->setColour (Label::textColourId, Colours::red);
-            labelX->setText ("x: " + String (roundToInt (127.f * points[draggingPoint][0])), dontSendNotification);
-            labelY->setText ("y: " + String (roundToInt (127.f * (1.f - points[draggingPoint][1]))), dontSendNotification);
+            labelX->setColour (juce::Label::textColourId, juce::Colours::red);
+            labelY->setColour (juce::Label::textColourId, juce::Colours::red);
+            labelX->setText ("x: " + juce::String (roundToInt (127.f * points[draggingPoint][0])), juce::dontSendNotification);
+            labelY->setText ("y: " + juce::String (roundToInt (127.f * (1.f - points[draggingPoint][1]))), juce::dontSendNotification);
         }
     }
     else
@@ -233,7 +237,7 @@ int MidiEnvelope::findInactivePoint()
     return -1;
 }
 
-void MidiEnvelope::mouseDoubleClick (const MouseEvent& e)
+void MidiEnvelope::mouseDoubleClick (const juce::MouseEvent& e)
 {
     int p = findPointByMousePos (e.x, e.y);
     if (p != -1)
@@ -251,7 +255,7 @@ void MidiEnvelope::mouseDoubleClick (const MouseEvent& e)
     repaint();
 }
 
-void MidiEnvelope::mouseDrag (const MouseEvent& e)
+void MidiEnvelope::mouseDrag (const juce::MouseEvent& e)
 {
     int restrict = 0;
     if (e.mods.isCommandDown())
@@ -295,10 +299,10 @@ void MidiEnvelope::mouseDrag (const MouseEvent& e)
 
         plugin->setParameterNotifyingHost ((paramNumber + 1), (1.f - points[draggingPoint][1]));
 
-        labelX->setColour (Label::textColourId, Colours::red);
-        labelY->setColour (Label::textColourId, Colours::red);
-        labelX->setText ("x: " + String (roundToInt (127.f * points[draggingPoint][0])), dontSendNotification);
-        labelY->setText ("y: " + String (roundToInt (127.f * (1.f - points[draggingPoint][1]))), dontSendNotification);
+        labelX->setColour (juce::Label::textColourId, juce::Colours::red);
+        labelY->setColour (juce::Label::textColourId, juce::Colours::red);
+        labelX->setText ("x: " + juce::String (roundToInt (127.f * points[draggingPoint][0])), juce::dontSendNotification);
+        labelY->setText ("y: " + juce::String (roundToInt (127.f * (1.f - points[draggingPoint][1]))), juce::dontSendNotification);
 
         repaint();
     }
@@ -326,22 +330,22 @@ void MidiEnvelope::mouseDrag (const MouseEvent& e)
                 plugin->setParameterNotifyingHost ((i * 2 + 1), (1.f - points[i][1]));
             }
         }
-        labelX->setColour (Label::textColourId, Colours::black);
-        labelY->setColour (Label::textColourId, Colours::black);
+        labelX->setColour (juce::Label::textColourId, juce::Colours::black);
+        labelY->setColour (juce::Label::textColourId, juce::Colours::black);
         repaint();
     }
 }
 
-void MidiEnvelope::mouseUp (const MouseEvent& e)
+void MidiEnvelope::mouseUp (const juce::MouseEvent& e)
 {
-    labelX->setColour (Label::textColourId, Colours::black);
-    labelY->setColour (Label::textColourId, Colours::black);
+    labelX->setColour (juce::Label::textColourId, juce::Colours::black);
+    labelY->setColour (juce::Label::textColourId, juce::Colours::black);
     draggingPoint = -1;
 
     repaint();
 }
 
-void MidiEnvelope::mouseMove (const MouseEvent& e)
+void MidiEnvelope::mouseMove (const juce::MouseEvent& e)
 {
     hoveringPoint = findPointByMousePos (e.x, e.y);
     if (hoveringPoint != -1)
@@ -353,19 +357,19 @@ void MidiEnvelope::mouseMove (const MouseEvent& e)
 
         //labelX->setTopLeftPosition(x,y);
         //labelY->setTopLeftPosition(x,y+labelX->getHeight());
-        labelX->setColour (Label::textColourId, Colours::green);
-        labelY->setColour (Label::textColourId, Colours::green);
-        labelX->setText ("x: " + String (roundToInt (127.f * points[hoveringPoint][0])), dontSendNotification);
-        labelY->setText ("y: " + String (roundToInt (127.f * (1.f - points[hoveringPoint][1]))), dontSendNotification);
+        labelX->setColour (juce::Label::textColourId, juce::Colours::green);
+        labelY->setColour (juce::Label::textColourId, juce::Colours::green);
+        labelX->setText ("x: " + juce::String (roundToInt (127.f * points[hoveringPoint][0])), juce::dontSendNotification);
+        labelY->setText ("y: " + juce::String (roundToInt (127.f * (1.f - points[hoveringPoint][1]))), juce::dontSendNotification);
     }
     else
     {
         //labelX->setTopLeftPosition(e.x+16,e.y);
         //labelY->setTopLeftPosition(e.x+16,e.y+labelX->getHeight());
-        labelX->setColour (Label::textColourId, Colours::black);
-        labelY->setColour (Label::textColourId, Colours::black);
-        labelX->setText ("x: " + String (roundToInt (127.f * (float) e.x / (float) getWidth())), dontSendNotification);
-        labelY->setText ("y: " + String (roundToInt (127.f * (1.f - (float) e.y / (float) getHeight()))), dontSendNotification);
+        labelX->setColour (juce::Label::textColourId, juce::Colours::black);
+        labelY->setColour (juce::Label::textColourId, juce::Colours::black);
+        labelX->setText ("x: " + juce::String (roundToInt (127.f * (float) e.x / (float) getWidth())), juce::dontSendNotification);
+        labelY->setText ("y: " + juce::String (roundToInt (127.f * (1.f - (float) e.y / (float) getHeight()))), juce::dontSendNotification);
     }
 
     repaint();

--- a/pizjuce/midiCurve/MidiEnvelope.h
+++ b/pizjuce/midiCurve/MidiEnvelope.h
@@ -3,7 +3,7 @@
 
 #include "curve.h"
 
-class MidiIndicator : public Component
+class MidiIndicator : public juce::Component
 {
     friend class MidiEnvelope;
 
@@ -15,12 +15,12 @@ public:
     }
     ~MidiIndicator() override {}
 
-    void paint (Graphics& g) override
+    void paint (juce::Graphics& g) override
     {
         const int dotSize     = MAX_ENVELOPE_DOT_SIZE;
         const int halfDotSize = dotSize / 2;
-        g.fillAll (Colours::transparentBlack);
-        g.setColour (Colours::darkgoldenrod);
+        g.fillAll (juce::Colours::transparentBlack);
+        g.setColour (juce::Colours::darkgoldenrod);
         g.drawVerticalLine ((int) ((float) (inmsg * getWidth()) * fmidiScaler),
                             (float) getHeight() - (float) (outmsg * getHeight()) * fmidiScaler,
                             (float) getHeight());
@@ -35,12 +35,12 @@ private:
 };
 
 //==============================================================================
-class MidiEnvelope : public Component
+class MidiEnvelope : public juce::Component
 {
 public:
     //==============================================================================
     MidiEnvelope (const int envelopeType,
-                  AudioProcessorEditor* owner,
+                  juce::AudioProcessorEditor* owner,
                   MidiCurve* plugin);
     ~MidiEnvelope() override;
 
@@ -48,13 +48,13 @@ public:
     void updateParameters (const bool repaintComponent = true);
 
     //==============================================================================
-    void mouseDown (const MouseEvent& e) override;
-    void mouseDrag (const MouseEvent& e) override;
-    void mouseUp (const MouseEvent& e) override;
-    void mouseMove (const MouseEvent& e) override;
-    void mouseDoubleClick (const MouseEvent& e) override;
+    void mouseDown (const juce::MouseEvent& e) override;
+    void mouseDrag (const juce::MouseEvent& e) override;
+    void mouseUp (const juce::MouseEvent& e) override;
+    void mouseMove (const juce::MouseEvent& e) override;
+    void mouseDoubleClick (const juce::MouseEvent& e) override;
 
-    void paint (Graphics& g) override;
+    void paint (juce::Graphics& g) override;
     void resized() override;
     float getValue (float input);
     void repaintIndicator (int in, int out)
@@ -67,21 +67,21 @@ public:
 protected:
     int findPointByMousePos (const int x, const int y);
 
-    AudioProcessorEditor* owner;
+    juce::AudioProcessorEditor* owner;
     MidiCurve* plugin;
     MidiIndicator* indicator;
 
     int draggingPoint;
     int hoveringPoint;
-    Point<float> mouseDownPoint;
+    juce::Point<float> mouseDownPoint;
     float points[MAX_ENVELOPE_POINTS][2];
     float oldpoints[MAX_ENVELOPE_POINTS][2];
     void setPointActive (int point, bool active);
     bool isPointActive (int point);
     void setPointControl (int point, bool control);
     bool isPointControl (int point);
-    Label* labelX;
-    Label* labelY;
+    juce::Label* labelX;
+    juce::Label* labelY;
     int findInactivePoint();
     int addPoint (float x, float y, bool control = false);
 };

--- a/pizjuce/midiCurve/curve.cpp
+++ b/pizjuce/midiCurve/curve.cpp
@@ -1,6 +1,8 @@
 #include "curve.h"
 #include "curvegui.h"
 
+using juce::roundToInt;
+
 //==============================================================================
 /*
     This function must be implemented to create the actual plugin object that
@@ -27,13 +29,13 @@ MidiCurvePrograms::MidiCurvePrograms()
         set (p, "PointType1", 1.f);
         for (int i = 2; i < MAX_ENVELOPE_POINTS - 1; i++)
         {
-            set (p, "x" + String (i), (float) roundToInt (127.f * (float) i / (MAX_ENVELOPE_POINTS - 1)) * fmidiScaler);
-            set (p, "y" + String (i), (float) roundToInt (127.f * (float) i / (MAX_ENVELOPE_POINTS - 1)) * fmidiScaler);
-            set (p, "PointType" + String (i), 0.f);
+            set (p, "x" + juce::String (i), (float) roundToInt (127.f * (float) i / (MAX_ENVELOPE_POINTS - 1)) * fmidiScaler);
+            set (p, "y" + juce::String (i), (float) roundToInt (127.f * (float) i / (MAX_ENVELOPE_POINTS - 1)) * fmidiScaler);
+            set (p, "PointType" + juce::String (i), 0.f);
         }
-        set (p, "x" + String (MAX_ENVELOPE_POINTS - 1), 1.f);
-        set (p, "y" + String (MAX_ENVELOPE_POINTS - 1), 1.f);
-        set (p, "PointType" + String (MAX_ENVELOPE_POINTS - 1), 1.f);
+        set (p, "x" + juce::String (MAX_ENVELOPE_POINTS - 1), 1.f);
+        set (p, "y" + juce::String (MAX_ENVELOPE_POINTS - 1), 1.f);
+        set (p, "PointType" + juce::String (MAX_ENVELOPE_POINTS - 1), 1.f);
 
         set (p, "CC", 0.f);
         set (p, "CCNumber", 1.f * fmidiScaler);
@@ -43,7 +45,7 @@ MidiCurvePrograms::MidiCurvePrograms()
         set (p, "PitchBend", 0.f);
         set (p, "Channel", 0.f);
 
-        set (p, "Name", "Program " + String (p + 1));
+        set (p, "Name", "Program " + juce::String (p + 1));
         set (p, "lastUIWidth", 600);
         set (p, "lastUIHeight", 400);
     }
@@ -53,8 +55,8 @@ MidiCurvePrograms::MidiCurvePrograms()
 MidiCurve::MidiCurve()
 {
     // create built-in programs
-    programs           = new MidiCurvePrograms;
-    String defaultBank = String();
+    programs                 = new MidiCurvePrograms;
+    juce::String defaultBank = juce::String();
     loadDefaultFxb();
 
     init = true;
@@ -96,17 +98,17 @@ void MidiCurve::setParameter (int index, float newValue)
     }
 }
 
-const String MidiCurve::getParameterName (int index)
+const juce::String MidiCurve::getParameterName (int index)
 {
     if (index < kNumPointParams)
     {
         if (index % 2 == 0)
-            return "x" + String (index / 2);
-        return "y" + String (index / 2);
+            return "x" + juce::String (index / 2);
+        return "y" + juce::String (index / 2);
     }
     if (index < kNumPointParams + MAX_ENVELOPE_POINTS)
     {
-        return "PointType" + String (index - kActive);
+        return "PointType" + juce::String (index - kActive);
     }
     if (index == kCC)
         return "CC";
@@ -123,14 +125,14 @@ const String MidiCurve::getParameterName (int index)
     if (index == kPitchBend)
         return "PitchBend";
 
-    return "param" + String (index);
+    return "param" + juce::String (index);
 }
 
-const String MidiCurve::getParameterText (int index)
+const juce::String MidiCurve::getParameterText (int index)
 {
     if (index < kNumPointParams)
     {
-        return String (roundToInt (127.f * param[index]));
+        return juce::String (roundToInt (127.f * param[index]));
     }
     if (index < kNumPointParams + MAX_ENVELOPE_POINTS)
     {
@@ -147,29 +149,29 @@ const String MidiCurve::getParameterText (int index)
     }
     if (index == kCCNumber)
     {
-        return String (roundToInt (127.f * param[index]));
+        return juce::String (roundToInt (127.f * param[index]));
     }
     if (index == kChannel)
     {
         if (roundToInt (param[kChannel] * 16.0f) == 0)
-            return String ("Any");
-        return String (roundToInt (param[kChannel] * 16.0f));
+            return juce::String ("Any");
+        return juce::String (roundToInt (param[kChannel] * 16.0f));
     }
-    return String();
+    return juce::String();
 }
 
-const String MidiCurve::getInputChannelName (const int channelIndex) const
+const juce::String MidiCurve::getInputChannelName (const int channelIndex) const
 {
     if (channelIndex < getNumInputChannels())
-        return String (JucePlugin_Name) + String (" ") + String (channelIndex + 1);
-    return String();
+        return juce::String (JucePlugin_Name) + juce::String (" ") + juce::String (channelIndex + 1);
+    return juce::String();
 }
 
-const String MidiCurve::getOutputChannelName (const int channelIndex) const
+const juce::String MidiCurve::getOutputChannelName (const int channelIndex) const
 {
     if (channelIndex < getNumOutputChannels())
-        return String (JucePlugin_Name) + String (" ") + String (channelIndex + 1);
-    return String();
+        return juce::String (JucePlugin_Name) + juce::String (" ") + juce::String (channelIndex + 1);
+    return juce::String();
 }
 
 bool MidiCurve::isInputChannelStereoPair (int index) const
@@ -213,17 +215,17 @@ void MidiCurve::setCurrentProgram (int index)
     sendChangeMessage();
 }
 
-void MidiCurve::changeProgramName (int index, const String& newName)
+void MidiCurve::changeProgramName (int index, const juce::String& newName)
 {
     if (index < getNumPrograms())
         programs->set (index, "Name", newName);
 }
 
-const String MidiCurve::getProgramName (int index)
+const juce::String MidiCurve::getProgramName (int index)
 {
     if (index < getNumPrograms())
         return programs->get (index, "Name");
-    return String();
+    return juce::String();
 }
 
 int MidiCurve::getCurrentProgram()
@@ -257,7 +259,7 @@ float MidiCurve::getPointValue (int n, int y)
 
 float MidiCurve::findValue (float input)
 {
-    PathFlatteningIterator it (path, {}, fmidiScaler);
+    juce::PathFlatteningIterator it (path, {}, fmidiScaler);
     while (it.next())
     {
         if (it.x1 == input)
@@ -278,15 +280,15 @@ double MidiCurve::linearInterpolate (double x, double y1, double y2, double x1, 
     return slope * x + y0;
 }
 
-void MidiCurve::processBlock (AudioSampleBuffer& buffer,
-                              MidiBuffer& midiMessages)
+void MidiCurve::processBlock (juce::AudioSampleBuffer& buffer,
+                              juce::MidiBuffer& midiMessages)
 {
     for (int i = getNumInputChannels(); i < getNumOutputChannels(); ++i)
     {
         buffer.clear (i, 0, buffer.getNumSamples());
     }
     const int channel = roundToInt (param[kChannel] * 16.0f);
-    MidiBuffer output;
+    juce::MidiBuffer output;
     for (auto&& msgMetadata : midiMessages)
     {
         auto midi_message  = msgMetadata.getMessage();
@@ -302,12 +304,12 @@ void MidiCurve::processBlock (AudioSampleBuffer& buffer,
             {
                 if (param[kCC] >= 0.5f && midi_message.getControllerNumber() == roundToInt (param[kCCNumber] * 127.f))
                 {
-                    int v             = midi_message.getControllerValue();
-                    const uint8* data = midi_message.getRawData();
-                    lastMsg.lastCCIn  = v;
-                    v                 = roundToInt (127.f * findValue (v * fmidiScaler));
-                    lastMsg.lastCCOut = v;
-                    MidiMessage cc    = MidiMessage (data[0], data[1], v);
+                    int v                   = midi_message.getControllerValue();
+                    const juce::uint8* data = midi_message.getRawData();
+                    lastMsg.lastCCIn        = v;
+                    v                       = roundToInt (127.f * findValue (v * fmidiScaler));
+                    lastMsg.lastCCOut       = v;
+                    juce::MidiMessage cc    = juce::MidiMessage (data[0], data[1], v);
                     output.addEvent (cc, sample_number);
                     lastMsg.sendChangeMessage();
                 }
@@ -318,12 +320,12 @@ void MidiCurve::processBlock (AudioSampleBuffer& buffer,
             {
                 if (param[kVelocity] >= 0.5f)
                 {
-                    int v             = midi_message.getVelocity();
-                    const uint8* data = midi_message.getRawData();
-                    lastMsg.lastCCIn  = v;
-                    v                 = roundToInt (127.f * findValue (v * fmidiScaler));
-                    lastMsg.lastCCOut = v;
-                    MidiMessage cc    = MidiMessage (data[0], data[1], v);
+                    int v                   = midi_message.getVelocity();
+                    const juce::uint8* data = midi_message.getRawData();
+                    lastMsg.lastCCIn        = v;
+                    v                       = roundToInt (127.f * findValue (v * fmidiScaler));
+                    lastMsg.lastCCOut       = v;
+                    juce::MidiMessage cc    = juce::MidiMessage (data[0], data[1], v);
                     output.addEvent (cc, sample_number);
                     lastMsg.sendChangeMessage();
                 }
@@ -334,12 +336,12 @@ void MidiCurve::processBlock (AudioSampleBuffer& buffer,
             {
                 if (param[kChannelPressure] >= 0.5f)
                 {
-                    int v             = midi_message.getChannelPressureValue();
-                    const uint8* data = midi_message.getRawData();
-                    lastMsg.lastCCIn  = v;
-                    v                 = roundToInt (127.f * findValue (v * fmidiScaler));
-                    lastMsg.lastCCOut = v;
-                    MidiMessage out   = MidiMessage (data[0], v);
+                    int v                   = midi_message.getChannelPressureValue();
+                    const juce::uint8* data = midi_message.getRawData();
+                    lastMsg.lastCCIn        = v;
+                    v                       = roundToInt (127.f * findValue (v * fmidiScaler));
+                    lastMsg.lastCCOut       = v;
+                    juce::MidiMessage out   = juce::MidiMessage (data[0], v);
                     output.addEvent (out, sample_number);
                     lastMsg.sendChangeMessage();
                 }
@@ -350,12 +352,12 @@ void MidiCurve::processBlock (AudioSampleBuffer& buffer,
             {
                 if (param[kAftertouch] >= 0.5f)
                 {
-                    int v             = midi_message.getAfterTouchValue();
-                    const uint8* data = midi_message.getRawData();
-                    lastMsg.lastCCIn  = v;
-                    v                 = roundToInt (127.f * findValue (v * fmidiScaler));
-                    lastMsg.lastCCOut = v;
-                    MidiMessage out   = MidiMessage (data[0], data[1], v);
+                    int v                   = midi_message.getAfterTouchValue();
+                    const juce::uint8* data = midi_message.getRawData();
+                    lastMsg.lastCCIn        = v;
+                    v                       = roundToInt (127.f * findValue (v * fmidiScaler));
+                    lastMsg.lastCCOut       = v;
+                    juce::MidiMessage out   = juce::MidiMessage (data[0], data[1], v);
                     output.addEvent (out, sample_number);
                     lastMsg.sendChangeMessage();
                 }
@@ -366,12 +368,12 @@ void MidiCurve::processBlock (AudioSampleBuffer& buffer,
             {
                 if (param[kPitchBend] >= 0.5f)
                 {
-                    int v             = midi_message.getPitchWheelValue();
-                    const uint8* data = midi_message.getRawData();
-                    lastMsg.lastCCIn  = (v & 0x3f80) >> 7;
-                    v                 = findPBValue (v);
-                    lastMsg.lastCCOut = (v & 0x3f80) >> 7;
-                    MidiMessage out   = MidiMessage (data[0], v & 0x007f, (v & 0x3f80) >> 7);
+                    int v                   = midi_message.getPitchWheelValue();
+                    const juce::uint8* data = midi_message.getRawData();
+                    lastMsg.lastCCIn        = (v & 0x3f80) >> 7;
+                    v                       = findPBValue (v);
+                    lastMsg.lastCCOut       = (v & 0x3f80) >> 7;
+                    juce::MidiMessage out   = juce::MidiMessage (data[0], v & 0x007f, (v & 0x3f80) >> 7);
                     output.addEvent (out, sample_number);
                     lastMsg.sendChangeMessage();
                 }
@@ -390,7 +392,7 @@ void MidiCurve::processBlock (AudioSampleBuffer& buffer,
 int MidiCurve::findPBValue (int input)
 {
     float v = (float) input;
-    PathFlatteningIterator it (path, {}, (float) 0.0000610388);
+    juce::PathFlatteningIterator it (path, {}, (float) 0.0000610388);
     while (it.next())
     {
         if (it.x1 == v)
@@ -412,7 +414,7 @@ void MidiCurve::updatePath()
         midiPoint p = midiPoint (param[i * 2], param[i * 2 + 1], isPointActive (i), isPointControl (i));
         points.addSorted (pointComparator, p);
     }
-    Path myPath;
+    juce::Path myPath;
     if (points[0].isActive)
     {
         myPath.startNewSubPath (0.f, getPointValue (0, 1));
@@ -510,7 +512,7 @@ bool MidiCurve::isPointControl (int point)
 }
 
 //==============================================================================
-AudioProcessorEditor* MidiCurve::createEditor()
+juce::AudioProcessorEditor* MidiCurve::createEditor()
 {
     return new CurveEditor (this);
 }
@@ -525,13 +527,13 @@ void MidiCurve::copySettingsToProgram (int index)
 }
 
 //==============================================================================
-void MidiCurve::getCurrentProgramStateInformation (MemoryBlock& destData)
+void MidiCurve::getCurrentProgramStateInformation (juce::MemoryBlock& destData)
 {
     copySettingsToProgram (curProgram);
     programs->dumpProgramTo (0, curProgram, destData);
 }
 
-void MidiCurve::getStateInformation (MemoryBlock& destData)
+void MidiCurve::getStateInformation (juce::MemoryBlock& destData)
 {
     copySettingsToProgram (curProgram);
     programs->dumpTo (destData);
@@ -550,7 +552,7 @@ void MidiCurve::setCurrentProgramStateInformation (const void* data, int sizeInB
             changeProgramName (getCurrentProgram(), xmlState->getStringAttribute ("progname", "Default"));
             for (int i = 0; i < kNumParams; i++)
             {
-                param[i] = (float) xmlState->getDoubleAttribute (String (i), param[i]);
+                param[i] = (float) xmlState->getDoubleAttribute (juce::String (i), param[i]);
             }
             lastUIWidth  = xmlState->getIntAttribute ("uiWidth", lastUIWidth);
             lastUIHeight = xmlState->getIntAttribute ("uiHeight", lastUIHeight);
@@ -564,7 +566,7 @@ void MidiCurve::setCurrentProgramStateInformation (const void* data, int sizeInB
     }
     else
     {
-        MemoryInputStream stream (data, sizeInBytes, false);
+        juce::MemoryInputStream stream (data, sizeInBytes, false);
         programs->loadProgram (curProgram, stream);
         init = true;
         setCurrentProgram (curProgram);
@@ -580,10 +582,10 @@ void MidiCurve::setStateInformation (const void* data, int sizeInBytes)
         {
             for (int p = 0; p < getNumPrograms(); p++)
             {
-                String prefix = "P" + String (p) + ".";
+                juce::String prefix = "P" + juce::String (p) + ".";
                 for (int i = 0; i < kNumParams; i++)
                 {
-                    programs->set (p, getParameterName (i), (float) xmlState->getDoubleAttribute (prefix + String (i), programs->get (p, getParameterName (i))));
+                    programs->set (p, getParameterName (i), (float) xmlState->getDoubleAttribute (prefix + juce::String (i), programs->get (p, getParameterName (i))));
                 }
                 programs->set (p, "lastUIWidth", xmlState->getIntAttribute (prefix + "uiWidth", programs->get (p, "lastUIWidth")));
                 programs->set (p, "lastUIHeight", xmlState->getIntAttribute (prefix + "uiHeight", programs->get (p, "lastUIHeight")));
@@ -595,8 +597,8 @@ void MidiCurve::setStateInformation (const void* data, int sizeInBytes)
     }
     else
     {
-        MemoryInputStream stream (data, sizeInBytes, false);
-        ValueTree vt = ValueTree::readFromStream (stream);
+        juce::MemoryInputStream stream (data, sizeInBytes, false);
+        juce::ValueTree vt = juce::ValueTree::readFromStream (stream);
         programs->loadFrom (vt);
         init = true;
         setCurrentProgram (vt.getProperty ("lastProgram", 0));

--- a/pizjuce/midiCurve/curve.h
+++ b/pizjuce/midiCurve/curve.h
@@ -31,26 +31,26 @@ class MidiCurvePrograms : public BankStorage
 public:
     MidiCurvePrograms();
 
-    void set (int prog, const Identifier& name, const var& newValue)
+    void set (int prog, const juce::Identifier& name, const juce::var& newValue)
     {
         BankStorage::set (0, prog, name.toString(), newValue);
     }
-    const var get (int prog, const Identifier& name)
+    const juce::var get (int prog, const juce::Identifier& name)
     {
         return BankStorage::get (0, prog, name.toString());
     }
 
-    void loadProgram (int prog, InputStream& stream)
+    void loadProgram (int prog, juce::InputStream& stream)
     {
-        values_.removeChild (values_.getChild (prog), 0);
-        values_.addChild (ValueTree::readFromStream (stream), prog, 0);
-        values_.getChild (prog).setProperty ("progIndex", prog, 0);
+        values_.removeChild (values_.getChild (prog), nullptr);
+        values_.addChild (juce::ValueTree::readFromStream (stream), prog, nullptr);
+        values_.getChild (prog).setProperty ("progIndex", prog, nullptr);
     }
 };
 
 //==============================================================================
 class MidiCurve : public PizAudioProcessor,
-                  public ChangeBroadcaster
+                  public juce::ChangeBroadcaster
 {
 public:
     //==============================================================================
@@ -61,13 +61,13 @@ public:
     void prepareToPlay (double sampleRate, int samplesPerBlock) override;
     void releaseResources() override;
 
-    void processBlock (AudioSampleBuffer& buffer, MidiBuffer& midiMessages) override;
+    void processBlock (juce::AudioSampleBuffer& buffer, juce::MidiBuffer& midiMessages) override;
 
     //==============================================================================
-    AudioProcessorEditor* createEditor() override;
+    juce::AudioProcessorEditor* createEditor() override;
 
     //==============================================================================
-    const String getName() const override { return JucePlugin_Name; }
+    const juce::String getName() const override { return JucePlugin_Name; }
     bool hasEditor() const override { return true; }
     bool acceptsMidi() const override
     {
@@ -91,11 +91,11 @@ public:
     float getParameter (int index) override;
     void setParameter (int index, float newValue) override;
 
-    const String getParameterName (int index) override;
-    const String getParameterText (int index) override;
+    const juce::String getParameterName (int index) override;
+    const juce::String getParameterText (int index) override;
 
-    const String getInputChannelName (int channelIndex) const override;
-    const String getOutputChannelName (int channelIndex) const override;
+    const juce::String getInputChannelName (int channelIndex) const override;
+    const juce::String getOutputChannelName (int channelIndex) const override;
     bool isInputChannelStereoPair (int index) const override;
     bool isOutputChannelStereoPair (int index) const override;
     double getTailLengthSeconds() const override { return 0; }
@@ -105,13 +105,13 @@ public:
     int getNumPrograms() override { return kNumPrograms; }
     int getCurrentProgram() override;
     void setCurrentProgram (int index) override;
-    const String getProgramName (int index) override;
-    void changeProgramName (int index, const String& newName) override;
+    const juce::String getProgramName (int index) override;
+    void changeProgramName (int index, const juce::String& newName) override;
 
     //==============================================================================
-    void getCurrentProgramStateInformation (MemoryBlock& destData) override;
+    void getCurrentProgramStateInformation (juce::MemoryBlock& destData) override;
     void setCurrentProgramStateInformation (const void* data, int sizeInBytes) override;
-    void getStateInformation (MemoryBlock& destData) override;
+    void getStateInformation (juce::MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
 
     //==============================================================================
@@ -129,12 +129,10 @@ public:
     int getPrevActivePoint (int currentPoint);
     int getNextActivePoint (int currentPoint);
     void resetPoints (bool copyToProgram = true);
-    Path path;
+    juce::Path path;
 
-    //==============================================================================
-    juce_UseDebuggingNewOperator
-
-        private : float param[kNumParams];
+private:
+    float param[kNumParams];
 
     class midiPoint
     {
@@ -153,17 +151,17 @@ public:
         }
         ~midiPoint(){};
 
-        Point<float> p;
+        juce::Point<float> p;
         bool isControl;
         bool isActive;
     };
 
     struct PointComparator
     {
-        int compareElements (midiPoint a, midiPoint b) { return roundToInt (a.p.getX() * 127.f) - roundToInt (b.p.getX() * 127.f); }
+        int compareElements (midiPoint a, midiPoint b) { return juce::roundToInt (a.p.getX() * 127.f) - juce::roundToInt (b.p.getX() * 127.f); }
     } pointComparator;
 
-    Array<midiPoint> points;
+    juce::Array<midiPoint> points;
     void updatePath();
 
     MidiCurvePrograms* programs;
@@ -175,6 +173,8 @@ public:
     float findValue (float input);
     double linearInterpolate (double x, double y1, double y2, double x1, double x2);
     int findPBValue (int input);
+
+    JUCE_LEAK_DETECTOR (MidiCurve)
 };
 
 #endif

--- a/pizjuce/midiCurve/curvegui.cpp
+++ b/pizjuce/midiCurve/curvegui.cpp
@@ -54,7 +54,7 @@ CurveEditor::CurveEditor (MidiCurve* const ownerFilter)
     label2->setColour (juce::TextEditor::textColourId, juce::Colours::black);
     label2->setColour (juce::TextEditor::backgroundColourId, juce::Colour (0x00000000));
 
-    resizer.reset (new ResizableCornerComponent (this, &resizeLimits));
+    resizer.reset (new juce::ResizableCornerComponent (this, &resizeLimits));
     addAndMakeVisible (resizer.get());
 
     velocityButton.reset (new juce::ToggleButton ("new toggle button"));
@@ -309,7 +309,7 @@ void CurveEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
 }
 
 //[MiscUserCode] You can add your own definitions of your custom methods or any other code here...
-void CurveEditor::changeListenerCallback (ChangeBroadcaster* source)
+void CurveEditor::changeListenerCallback (juce::ChangeBroadcaster* source)
 {
     if (source == getFilter())
         updateParameters();
@@ -320,9 +320,9 @@ void CurveEditor::changeListenerCallback (ChangeBroadcaster* source)
         const int lastout = getFilter()->lastMsg.lastCCOut;
         getFilter()->getCallbackLock().exit();
         if (lastin != -1)
-            label->setText ("In: " + String (lastin), dontSendNotification);
+            label->setText ("In: " + juce::String (lastin), juce::dontSendNotification);
         if (lastout != -1)
-            label2->setText ("Out: " + String (lastout), dontSendNotification);
+            label2->setText ("Out: " + juce::String (lastout), juce::dontSendNotification);
         curve->repaintIndicator (lastin, lastout);
     }
 }
@@ -345,13 +345,13 @@ void CurveEditor::updateParameters()
     const float p_pitchbend       = filter->getParameter (kPitchBend);
     filter->getCallbackLock().exit();
 
-    slider->setValue (p_ccnumber * slider->getMaximum(), dontSendNotification);
-    channelSlider->setValue (p_channel * channelSlider->getMaximum(), dontSendNotification);
+    slider->setValue (p_ccnumber * slider->getMaximum(), juce::dontSendNotification);
+    channelSlider->setValue (p_channel * channelSlider->getMaximum(), juce::dontSendNotification);
 
-    velocityButton->setToggleState (p_velocity >= 0.5f, dontSendNotification);
-    ccButton->setToggleState (p_cc >= 0.5f, dontSendNotification);
-    aftertouchButton->setToggleState (p_aftertouch >= 0.5f, dontSendNotification);
-    channelPressureButton->setToggleState (p_channelpressure >= 0.5f, dontSendNotification);
+    velocityButton->setToggleState (p_velocity >= 0.5f, juce::dontSendNotification);
+    ccButton->setToggleState (p_cc >= 0.5f, juce::dontSendNotification);
+    aftertouchButton->setToggleState (p_aftertouch >= 0.5f, juce::dontSendNotification);
+    channelPressureButton->setToggleState (p_channelpressure >= 0.5f, juce::dontSendNotification);
 
     curve->updateParameters (true);
 

--- a/pizjuce/midiCurve/curvegui.h
+++ b/pizjuce/midiCurve/curvegui.h
@@ -20,7 +20,7 @@
 #pragma once
 
 //[Headers]     -- You can add your own extra header files here --
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_gui_basics/juce_gui_basics.h>
 
 #include "../_common/ChannelSlider.h"
 #include "curve.h"
@@ -35,8 +35,8 @@
     Describe your class and how it works here!
                                                                     //[/Comments]
 */
-class CurveEditor : public AudioProcessorEditor,
-                    public ChangeListener,
+class CurveEditor : public juce::AudioProcessorEditor,
+                    public juce::ChangeListener,
                     public juce::Button::Listener,
                     public juce::Slider::Listener
 {
@@ -57,16 +57,16 @@ public:
 private:
     //[UserVariables]   -- You can add your own custom variables in this section.
     MidiCurve* getFilter() const throw() { return (MidiCurve*) getAudioProcessor(); }
-    void changeListenerCallback (ChangeBroadcaster* source) override;
+    void changeListenerCallback (juce::ChangeBroadcaster* source) override;
     void updateParameters();
-    ComponentBoundsConstrainer resizeLimits;
+    juce::ComponentBoundsConstrainer resizeLimits;
     //[/UserVariables]
 
     //==============================================================================
     std::unique_ptr<MidiEnvelope> curve;
     std::unique_ptr<juce::Label> label;
     std::unique_ptr<juce::Label> label2;
-    std::unique_ptr<ResizableCornerComponent> resizer;
+    std::unique_ptr<juce::ResizableCornerComponent> resizer;
     std::unique_ptr<juce::ToggleButton> velocityButton;
     std::unique_ptr<juce::ToggleButton> ccButton;
     std::unique_ptr<juce::Slider> slider;

--- a/pizjuce/midiIn/MidiPad.cpp
+++ b/pizjuce/midiIn/MidiPad.cpp
@@ -1,13 +1,13 @@
 #include "MidiPad.h"
 
 MidiPad::MidiPad()
-    : drawableButton (0)
+    : drawableButton (nullptr)
 {
     addAndMakeVisible (drawableButton = new DrawablePad ("MidiPad"));
     drawableButton->addListener (this);
-    addAndMakeVisible (label = new Label ("Label", String()));
-    label->setFont (Font (9.0000f, Font::plain));
-    label->setJustificationType (Justification::centred);
+    addAndMakeVisible (label = new juce::Label ("Label", juce::String()));
+    label->setFont (juce::Font (9.0000f, juce::Font::plain));
+    label->setJustificationType (juce::Justification::centred);
     setMouseClickGrabsKeyboardFocus (false);
 }
 
@@ -17,12 +17,12 @@ MidiPad::~MidiPad()
     deleteAndZero (label);
 }
 
-void MidiPad::setTooltip (String text)
+void MidiPad::setTooltip (juce::String text)
 {
     drawableButton->setTooltip (text);
 }
 
-void MidiPad::paint (Graphics& g)
+void MidiPad::paint (juce::Graphics& g)
 {
 }
 
@@ -37,13 +37,13 @@ void MidiPad::resized()
     label->setBounds (0, 0, proportionOfWidth (1.0000f), proportionOfHeight (1.0000f));
 }
 
-void MidiPad::buttonClicked (Button* buttonThatWasClicked)
+void MidiPad::buttonClicked (juce::Button* buttonThatWasClicked)
 {
 }
 
-bool MidiPad::isInterestedInFileDrag (const StringArray& files)
+bool MidiPad::isInterestedInFileDrag (const juce::StringArray& files)
 {
-    File file = File (files.joinIntoString (String(), 0, 1));
+    juce::File file = juce::File (files.joinIntoString (juce::String(), 0, 1));
     if (file.hasFileExtension ("png") || file.hasFileExtension ("gif") || file.hasFileExtension ("jpg") || file.hasFileExtension ("svg"))
         return true;
     else
@@ -54,20 +54,20 @@ void MidiPad::filesDropped (const juce::StringArray& filenames, int mouseX, int 
 {
     if (isInterestedInFileDrag (filenames))
     {
-        String filename = filenames.joinIntoString (String(), 0, 1);
-        File file       = File (filename);
-        auto image      = Drawable::createFromImageFile (file);
+        juce::String filename = filenames.joinIntoString (juce::String(), 0, 1);
+        juce::File file       = juce::File (filename);
+        auto image            = juce::Drawable::createFromImageFile (file);
         drawableButton->setImages (image.get());
         //save the relative path
-        drawableButton->setName (file.getRelativePathFrom (File::getSpecialLocation (File::currentExecutableFile)));
-        drawableButton->setState (Button::buttonNormal);
-        label->setText (String(), dontSendNotification);
+        drawableButton->setName (file.getRelativePathFrom (juce::File::getSpecialLocation (juce::File::currentExecutableFile)));
+        drawableButton->setState (juce::Button::buttonNormal);
+        label->setText (juce::String(), juce::dontSendNotification);
     }
 }
 
-void MidiPad::setButtonText (const String& newText)
+void MidiPad::setButtonText (const juce::String& newText)
 {
-    label->setText (newText, dontSendNotification);
+    label->setText (newText, juce::dontSendNotification);
 }
 
 void MidiPad::setTriggeredOnMouseDown (const bool isTriggeredOnMouseDown)
@@ -75,14 +75,14 @@ void MidiPad::setTriggeredOnMouseDown (const bool isTriggeredOnMouseDown)
     drawableButton->setTriggeredOnMouseDown (isTriggeredOnMouseDown);
 }
 
-void MidiPad::addButtonListener (Button::Listener* const newListener)
+void MidiPad::addButtonListener (juce::Button::Listener* const newListener)
 {
     drawableButton->addListener (newListener);
 }
 
 void MidiPad::clearIcon()
 {
-    drawableButton->setImages (0);
+    drawableButton->setImages (nullptr);
     drawableButton->setName ("");
-    label->setText ("Drag\nIcon", dontSendNotification);
+    label->setText ("Drag\nIcon", juce::dontSendNotification);
 }

--- a/pizjuce/midiIn/MidiPad.h
+++ b/pizjuce/midiIn/MidiPad.h
@@ -1,39 +1,39 @@
 #ifndef imagePluginFilter_PAD_H
 #define imagePluginFilter_PAD_H
 
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_gui_basics/juce_gui_basics.h>
 
 #include "../_common/DrawablePad.h"
 
-class MidiPad : public Component,
-                public Button::Listener,
-                public FileDragAndDropTarget
+class MidiPad : public juce::Component,
+                public juce::Button::Listener,
+                public juce::FileDragAndDropTarget
 {
 public:
     //==============================================================================
     MidiPad();
     ~MidiPad() override;
 
-    void paint (Graphics&) override;
+    void paint (juce::Graphics&) override;
     void resized() override;
-    void buttonClicked (Button*) override;
-    void filesDropped (const StringArray& files, int x, int y) override;
-    bool isInterestedInFileDrag (const StringArray& files) override;
-    void setButtonText (const String&);
-    void setTooltip (String text);
-    void setColour (const Colour&);
+    void buttonClicked (juce::Button*) override;
+    void filesDropped (const juce::StringArray& files, int x, int y) override;
+    bool isInterestedInFileDrag (const juce::StringArray& files) override;
+    void setButtonText (const juce::String&);
+    void setTooltip (juce::String text);
+    void setColour (const juce::Colour&);
     void setTriggeredOnMouseDown (const bool);
-    void addButtonListener (Button::Listener* const);
+    void addButtonListener (juce::Button::Listener* const);
     void clearIcon();
 
     DrawablePad* drawableButton;
 
-    //==============================================================================
-    juce_UseDebuggingNewOperator
-
-        private : Label* label;
+private:
+    juce::Label* label;
     MidiPad (const MidiPad&);
     const MidiPad& operator= (const MidiPad&);
+
+    JUCE_LEAK_DETECTOR (MidiPad)
 };
 
 #endif

--- a/pizjuce/midiIn/midiIn.h
+++ b/pizjuce/midiIn/midiIn.h
@@ -3,14 +3,12 @@
 
 #include <memory>
 
-#include "juce_audio_devices/juce_audio_devices.h"
-#include "juce_core/juce_core.h"
-#include "juce_events/juce_events.h"
+#include <juce_audio_devices/juce_audio_devices.h>
+#include <juce_core/juce_core.h>
+#include <juce_events/juce_events.h>
 
 #include "../_common/PizArray.h"
 #include "../_common/PizAudioProcessor.h"
-
-using namespace juce;
 
 enum
 {
@@ -30,14 +28,14 @@ public:
 
 private:
     float param[numParams];
-    String icon;
-    MidiDeviceInfo device;
-    String name;
+    juce::String icon;
+    juce::MidiDeviceInfo device;
+    juce::String name;
 };
 
 //==============================================================================
 class MidiInFilter : public PizAudioProcessor,
-                     public ChangeBroadcaster
+                     public juce::ChangeBroadcaster
 {
 public:
     //==============================================================================
@@ -47,14 +45,14 @@ public:
     void prepareToPlay (double sampleRate, int samplesPerBlock) override;
     void releaseResources() override;
 
-    void processBlock (AudioSampleBuffer& buffer,
-                       MidiBuffer& midiMessages) override;
+    void processBlock (juce::AudioSampleBuffer& buffer,
+                       juce::MidiBuffer& midiMessages) override;
 
     //==============================================================================
-    AudioProcessorEditor* createEditor() override;
+    juce::AudioProcessorEditor* createEditor() override;
 
     //==============================================================================
-    const String getName() const override { return JucePlugin_Name; }
+    const juce::String getName() const override { return JucePlugin_Name; }
     bool hasEditor() const override { return true; }
     bool acceptsMidi() const override { return true; }
     bool producesMidi() const override { return true; }
@@ -65,11 +63,11 @@ public:
     float getParameter (int index) override;
     void setParameter (int index, float newValue) override;
 
-    const String getParameterName (int index) override;
-    const String getParameterText (int index) override;
+    const juce::String getParameterName (int index) override;
+    const juce::String getParameterText (int index) override;
 
-    const String getInputChannelName (int channelIndex) const override;
-    const String getOutputChannelName (int channelIndex) const override;
+    const juce::String getInputChannelName (int channelIndex) const override;
+    const juce::String getOutputChannelName (int channelIndex) const override;
     bool isInputChannelStereoPair (int index) const override;
     bool isOutputChannelStereoPair (int index) const override;
 
@@ -77,45 +75,44 @@ public:
     int getNumPrograms() override { return 1; }
     int getCurrentProgram() override;
     void setCurrentProgram (int index) override;
-    const String getProgramName (int index) override;
-    void changeProgramName (int index, const String& newName) override;
+    const juce::String getProgramName (int index) override;
+    void changeProgramName (int index, const juce::String& newName) override;
 
     //==============================================================================
-    void getStateInformation (MemoryBlock& destData) override;
+    void getStateInformation (juce::MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
-    void getCurrentProgramStateInformation (MemoryBlock& destData) override;
+    void getCurrentProgramStateInformation (juce::MemoryBlock& destData) override;
     void setCurrentProgramStateInformation (const void* data, int sizeInBytes) override;
 
     //==============================================================================
     // These properties are public so that our editor component can access them
     //  - a bit of a hacky way to do it, but it's only a demo!
 
-    PizArray<MidiDeviceInfo> devices;
-    String icon;
+    PizArray<juce::MidiDeviceInfo> devices;
+    juce::String icon;
 
-    void setActiveDevice (String name);
-    void setActiveDevice (MidiDeviceInfo device);
-    MidiDeviceInfo getActiveDevice() { return activeDevice; }
-    MidiDeviceInfo getDeviceByName (String name) const;
+    void setActiveDevice (juce::String name);
+    void setActiveDevice (juce::MidiDeviceInfo device);
+    juce::MidiDeviceInfo getActiveDevice() { return activeDevice; }
+    juce::MidiDeviceInfo getDeviceByName (juce::String name) const;
 
-    //==============================================================================
-    juce_UseDebuggingNewOperator
-
-        private :
-        // this is our gain - the UI and the host can access this by getting/setting
-        // parameter 0.
-        float param[numParams];
-    MidiDeviceInfo activeDevice;
+private:
+    // this is our gain - the UI and the host can access this by getting/setting
+    // parameter 0.
+    float param[numParams];
+    juce::MidiDeviceInfo activeDevice;
 
     JuceProgram* programs;
     int curProgram;
     bool init;
-    std::unique_ptr<MidiInput> midiInput;
-    MidiMessageCollector collector;
+    std::unique_ptr<juce::MidiInput> midiInput;
+    juce::MidiMessageCollector collector;
 
     bool wasPlaying;
 
-    AudioPlayHead::CurrentPositionInfo lastPosInfo;
+    juce::AudioPlayHead::CurrentPositionInfo lastPosInfo;
+
+    JUCE_LEAK_DETECTOR (MidiInFilter)
 };
 
 #endif

--- a/pizjuce/midiIn/midiInEditor.cpp
+++ b/pizjuce/midiIn/midiInEditor.cpp
@@ -23,6 +23,7 @@
 #include "midiInEditor.h"
 
 //[MiscUserDefs] You can add your own user definitions and misc code here...
+using juce::roundToInt;
 //[/MiscUserDefs]
 
 //==============================================================================
@@ -98,7 +99,7 @@ MidiInEditor::MidiInEditor (MidiInFilter* const ownerFilter)
     setMouseClickGrabsKeyboardFocus (false);
 
     comboBox->setMouseClickGrabsKeyboardFocus (false);
-    comboBox->addItem (String ("--"), 1);
+    comboBox->addItem (juce::String ("--"), 1);
     for (int i = 0; i < ownerFilter->devices.size(); i++)
     {
         comboBox->addItem (ownerFilter->devices[i].name, i + 2);
@@ -108,7 +109,7 @@ MidiInEditor::MidiInEditor (MidiInFilter* const ownerFilter)
     imagepad->setTriggeredOnMouseDown (true);
     imagepad->addButtonListener (this);
     imagepad->drawableButton->Label = "";
-    imagepad->setButtonText (String());
+    imagepad->setButtonText (juce::String());
 
     hostButton->setMouseClickGrabsKeyboardFocus (false);
     //[/UserPreSize]
@@ -208,15 +209,15 @@ void MidiInEditor::buttonClicked (juce::Button* buttonThatWasClicked)
 }
 
 //[MiscUserCode] You can add your own definitions of your custom methods or any other code here...
-void MidiInEditor::buttonStateChanged (Button* buttonThatWasClicked)
+void MidiInEditor::buttonStateChanged (juce::Button* buttonThatWasClicked)
 {
     getFilter()->icon = imagepad->drawableButton->getName();
     if (imagepad->drawableButton->isDown())
     {
-        ModifierKeys mousebutton = ModifierKeys::getCurrentModifiers();
+        juce::ModifierKeys mousebutton = juce::ModifierKeys::getCurrentModifiers();
         if (mousebutton.isPopupMenu())
         {
-            PopupMenu m, sub1;
+            juce::PopupMenu m, sub1;
             m.addItem (66, "Clear Image");
             m.addSeparator();
 
@@ -225,8 +226,8 @@ void MidiInEditor::buttonStateChanged (Button* buttonThatWasClicked)
             {
                 if (result == 66)
                 {
-                    getFilter()->icon = String ("");
-                    imagepad->drawableButton->setImages (0);
+                    getFilter()->icon = juce::String ("");
+                    imagepad->drawableButton->setImages (nullptr);
                     imagepad->drawableButton->setName ("");
                 }
             }
@@ -235,7 +236,7 @@ void MidiInEditor::buttonStateChanged (Button* buttonThatWasClicked)
 }
 
 //==============================================================================
-void MidiInEditor::changeListenerCallback (ChangeBroadcaster* source)
+void MidiInEditor::changeListenerCallback (juce::ChangeBroadcaster* source)
 {
     updateParametersFromFilter();
 }
@@ -250,29 +251,29 @@ void MidiInEditor::updateParametersFromFilter()
     filter->getCallbackLock().enter();
 
     // take a local copy of the info we need while we've got the lock..
-    const int newDevice = filter->devices.indexOf (filter->getActiveDevice());
-    const float hostin  = filter->getParameter (kHostIn);
-    const String icon   = filter->icon;
-    const int channel   = roundToInt (filter->getParameter (kChannel) * 16.f);
+    const int newDevice     = filter->devices.indexOf (filter->getActiveDevice());
+    const float hostin      = filter->getParameter (kHostIn);
+    const juce::String icon = filter->icon;
+    const int channel       = roundToInt (filter->getParameter (kChannel) * 16.f);
 
     // ..release the lock ASAP
     filter->getCallbackLock().exit();
 
-    comboBox->setSelectedItemIndex (newDevice + 1, dontSendNotification);
-    channelBox->setSelectedItemIndex (channel, dontSendNotification);
+    comboBox->setSelectedItemIndex (newDevice + 1, juce::dontSendNotification);
+    channelBox->setSelectedItemIndex (channel, juce::dontSendNotification);
 
-    hostButton->setToggleState (hostin >= 0.5f, dontSendNotification);
+    hostButton->setToggleState (hostin >= 0.5f, juce::dontSendNotification);
 
-    String fullpath = icon;
-    if (! File (fullpath).existsAsFile())
-        fullpath = ((File::getSpecialLocation (File::currentExecutableFile)).getParentDirectory()).getFullPathName()
-                 + File::getSeparatorString() + icon;
-    auto image = Drawable::createFromImageFile (File (fullpath));
+    juce::String fullpath = icon;
+    if (! juce::File (fullpath).existsAsFile())
+        fullpath = ((juce::File::getSpecialLocation (juce::File::currentExecutableFile)).getParentDirectory()).getFullPathName()
+                 + juce::File::getSeparatorString() + icon;
+    auto image = juce::Drawable::createFromImageFile (juce::File (fullpath));
     if (image != nullptr)
     {
         imagepad->drawableButton->setImages (image.get());
         imagepad->drawableButton->setName (icon);
-        imagepad->setButtonText (String());
+        imagepad->setButtonText (juce::String());
     }
     else
         imagepad->setButtonText ("IPH\nmidiIn\n1.2");

--- a/pizjuce/midiIn/midiInEditor.h
+++ b/pizjuce/midiIn/midiInEditor.h
@@ -20,9 +20,9 @@
 #pragma once
 
 //[Headers]     -- You can add your own extra header files here --
-#include "juce_audio_processors/juce_audio_processors.h"
-#include "juce_events/juce_events.h"
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_events/juce_events.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
 #include "midiIn.h"
 #include "MidiPad.h"
@@ -48,8 +48,8 @@ public:
 
     //==============================================================================
     //[UserMethods]     -- You can add your own custom methods in this section.
-    void changeListenerCallback (ChangeBroadcaster* source) override;
-    void buttonStateChanged (Button* buttonThatWasClicked) override;
+    void changeListenerCallback (juce::ChangeBroadcaster* source) override;
+    void buttonStateChanged (juce::Button* buttonThatWasClicked) override;
     //[/UserMethods]
 
     void paint (juce::Graphics& g) override;

--- a/pizjuce/midiKeyboard/PizKeyboard.cpp
+++ b/pizjuce/midiKeyboard/PizKeyboard.cpp
@@ -5,6 +5,8 @@
 #include "PizKeyboard.h"
 #include "PizKeyboardEditor.h"
 
+using juce::roundToInt;
+
 bool PizKeyboard::isCapsLockOn()
 {
     // TODO: WTF?
@@ -56,12 +58,12 @@ PizKeyboard::PizKeyboard()
     lastProgram    = 0;
     curProgram     = 0;
 
-    ccqwertyState[0] = KeyPress::isKeyCurrentlyDown (KeyPress::tabKey);
-    ccqwertyState[1] = KeyPress::isKeyCurrentlyDown (KeyPress::createFromDescription ("`").getKeyCode());
+    ccqwertyState[0] = juce::KeyPress::isKeyCurrentlyDown (juce::KeyPress::tabKey);
+    ccqwertyState[1] = juce::KeyPress::isKeyCurrentlyDown (juce::KeyPress::createFromDescription ("`").getKeyCode());
     ccState[0]       = false;
     ccState[1]       = false;
     for (int i = keymapLength; --i >= 0;)
-        qwertyState[i] = KeyPress::isKeyCurrentlyDown (keymap[i]);
+        qwertyState[i] = juce::KeyPress::isKeyCurrentlyDown (keymap[i]);
 }
 
 PizKeyboard::~PizKeyboard()
@@ -70,7 +72,7 @@ PizKeyboard::~PizKeyboard()
 }
 
 //==============================================================================
-const String PizKeyboard::getName() const
+const juce::String PizKeyboard::getName() const
 {
     return "midiKeyboard";
 }
@@ -180,7 +182,7 @@ void PizKeyboard::setParameter (int index, float newValue)
     }
 }
 
-const String PizKeyboard::getParameterName (int index)
+const juce::String PizKeyboard::getParameterName (int index)
 {
     if (index == kWidth)
         return "KeyWidth";
@@ -206,17 +208,17 @@ const String PizKeyboard::getParameterName (int index)
         return "Reset";
     if (index == kShowNumbers)
         return "ShowNumbers";
-    return String();
+    return juce::String();
 }
 
-const String PizKeyboard::getParameterText (int index)
+const juce::String PizKeyboard::getParameterText (int index)
 {
     if (index == kWidth)
-        return String (width, 2);
+        return juce::String (width, 2);
     if (index == kChannel)
-        return String (channel + 1);
+        return juce::String (channel + 1);
     if (index == kVelocity)
-        return String (roundToInt (velocity * 127.f));
+        return juce::String (roundToInt (velocity * 127.f));
     if (index == kUseY)
         return useY ? "Yes" : "No";
     if (index == kToggleInput)
@@ -235,17 +237,17 @@ const String PizKeyboard::getParameterText (int index)
         return "--->";
     if (index == kShowNumbers)
         return showNumbers ? "Yes" : "No";
-    return String();
+    return juce::String();
 }
 
-const String PizKeyboard::getInputChannelName (const int channelIndex) const
+const juce::String PizKeyboard::getInputChannelName (const int channelIndex) const
 {
-    return String (channelIndex + 1);
+    return juce::String (channelIndex + 1);
 }
 
-const String PizKeyboard::getOutputChannelName (const int channelIndex) const
+const juce::String PizKeyboard::getOutputChannelName (const int channelIndex) const
 {
-    return String (channelIndex + 1);
+    return juce::String (channelIndex + 1);
 }
 
 bool PizKeyboard::isInputChannelStereoPair (int index) const
@@ -280,10 +282,10 @@ void PizKeyboard::releaseResources()
     // spare memory, etc.
 }
 
-void PizKeyboard::processBlock (AudioSampleBuffer& buffer,
-                                MidiBuffer& midiMessages)
+void PizKeyboard::processBlock (juce::AudioSampleBuffer& buffer,
+                                juce::MidiBuffer& midiMessages)
 {
-    MidiBuffer output;
+    juce::MidiBuffer output;
     if (lastProgram != curProgram)
     {
         for (int ch = 1; ch <= 16; ch++)
@@ -317,7 +319,7 @@ void PizKeyboard::processBlock (AudioSampleBuffer& buffer,
             for (int n = 0; n < 128; n++)
             {
                 if (progKbState[curProgram].isNoteOn (ch, n))
-                    output.addEvent (MidiMessage::noteOff (ch, n), 0);
+                    output.addEvent (juce::MidiMessage::noteOff (ch, n), 0);
             }
         }
         progKbState[curProgram].reset();
@@ -343,26 +345,26 @@ void PizKeyboard::processBlock (AudioSampleBuffer& buffer,
         //}
         for (int i = keymapLength; --i >= 0;)
         {
-            if (qwertyState[i] != KeyPress::isKeyCurrentlyDown (keymap[i]))
+            if (qwertyState[i] != juce::KeyPress::isKeyCurrentlyDown (keymap[i]))
             {
                 const int note = 12 * octave + i;
-                if (KeyPress::isKeyCurrentlyDown (keymap[i]) != progKbState[curProgram].isNoteOn (channel + 1, note)
-                    && ! ModifierKeys::getCurrentModifiers().isAnyModifierKeyDown())
+                if (juce::KeyPress::isKeyCurrentlyDown (keymap[i]) != progKbState[curProgram].isNoteOn (channel + 1, note)
+                    && ! juce::ModifierKeys::getCurrentModifiers().isAnyModifierKeyDown())
                 {
-                    if (KeyPress::isKeyCurrentlyDown (keymap[i]))
+                    if (juce::KeyPress::isKeyCurrentlyDown (keymap[i]))
                     {
-                        editorKbState.noteOn (channel + 1, note, ModifierKeys::getCurrentModifiers().isShiftDown() ? 127 : velocity);
+                        editorKbState.noteOn (channel + 1, note, juce::ModifierKeys::getCurrentModifiers().isShiftDown() ? 127 : velocity);
                     }
                     else if (! toggle)
                     {
                         editorKbState.noteOff (channel + 1, note, 1.f);
                     }
                 }
-                else if (toggle && KeyPress::isKeyCurrentlyDown (keymap[i]) && progKbState[curProgram].isNoteOn (channel + 1, note))
+                else if (toggle && juce::KeyPress::isKeyCurrentlyDown (keymap[i]) && progKbState[curProgram].isNoteOn (channel + 1, note))
                 {
                     editorKbState.noteOff (channel + 1, note, 1.f);
                 }
-                qwertyState[i] = KeyPress::isKeyCurrentlyDown (keymap[i]);
+                qwertyState[i] = juce::KeyPress::isKeyCurrentlyDown (keymap[i]);
             }
         }
     }
@@ -381,7 +383,7 @@ void PizKeyboard::processBlock (AudioSampleBuffer& buffer,
                 {
                     skip = true;
                     if (progKbState[curProgram].isNoteOn (m.getChannel(), m.getNoteNumber()))
-                        output.addEvent (MidiMessage::noteOff (m.getChannel(), m.getNoteNumber()), sample);
+                        output.addEvent (juce::MidiMessage::noteOff (m.getChannel(), m.getNoteNumber()), sample);
                     else
                         output.addEvent (m, sample);
                 }
@@ -400,7 +402,7 @@ void PizKeyboard::processBlock (AudioSampleBuffer& buffer,
                         for (int n = 0; n < 128; n++)
                         {
                             if (progKbState[lastProgram].isNoteOn (ch, n))
-                                output.addEvent (MidiMessage::noteOff (ch, n), sample);
+                                output.addEvent (juce::MidiMessage::noteOff (ch, n), sample);
                         }
                     }
                     editorKbState.reset();
@@ -411,7 +413,7 @@ void PizKeyboard::processBlock (AudioSampleBuffer& buffer,
                             if (progKbState[curProgram].isNoteOn (ch, n))
                             {
                                 editorKbState.noteOn (ch, n, velocity);
-                                output.addEvent (MidiMessage::noteOn (ch, n, velocity), sample);
+                                output.addEvent (juce::MidiMessage::noteOn (ch, n, velocity), sample);
                             }
                         }
                     }
@@ -434,7 +436,7 @@ void PizKeyboard::processBlock (AudioSampleBuffer& buffer,
             for (int n = 0; n < 128; n++)
             {
                 if (progKbState[curProgram].isNoteOn (ch, n))
-                    output.addEvent (MidiMessage::noteOn (ch, n, velocity), 0);
+                    output.addEvent (juce::MidiMessage::noteOn (ch, n, velocity), 0);
             }
         }
     }
@@ -451,13 +453,13 @@ void PizKeyboard::processBlock (AudioSampleBuffer& buffer,
 }
 
 //==============================================================================
-AudioProcessorEditor* PizKeyboard::createEditor()
+juce::AudioProcessorEditor* PizKeyboard::createEditor()
 {
     return new midiKeyboardEditor (this);
 }
 
 //==============================================================================
-void PizKeyboard::getStateInformation (MemoryBlock& destData)
+void PizKeyboard::getStateInformation (juce::MemoryBlock& destData)
 {
     // you can store your parameters as binary data if you want to or if you've got
     // a load of binary to put in there, but if you're not doing anything too heavy,
@@ -465,7 +467,7 @@ void PizKeyboard::getStateInformation (MemoryBlock& destData)
     // params as XML..
 
     // create an outer XML element..
-    XmlElement xmlState ("MYPLUGINSETTINGS");
+    juce::XmlElement xmlState ("MYPLUGINSETTINGS");
 
     // add some attributes to it..
     xmlState.setAttribute ("pluginVersion", 2);
@@ -496,7 +498,7 @@ void PizKeyboard::setStateInformation (const void* data, int sizeInBytes)
     // use this helper function to get the XML from this binary blob..
     auto xmlState = getXmlFromBinary (data, sizeInBytes);
 
-    if (xmlState != 0)
+    if (xmlState != nullptr)
     {
         // check that it's the right type of xml..
         if (xmlState->hasTagName ("MYPLUGINSETTINGS"))

--- a/pizjuce/midiKeyboard/PizKeyboard.h
+++ b/pizjuce/midiKeyboard/PizKeyboard.h
@@ -22,11 +22,11 @@ enum parameters
 };
 
 static const char* const keymap = "zsxdcvgbhnjmq2w3er5t6y7ui9o0p[+]";
-static const int keymapLength   = String (keymap).length();
+static const int keymapLength   = juce::String (keymap).length();
 
 //==============================================================================
 class PizKeyboard : public PizAudioProcessor,
-                    public ChangeBroadcaster
+                    public juce::ChangeBroadcaster
 {
 public:
     //==============================================================================
@@ -37,14 +37,14 @@ public:
     void prepareToPlay (double sampleRate, int samplesPerBlock) override;
     void releaseResources() override;
 
-    void processBlock (AudioSampleBuffer& buffer,
-                       MidiBuffer& midiMessages) override;
+    void processBlock (juce::AudioSampleBuffer& buffer,
+                       juce::MidiBuffer& midiMessages) override;
 
     //==============================================================================
-    AudioProcessorEditor* createEditor() override;
+    juce::AudioProcessorEditor* createEditor() override;
 
     //==============================================================================
-    const String getName() const override;
+    const juce::String getName() const override;
     bool hasEditor() const override { return true; }
 
     int getNumParameters() override;
@@ -52,11 +52,11 @@ public:
     float getParameter (int index) override;
     void setParameter (int index, float newValue) override;
 
-    const String getParameterName (int index) override;
-    const String getParameterText (int index) override;
+    const juce::String getParameterName (int index) override;
+    const juce::String getParameterText (int index) override;
 
-    const String getInputChannelName (int channelIndex) const override;
-    const String getOutputChannelName (int channelIndex) const override;
+    const juce::String getInputChannelName (int channelIndex) const override;
+    const juce::String getOutputChannelName (int channelIndex) const override;
     bool isInputChannelStereoPair (int index) const override;
     bool isOutputChannelStereoPair (int index) const override;
 
@@ -72,11 +72,11 @@ public:
         lastProgram = curProgram;
         curProgram  = index;
     }
-    const String getProgramName (int index) override { return "State " + String (index + 1); }
-    void changeProgramName (int index, const String& newName) override {}
+    const juce::String getProgramName (int index) override { return "State " + juce::String (index + 1); }
+    void changeProgramName (int index, const juce::String& newName) override {}
 
     //==============================================================================
-    void getStateInformation (MemoryBlock& destData) override;
+    void getStateInformation (juce::MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
 
     //==============================================================================
@@ -84,8 +84,8 @@ public:
 
     // this is kept up to date with the midi messages that arrive, and the UI component
     // registers with it so it can represent the incoming messages
-    MidiKeyboardState progKbState[128];
-    MidiKeyboardState editorKbState;
+    juce::MidiKeyboardState progKbState[128];
+    juce::MidiKeyboardState editorKbState;
 
     // these are used to persist the UI's size - the values are stored along with the
     // filter's other parameters, and the UI component will update them when it gets
@@ -94,10 +94,8 @@ public:
     int keyPosition;
     int octave;
 
-    //==============================================================================
-    juce_UseDebuggingNewOperator
-
-        private : int lastProgram;
+private:
+    int lastProgram;
     int curProgram;
     float width;
     float velocity;
@@ -117,6 +115,8 @@ public:
     bool ccState[2];
 
     bool isCapsLockOn();
+
+    JUCE_LEAK_DETECTOR (PizKeyboard)
 };
 
 #endif

--- a/pizjuce/midiKeyboard/PizKeyboardComponent.cpp
+++ b/pizjuce/midiKeyboard/PizKeyboardComponent.cpp
@@ -1,14 +1,14 @@
 #include "PizKeyboardComponent.h"
 #include "PizKeyboardEditor.h"
 
-PizKeyboardComponent::PizKeyboardComponent (MidiKeyboardState& state, const Orientation orientation)
+PizKeyboardComponent::PizKeyboardComponent (juce::MidiKeyboardState& state, const Orientation orientation)
     : MidiKeyboardComponent (state, orientation),
       drawQwerty (false),
       drawNoteNumber (false)
 {
     s = &state;
-    for (int i = String (keymap).length(); --i >= 0;)
-        setKeyPressForNote (KeyPress (keymap[i], 0, 0), i);
+    for (int i = juce::String (keymap).length(); --i >= 0;)
+        setKeyPressForNote (juce::KeyPress (keymap[i], 0, 0), i);
     setKeyPressBaseOctave (4);
 }
 
@@ -56,7 +56,7 @@ bool PizKeyboardComponent::keyStateChanged (bool isKeyDown)
     return MidiKeyboardComponent::keyStateChanged (isKeyDown);
 }
 
-bool PizKeyboardComponent::mouseDownOnKey (int midiNoteNumber, const MouseEvent& e)
+bool PizKeyboardComponent::mouseDownOnKey (int midiNoteNumber, const juce::MouseEvent& e)
 {
     midiKeyboardEditor* editor = ((midiKeyboardEditor*) (this->getParentComponent()));
     if (e.mods.isAltDown())

--- a/pizjuce/midiKeyboard/PizKeyboardComponent.h
+++ b/pizjuce/midiKeyboard/PizKeyboardComponent.h
@@ -1,19 +1,17 @@
 #ifndef PIZMIDIKEYBOARDCOMPONENT_H
 #define PIZMIDIKEYBOARDCOMPONENT_H
 
-#include "juce_audio_utils/juce_audio_utils.h"
-#include "juce_graphics/juce_graphics.h"
+#include <juce_audio_utils/juce_audio_utils.h>
+#include <juce_graphics/juce_graphics.h>
 
 #include "PizKeyboard.h"
 
-using namespace juce;
-
-class PizKeyboardComponent : public MidiKeyboardComponent
+class PizKeyboardComponent : public juce::MidiKeyboardComponent
 {
 public:
-    PizKeyboardComponent (MidiKeyboardState& state, const Orientation orientation);
+    PizKeyboardComponent (juce::MidiKeyboardState& state, const Orientation orientation);
     bool keyStateChanged (bool isKeyDown) override;
-    void setKeyPressForNote (const KeyPress& key, const int midiNoteOffsetFromC)
+    void setKeyPressForNote (const juce::KeyPress& key, const int midiNoteOffsetFromC)
     {
         MidiKeyboardComponent::setKeyPressForNote (key, midiNoteOffsetFromC);
         _keyPressNotes.add (midiNoteOffsetFromC);
@@ -28,7 +26,7 @@ public:
     }
     int getKeyPressBaseOctave() { return baseOctave; }
     bool toggle;
-    void drawBlackNote (int midiNoteNumber, Graphics& g, juce::Rectangle<float> area, bool isDown, bool isOver, const Colour& textColour)
+    void drawBlackNote (int midiNoteNumber, juce::Graphics& g, juce::Rectangle<float> area, bool isDown, bool isOver, const juce::Colour& textColour)
     {
         auto x = area.getX(), y = area.getY(), w = area.getWidth(), h = area.getHeight();
         MidiKeyboardComponent::drawBlackNote (midiNoteNumber, g, area, isDown, isOver, textColour);
@@ -36,53 +34,53 @@ public:
         {
             if (midiNoteNumber >= baseOctave * 12 && midiNoteNumber < 32 + baseOctave * 12)
             {
-                int n      = midiNoteNumber - baseOctave * 12;
-                String key = String::charToString (keymap[n]);
-                g.setColour (Colours::white.withMultipliedAlpha (0.5f));
+                int n            = midiNoteNumber - baseOctave * 12;
+                juce::String key = juce::String::charToString (keymap[n]);
+                g.setColour (juce::Colours::white.withMultipliedAlpha (0.5f));
                 if (midiNoteNumber / 12 == baseOctave && midiNoteNumber % 12 == 0)
                 {
                     g.drawEllipse ((float) (x + w / 4), (float) (y + h - w), (float) (w / 2), (float) (w / 2), 2.f);
                 }
-                g.setFont (Font ((float) (w / 2), Font::bold));
-                g.drawText (key, x + w / 4, y + h - w, w / 2, w / 2, Justification::centred, false);
+                g.setFont (juce::Font ((float) (w / 2), juce::Font::bold));
+                g.drawText (key, x + w / 4, y + h - w, w / 2, w / 2, juce::Justification::centred, false);
             }
         }
         if (drawNoteNumber)
         {
-            Font f (jmin (12.0f, w * 0.9f));
+            juce::Font f (juce::jmin (12.0f, w * 0.9f));
             f.setHorizontalScale (0.8f);
             g.setFont (f);
-            g.setColour (Colours::white);
-            g.drawFittedText (String (midiNoteNumber), x + 2, y + 2, w - 4, h - 4, Justification::centredBottom, 1);
+            g.setColour (juce::Colours::white);
+            g.drawFittedText (juce::String (midiNoteNumber), x + 2, y + 2, w - 4, h - 4, juce::Justification::centredBottom, 1);
         }
     }
-    void drawWhiteNote (int midiNoteNumber, Graphics& g, juce::Rectangle<float> area, bool isDown, bool isOver, const Colour& lineColour, const Colour& textColour)
+    void drawWhiteNote (int midiNoteNumber, juce::Graphics& g, juce::Rectangle<float> area, bool isDown, bool isOver, const juce::Colour& lineColour, const juce::Colour& textColour)
     {
         auto x = area.getX(), y = area.getY(), w = area.getWidth(), h = area.getHeight();
-        MidiKeyboardComponent::drawWhiteNote (midiNoteNumber, g, area, isDown, isOver, lineColour, drawNoteNumber ? Colours::transparentWhite : textColour);
+        MidiKeyboardComponent::drawWhiteNote (midiNoteNumber, g, area, isDown, isOver, lineColour, drawNoteNumber ? juce::Colours::transparentWhite : textColour);
         if (hasKeyboardFocus (false) || drawQwerty)
         {
             if (midiNoteNumber >= baseOctave * 12 && midiNoteNumber < 32 + baseOctave * 12)
             {
-                int n      = midiNoteNumber - baseOctave * 12;
-                String key = String::charToString (keymap[n]);
-                g.setColour (Colours::grey.withMultipliedAlpha (0.5f));
+                int n            = midiNoteNumber - baseOctave * 12;
+                juce::String key = juce::String::charToString (keymap[n]);
+                g.setColour (juce::Colours::grey.withMultipliedAlpha (0.5f));
                 if (midiNoteNumber / 12 == baseOctave && midiNoteNumber % 12 == 0)
                 {
                     g.drawEllipse ((float) (x + w / 4), (float) (y + h - 3 * w / 4), (float) (w / 2), (float) (w / 2), 2.f);
                 }
-                g.setFont (Font ((float) (w / 2), Font::bold));
-                g.drawText (key, x + w / 4, y + h - 3 * w / 4, w / 2, w / 2, Justification::centred, false);
+                g.setFont (juce::Font ((float) (w / 2), juce::Font::bold));
+                g.drawText (key, x + w / 4, y + h - 3 * w / 4, w / 2, w / 2, juce::Justification::centred, false);
             }
         }
         if (drawNoteNumber)
         {
-            Font f (jmin (12.0f, w * 0.9f));
+            juce::Font f (juce::jmin (12.0f, w * 0.9f));
             f.setHorizontalScale (0.8f);
             //f.setBold (midiNoteNumber%12==0);
             g.setFont (f);
             g.setColour (textColour);
-            g.drawFittedText (String (midiNoteNumber), x + 2, y + 2, w - 4, h - 4, Justification::centredBottom, 1);
+            g.drawFittedText (juce::String (midiNoteNumber), x + 2, y + 2, w - 4, h - 4, juce::Justification::centredBottom, 1);
         }
     }
 
@@ -105,11 +103,11 @@ public:
 
 private:
     int baseOctave;
-    Array<KeyPress> _keyPresses;
-    BigInteger _keysPressed;
-    Array<int> _keyPressNotes;
-    bool mouseDownOnKey (int midiNoteNumber, const MouseEvent& e) override;
-    MidiKeyboardState* s;
+    juce::Array<juce::KeyPress> _keyPresses;
+    juce::BigInteger _keysPressed;
+    juce::Array<int> _keyPressNotes;
+    bool mouseDownOnKey (int midiNoteNumber, const juce::MouseEvent& e) override;
+    juce::MidiKeyboardState* s;
     bool drawQwerty;
     bool drawNoteNumber;
 

--- a/pizjuce/midiKeyboard/PizKeyboardEditor.cpp
+++ b/pizjuce/midiKeyboard/PizKeyboardEditor.cpp
@@ -23,6 +23,8 @@
 #include "PizKeyboardEditor.h"
 
 //[MiscUserDefs] You can add your own user definitions and misc code here...
+using juce::jmax;
+using juce::roundToInt;
 //[/MiscUserDefs]
 
 //==============================================================================
@@ -109,11 +111,11 @@ midiKeyboardEditor::midiKeyboardEditor (PizKeyboard* const ownerFilter)
 
     hideButton->setBounds (498, 1, 14, 14);
 
-    resizer.reset (new ResizableCornerComponent (this, &resizeLimits));
+    resizer.reset (new juce::ResizableCornerComponent (this, &resizeLimits));
     addAndMakeVisible (resizer.get());
     resizer->setName ("new component");
 
-    midiKeyboard.reset (new PizKeyboardComponent (ownerFilter->editorKbState, MidiKeyboardComponent::horizontalKeyboard));
+    midiKeyboard.reset (new PizKeyboardComponent (ownerFilter->editorKbState, juce::MidiKeyboardComponent::horizontalKeyboard));
     addAndMakeVisible (midiKeyboard.get());
 
     aboutBox.reset (new juce::TextEditor ("Instructions"));
@@ -236,7 +238,7 @@ void midiKeyboardEditor::paint (juce::Graphics& g)
 {
     //[UserPrePaint] Add your own custom painting code here..
     if (getFilter()->getParameter (kHidePanel))
-        g.fillAll (Colour (0xff8c8c8c));
+        g.fillAll (juce::Colour (0xff8c8c8c));
     else
     {
         //[/UserPrePaint]
@@ -384,7 +386,7 @@ void midiKeyboardEditor::buttonClicked (juce::Button* buttonThatWasClicked)
 }
 
 //[MiscUserCode] You can add your own definitions of your custom methods or any other code here...
-void midiKeyboardEditor::mouseUp (const MouseEvent& e)
+void midiKeyboardEditor::mouseUp (const juce::MouseEvent& e)
 {
     if (e.eventComponent == this)
     {
@@ -415,7 +417,7 @@ void midiKeyboardEditor::mouseUp (const MouseEvent& e)
     }
 }
 
-void midiKeyboardEditor::changeListenerCallback (ChangeBroadcaster* source)
+void midiKeyboardEditor::changeListenerCallback (juce::ChangeBroadcaster* source)
 {
     if (source == midiKeyboard.get())
     {
@@ -449,20 +451,20 @@ void midiKeyboardEditor::updateParametersFromFilter()
 
     filter->getCallbackLock().exit();
 
-    useProgCh->setToggleState (progch, dontSendNotification);
-    useCapsLock->setToggleState (capslock, dontSendNotification);
-    grabQwertyButton->setToggleState (qwerty, dontSendNotification);
-    showNumbersButton->setToggleState (showNumbers, dontSendNotification);
+    useProgCh->setToggleState (progch, juce::dontSendNotification);
+    useCapsLock->setToggleState (capslock, juce::dontSendNotification);
+    grabQwertyButton->setToggleState (qwerty, juce::dontSendNotification);
+    showNumbersButton->setToggleState (showNumbers, juce::dontSendNotification);
     midiKeyboard->setDrawNoteNumber (showNumbers);
     midiKeyboard->setDrawQwerty (qwerty);
     if (qwerty)
         midiKeyboard->grabKeyboardFocus();
     midiKeyboard->setMidiChannelsToDisplay (1 << ch);
     midiKeyboard->setMidiChannel (ch + 1);
-    chSlider->setValue (ch + 1, dontSendNotification);
-    yButton->setToggleState (useY, dontSendNotification);
+    chSlider->setValue (ch + 1, juce::dontSendNotification);
+    yButton->setToggleState (useY, juce::dontSendNotification);
     velocitySlider->setValue (velocity);
-    inputToggleButton->setToggleState (toggle, dontSendNotification);
+    inputToggleButton->setToggleState (toggle, juce::dontSendNotification);
     setMouseClickGrabsKeyboardFocus (qwerty);
     midiKeyboard->setMouseClickGrabsKeyboardFocus (qwerty);
     midiKeyboard->toggle = toggle;
@@ -470,7 +472,7 @@ void midiKeyboardEditor::updateParametersFromFilter()
     midiKeyboard->setLowestVisibleKey (keyPos);
     midiKeyboard->setKeyWidth (jmax ((float) getWidth() / 76.f, keywidth * 150.0f + 5.0f));
     midiKeyboard->setScrollButtonsVisible (keywidth > 0.f);
-    keyWidthSlider->setValue (keywidth * 100.f, dontSendNotification);
+    keyWidthSlider->setValue (keywidth * 100.f, juce::dontSendNotification);
 
     keyWidthSlider->setVisible (! hide);
     chSlider->setVisible (! hide);

--- a/pizjuce/midiKeyboard/PizKeyboardEditor.h
+++ b/pizjuce/midiKeyboard/PizKeyboardEditor.h
@@ -20,9 +20,9 @@
 #pragma once
 
 //[Headers]     -- You can add your own extra header files here --
-#include "juce_audio_processors/juce_audio_processors.h"
-#include "juce_events/juce_events.h"
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_events/juce_events.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
 #include "PizKeyboard.h"
 #include "PizKeyboardComponent.h"
@@ -50,11 +50,11 @@ public:
     //==============================================================================
     //[UserMethods]     -- You can add your own custom methods in this section.
     friend class PizKeyboardComponent;
-    void changeListenerCallback (ChangeBroadcaster* source) override;
-    void mouseUp (const MouseEvent& e) override;
-    bool keyPressed (const KeyPress& key, Component* originatingComponent) override
+    void changeListenerCallback (juce::ChangeBroadcaster* source) override;
+    void mouseUp (const juce::MouseEvent& e) override;
+    bool keyPressed (const juce::KeyPress& key, Component* originatingComponent) override
     {
-        DBG (String (key.getKeyCode()) + " " + key.getTextDescription());
+        DBG (juce::String (key.getKeyCode()) + " " + key.getTextDescription());
         return false;
     }
     //[/UserMethods]
@@ -66,8 +66,8 @@ public:
 
 private:
     //[UserVariables]   -- You can add your own custom variables in this section.
-    ComponentBoundsConstrainer resizeLimits;
-    TooltipWindow tooltipWindow;
+    juce::ComponentBoundsConstrainer resizeLimits;
+    juce::TooltipWindow tooltipWindow;
     void updateParametersFromFilter();
     PizKeyboard* getFilter() const throw() { return (PizKeyboard*) getAudioProcessor(); }
     //[/UserVariables]
@@ -81,7 +81,7 @@ private:
     std::unique_ptr<juce::ToggleButton> inputToggleButton;
     std::unique_ptr<juce::TextButton> aboutButton;
     std::unique_ptr<juce::TextButton> hideButton;
-    std::unique_ptr<ResizableCornerComponent> resizer;
+    std::unique_ptr<juce::ResizableCornerComponent> resizer;
     std::unique_ptr<PizKeyboardComponent> midiKeyboard;
     std::unique_ptr<juce::TextEditor> aboutBox;
     std::unique_ptr<juce::ToggleButton> useProgCh;

--- a/pizjuce/midiLooper/MidiLoop.cpp
+++ b/pizjuce/midiLooper/MidiLoop.cpp
@@ -1,5 +1,7 @@
 #include "MidiLoop.h"
 
+using juce::jlimit;
+
 Loop::Loop()
     : PizMidiMessageSequence(),
       currentIndex (0),
@@ -80,7 +82,7 @@ bool Loop::findNextNote()
     return false;
 }
 
-void Loop::playAllNotesAtCurrentTime (MidiBuffer& buffer, int sample_number, int velocity)
+void Loop::playAllNotesAtCurrentTime (juce::MidiBuffer& buffer, int sample_number, int velocity)
 {
     if (findNextNote())
     {
@@ -97,9 +99,9 @@ void Loop::playAllNotesAtCurrentTime (MidiBuffer& buffer, int sample_number, int
     }
 }
 
-void Loop::sendCurrentNoteToBuffer (MidiBuffer& buffer, int sample_number, int velocity)
+void Loop::sendCurrentNoteToBuffer (juce::MidiBuffer& buffer, int sample_number, int velocity)
 {
-    MidiMessage m = this->getEventPointer (currentIndex)->message;
+    juce::MidiMessage m = this->getEventPointer (currentIndex)->message;
     //playingNote[m.getNoteNumber()][m.getChannel()-1][0] = jlimit(0,127,m.getNoteNumber()+getTransposition());
     m.setNoteNumber (jlimit (0, 127, m.getNoteNumber() + getTransposition()));
     m.setVelocity ((((float) velocity * midiScaler * velocitySensitivity) + (1.f - velocitySensitivity)));
@@ -162,7 +164,7 @@ void Loop::resetNotes()
     }
 }
 
-void Loop::sendNoteOffMessagesToBuffer (MidiBuffer& buffer, int sample_number)
+void Loop::sendNoteOffMessagesToBuffer (juce::MidiBuffer& buffer, int sample_number)
 {
     for (int ch = 0; ch < 16; ch++)
     {
@@ -178,7 +180,7 @@ void Loop::sendNoteOffMessagesToBuffer (MidiBuffer& buffer, int sample_number)
     }
 }
 
-MidiMessage Loop::getCurrentMessage()
+juce::MidiMessage Loop::getCurrentMessage()
 {
     if (currentIndex >= this->getNumEvents())
         currentIndex = 0;
@@ -192,7 +194,7 @@ double Loop::getCurrentTime()
 
 void Loop::cleanZeroLengthNotes()
 {
-    Array<int> matchedNoteOffs;
+    juce::Array<int> matchedNoteOffs;
     for (int i = 0; i < getNumEvents(); i++)
     {
         if (getEventPointer (i)->message.isNoteOn())

--- a/pizjuce/midiLooper/MidiLoop.h
+++ b/pizjuce/midiLooper/MidiLoop.h
@@ -61,15 +61,15 @@ public:
 
     void startRecording();
     bool findNextNote();
-    void playAllNotesAtCurrentTime (MidiBuffer& buffer, int sample_number, int velocity);
-    void sendCurrentNoteToBuffer (MidiBuffer& buffer, int sample_number, int velocity);
+    void playAllNotesAtCurrentTime (juce::MidiBuffer& buffer, int sample_number, int velocity);
+    void sendCurrentNoteToBuffer (juce::MidiBuffer& buffer, int sample_number, int velocity);
     bool isNotePlaying (PizMidiMessageSequence::mehPtr note, int p);
     bool isNotePlaying (PizMidiMessageSequence::mehPtr note);
     bool isTriggerNote (int note);
     void setTriggerNote (int note);
     void resetNotes();
-    void sendNoteOffMessagesToBuffer (MidiBuffer& buffer, int sample_number);
-    MidiMessage getCurrentMessage();
+    void sendNoteOffMessagesToBuffer (juce::MidiBuffer& buffer, int sample_number);
+    juce::MidiMessage getCurrentMessage();
     double getCurrentTime();
     int getIndexOfNote (int noteNumber, double time, bool exact = false);
     void convertTimeBase (short timeBase);
@@ -100,7 +100,7 @@ public:
     float velocitySensitivity;
     double chordTolerance;
     double Qdelta[128][16]; // quantization shift for each note (to shift noteoff the same amount)
-    Array<LoopNote> playingNotes[polyphony];
+    juce::Array<LoopNote> playingNotes[polyphony];
 
 private:
     double length;

--- a/pizjuce/midiLooper/PianoRoll.h
+++ b/pizjuce/midiLooper/PianoRoll.h
@@ -1,13 +1,11 @@
 #ifndef PIZ_PIANO_ROLL_HEADER
 #define PIZ_PIANO_ROLL_HEADER
 
-#include "juce_audio_processors/juce_audio_processors.h"
-#include "juce_events/juce_events.h"
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_events/juce_events.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
 #include "MidiLoop.h"
-
-using namespace juce;
 
 class PianoRoll;
 
@@ -37,7 +35,7 @@ struct PizNote
     PizMidiMessageSequence::mehPtr object;
 };
 
-class Timeline : public Component, public ChangeBroadcaster
+class Timeline : public juce::Component, public juce::ChangeBroadcaster
 {
     friend class PianoRoll;
 
@@ -47,7 +45,7 @@ public:
 
     void setPianoRoll (PianoRoll* pr);
 
-    void paint (Graphics& g) override;
+    void paint (juce::Graphics& g) override;
     float getStartPixel();
     float getEndPixel();
     double getLength();
@@ -55,8 +53,8 @@ public:
 
     void setLoop (double start, double length);
 
-    void mouseDown (const MouseEvent& e) override;
-    void mouseDrag (const MouseEvent& e) override;
+    void mouseDown (const juce::MouseEvent& e) override;
+    void mouseDrag (const juce::MouseEvent& e) override;
 
     int scrollOffset;
 
@@ -66,15 +64,15 @@ private:
     PianoRoll* roll;
 };
 
-class PianoPort : public Viewport, public ChangeBroadcaster
+class PianoPort : public juce::Viewport, public juce::ChangeBroadcaster
 {
 public:
-    PianoPort (String name) : Viewport (name){};
+    PianoPort (juce::String name) : Viewport (name){};
     ~PianoPort() override { dispatchPendingMessages(); }
     void setTimeline (Timeline* t) { timeline = t; }
     void setPlayline (Component* p) { playline = p; }
     void setKeyboard (Viewport* kb) { keyboard = kb; }
-    void mouseWheelMove (const MouseEvent& e, const MouseWheelDetails& wheel) override
+    void mouseWheelMove (const juce::MouseEvent& e, const juce::MouseWheelDetails& wheel) override
     {
         this->getParentComponent()->mouseWheelMove (e, wheel);
     }
@@ -94,14 +92,14 @@ private:
     Viewport* keyboard;
 };
 
-class PianoRoll : public Component,
-                  public ChangeBroadcaster
+class PianoRoll : public juce::Component,
+                  public juce::ChangeBroadcaster
 {
     friend class Timeline;
     friend class PianoPort;
 
 public:
-    PianoRoll (AudioProcessor* _plugin, AudioProcessorEditor* _owner, Timeline* _timeline);
+    PianoRoll (juce::AudioProcessor* _plugin, juce::AudioProcessorEditor* _owner, Timeline* _timeline);
     ~PianoRoll() override;
 
     void setSequence (Loop* sequence_);
@@ -126,7 +124,7 @@ public:
         int pixelBarLength = (int) ppqToPixels (getPpqPerBar());
         blankLength        = getPpqPerBar() * bars;
         sequenceChanged();
-        setSize ((int) ppqToPixels (jmax (blankLength, seqLengthInPpq)), getHeight());
+        setSize ((int) ppqToPixels (juce::jmax (blankLength, seqLengthInPpq)), getHeight());
     }
     void addBar()
     {
@@ -137,18 +135,18 @@ public:
     void removeBar()
     {
         int pixelBarLength = (int) ppqToPixels (getPpqPerBar());
-        setDisplayLength (jmax (getPpqPerBar(), seqLengthInPpq - getPpqPerBar()));
-        setSize (jmax (pixelBarLength, getWidth() - pixelBarLength), getHeight());
+        setDisplayLength (juce::jmax (getPpqPerBar(), seqLengthInPpq - getPpqPerBar()));
+        setSize (juce::jmax (pixelBarLength, getWidth() - pixelBarLength), getHeight());
     }
-    int getDisplayLength() { return (int) (jmax (blankLength, seqLengthInPpq) / getPpqPerBar()); }
+    int getDisplayLength() { return (int) (juce::jmax (blankLength, seqLengthInPpq) / getPpqPerBar()); }
 
-    void mouseDown (const MouseEvent& e) override;
-    void mouseDrag (const MouseEvent& e) override;
-    void mouseUp (const MouseEvent& e) override;
+    void mouseDown (const juce::MouseEvent& e) override;
+    void mouseDrag (const juce::MouseEvent& e) override;
+    void mouseUp (const juce::MouseEvent& e) override;
     //void mouseMove (const MouseEvent& e);
-    void mouseDoubleClick (const MouseEvent& e) override;
+    void mouseDoubleClick (const juce::MouseEvent& e) override;
 
-    void paintOverChildren (Graphics& g) override;
+    void paintOverChildren (juce::Graphics& g) override;
     void resized() override;
 
     bool getSnap() { return snapToGrid; }
@@ -192,8 +190,8 @@ public:
 
 private:
     juce::Rectangle<int> lasso;
-    Array<PizMidiMessageSequence::mehPtr> selectedNotes;
-    Array<PizNote> selectedNoteLengths;
+    juce::Array<PizMidiMessageSequence::mehPtr> selectedNotes;
+    juce::Array<PizNote> selectedNoteLengths;
     void addToSelection (PizMidiMessageSequence::mehPtr note)
     {
         if (note->message.isNoteOn())
@@ -215,15 +213,15 @@ private:
     public:
         Playbar (PianoRoll* pianoroll) : Component(), roll (pianoroll) {}
         ~Playbar() override {}
-        void paint (Graphics& g) override
+        void paint (juce::Graphics& g) override
         {
-            g.fillAll (Colour (0x0));
+            g.fillAll (juce::Colour (0x0));
             //if (sequence->isRecording) {
             //	g.setColour(Colours::red);
             //	g.drawVerticalLine((int)((float)sequence->recTime*(float)getWidth()/seqLengthInPpq),0.f,(float)getHeight());
             //}
             //else {
-            g.setColour (Colours::green);
+            g.setColour (juce::Colours::green);
             g.drawVerticalLine ((int) roll->ppqToPixelsWithOffset (roll->playTime), 0.f, (float) getHeight());
             //}
         }
@@ -240,7 +238,7 @@ private:
             setBufferedToImage (true);
         }
         ~PianoRollBackground() override {}
-        void paint (Graphics& g) override
+        void paint (juce::Graphics& g) override
         {
             const PianoRoll* roll = (PianoRoll*) getParentComponent();
             int n                 = 0;
@@ -250,20 +248,20 @@ private:
             while (y > 0)
             {
                 if (getNoteNameWithoutOctave (n).contains ("#"))
-                    g.setColour (Colours::lightgrey);
+                    g.setColour (juce::Colours::lightgrey);
                 else if (n == 60)
-                    g.setColour (Colours::yellow);
+                    g.setColour (juce::Colours::yellow);
                 else
-                    g.setColour (Colours::white);
+                    g.setColour (juce::Colours::white);
                 g.fillRect (0.f, y - yinc, (float) getWidth(), yinc);
                 if (getNoteNameWithoutOctave (n).contains ("F") && ! getNoteNameWithoutOctave (n).contains ("#"))
                 {
-                    g.setColour (Colours::grey);
+                    g.setColour (juce::Colours::grey);
                     g.drawLine (0.f, y, (float) getWidth(), y, 1);
                 }
                 if (getNoteNameWithoutOctave (n).contains ("C") && ! getNoteNameWithoutOctave (n).contains ("#"))
                 {
-                    g.setColour (Colours::black);
+                    g.setColour (juce::Colours::black);
                     g.drawLine (0.f, y, (float) getWidth(), y, 1);
                 }
                 n++;
@@ -275,7 +273,7 @@ private:
                 //draw grid
                 if (! (fmod (x, roll->barSize) < 0.0001) && ! (fmod (x, roll->beatSize) < 0.0001))
                 {
-                    g.setColour (Colours::lightgrey);
+                    g.setColour (juce::Colours::lightgrey);
                     g.drawLine (x, 0.f, x, (float) getHeight());
                 }
                 x += roll->gridSize;
@@ -286,7 +284,7 @@ private:
                 //draw beats
                 if (! (fmod (x, roll->barSize) < 0.0001))
                 {
-                    g.setColour (Colours::grey);
+                    g.setColour (juce::Colours::grey);
                     g.drawLine (x, 0.f, x, (float) getHeight());
                 }
                 x += roll->beatSize;
@@ -295,7 +293,7 @@ private:
             while (x < getWidth())
             {
                 //draw bars
-                g.setColour (Colours::black);
+                g.setColour (juce::Colours::black);
                 g.drawLine (x, 0.f, x, (float) getHeight());
                 x += roll->barSize;
             }
@@ -310,7 +308,7 @@ private:
             setBufferedToImage (true);
         }
         ~PianoRollNotes() override {}
-        void paint (Graphics& g) override
+        void paint (juce::Graphics& g) override
         {
             const PianoRoll* roll = (PianoRoll*) getParentComponent();
             if (roll->barSize > 0)
@@ -321,7 +319,7 @@ private:
                     {
                         if (roll->sequence->getEventPointer (i)->message.isNoteOn() /* && (i-9999!=hoveringNote)*/)
                         {
-                            float noteLength = (float) (jmax (1.0, (roll->sequence->getEventTime (roll->sequence->getIndexOfMatchingKeyUp (i)) - roll->sequence->getEventTime (i))) * (double) getWidth() / roll->seqLengthInPpq);
+                            float noteLength = (float) (juce::jmax (1.0, (roll->sequence->getEventTime (roll->sequence->getIndexOfMatchingKeyUp (i)) - roll->sequence->getEventTime (i))) * (double) getWidth() / roll->seqLengthInPpq);
                             //if (i==sequence->indexOfLastNoteOn
                             //	|| abs(sequence->getEventTime(i)-sequence->getEventTime(sequence->indexOfLastNoteOn))<sequence->chordTolerance)
                             //	g.setColour(Colours::blue);
@@ -329,7 +327,7 @@ private:
                             if (roll->selectedNotes.contains (roll->sequence->getEventPointer (i)))
                             {
                                 //outline of original note position
-                                g.setColour (Colours::blue);
+                                g.setColour (juce::Colours::blue);
                                 g.drawRect ((float) getWidth() * (float) (roll->sequence->getEventTime (i) / roll->seqLengthInPpq),
                                             (float) getHeight() - (float) (roll->sequence->getEventPointer (i)->message.getNoteNumber()) * roll->yinc - roll->yinc,
                                             noteLength,
@@ -338,12 +336,12 @@ private:
                                 //dragging note position
                                 const double newTime = (float) ((roll->sequence->getEventTime (i) + roll->draggingNoteTimeDelta));
                                 const float newNote  = (float) (roll->sequence->getEventPointer (i)->message.getNoteNumber() + roll->draggingNoteTransposition);
-                                g.setColour (Colours::darkgoldenrod.withAlpha (roll->sequence->getEventPointer (i)->message.getFloatVelocity()));
+                                g.setColour (juce::Colours::darkgoldenrod.withAlpha (roll->sequence->getEventPointer (i)->message.getFloatVelocity()));
                                 g.fillRect ((float) getWidth() * (float) (newTime / roll->seqLengthInPpq),
                                             (float) getHeight() - newNote * roll->yinc - roll->yinc,
                                             noteLength,
                                             roll->yinc);
-                                g.setColour (Colours::red);
+                                g.setColour (juce::Colours::red);
                                 g.drawRect ((float) getWidth() * (float) (newTime / roll->seqLengthInPpq),
                                             (float) getHeight() - newNote * roll->yinc - roll->yinc,
                                             noteLength,
@@ -351,12 +349,12 @@ private:
                             }
                             else
                             {
-                                g.setColour (Colours::darkgoldenrod.withAlpha (roll->sequence->getEventPointer (i)->message.getFloatVelocity()));
+                                g.setColour (juce::Colours::darkgoldenrod.withAlpha (roll->sequence->getEventPointer (i)->message.getFloatVelocity()));
                                 g.fillRect ((float) getWidth() * (float) (roll->sequence->getEventTime (i) / roll->seqLengthInPpq),
                                             (float) getHeight() - (float) (roll->sequence->getEventPointer (i)->message.getNoteNumber()) * roll->yinc - roll->yinc,
                                             noteLength,
                                             roll->yinc);
-                                g.setColour (Colours::black);
+                                g.setColour (juce::Colours::black);
                                 g.drawRect ((float) getWidth() * (float) (roll->sequence->getEventTime (i) / roll->seqLengthInPpq),
                                             (float) getHeight() - (float) (roll->sequence->getEventPointer (i)->message.getNoteNumber()) * roll->yinc - roll->yinc,
                                             noteLength,
@@ -373,8 +371,8 @@ private:
     Playbar* playline;
     PianoRollBackground* bg;
     PianoRollNotes* noteLayer;
-    AudioProcessor* plugin;
-    AudioProcessorEditor* owner;
+    juce::AudioProcessor* plugin;
+    juce::AudioProcessorEditor* owner;
     Loop* sequence;
     PizMidiMessageSequence::mehPtr hoveringNote;
     int hoveringNoteIndex;
@@ -389,7 +387,7 @@ private:
     float xinc;
     float yinc;
     double lastDragTime;
-    uint8 draggingNoteChannel;
+    juce::uint8 draggingNoteChannel;
     int draggingNoteNumber;
     int draggingNoteVelocity;
     int originalNoteVelocity;

--- a/pizjuce/midiLooper/PizLooper.cpp
+++ b/pizjuce/midiLooper/PizLooper.cpp
@@ -1,6 +1,8 @@
 #include "PizLooper.h"
 #include "PizLooperEditor.h"
 
+using juce::roundToInt;
+
 //==============================================================================
 juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()
 {
@@ -74,7 +76,7 @@ JuceProgram::JuceProgram()
     measureFromHere = 0;
 
     numerator = denominator = 4;
-    device                  = MidiDeviceInfo();
+    device                  = juce::MidiDeviceInfo();
 
     //program name
     name = "Default";
@@ -106,12 +108,12 @@ PizLooper::PizLooper() : programs (0), slotLimit (numSlots)
     }
     lastUIWidth  = 800;
     lastUIHeight = 487;
-    devices      = MidiOutput::getAvailableDevices();
+    devices      = juce::MidiOutput::getAvailableDevices();
     recCC = playCC = -1;
     midiOutput     = NULL;
     info           = new Info();
-    loopDir        = ((File::getSpecialLocation (File::currentExecutableFile)).getParentDirectory()).getFullPathName()
-            + File::getSeparatorString() + String ("midiloops");
+    loopDir        = ((juce::File::getSpecialLocation (juce::File::currentExecutableFile)).getParentDirectory()).getFullPathName()
+            + juce::File::getSeparatorString() + juce::String ("midiloops");
 
     //look for a default bank
     if (! loadDefaultFxb())
@@ -120,7 +122,7 @@ PizLooper::PizLooper() : programs (0), slotLimit (numSlots)
         for (int i = 0; i < getNumPrograms(); i++)
         {
             // name programs "Loop 1" - "Loop 128" and then look for midi files "Loop 1.mid" etc.
-            programs[i].name = String ("Loop ") + String (i + 1);
+            programs[i].name = juce::String ("Loop ") + juce::String (i + 1);
             for (int p = 0; p < numGlobalParams; p++)
                 param[p] = programs[i].param[p];
             for (int p = 0; p < numParamsPerSlot; p++)
@@ -207,7 +209,7 @@ PizLooper::~PizLooper()
 }
 
 //==============================================================================
-const String PizLooper::getName() const
+const juce::String PizLooper::getName() const
 {
     return JucePlugin_Name;
 }
@@ -262,12 +264,12 @@ void PizLooper::setParameter (int index, float newValue)
                 {
                     if (newValue == 1.0f)
                     {
-                        writeMidiFile (curProgram, File (loopDir), true);
+                        writeMidiFile (curProgram, juce::File (loopDir), true);
                         param[kSave] = 0.f;
                     }
                     else if (newValue == 0.9f)
                     {
-                        writeMidiFile (curProgram, File (loopDir), false);
+                        writeMidiFile (curProgram, juce::File (loopDir), false);
                         param[kSave] = 0.f;
                     }
                 }
@@ -404,25 +406,25 @@ void PizLooper::setActiveSlot (int slot)
                 keySelectorState.noteOn (1, i, 1.f);
         }
         kbstate.reset();
-        info->s = (getParameterForSlot (kPlay, slot) >= 0.5f) ? "Playing (" + String (currentPoly[slot]) + ")" : "Stopped";
+        info->s = (getParameterForSlot (kPlay, slot) >= 0.5f) ? "Playing (" + juce::String (currentPoly[slot]) + ")" : "Stopped";
         newLoop = true;
         sendChangeMessage();
     }
 }
 
-void PizLooper::setActiveDevice (String name)
+void PizLooper::setActiveDevice (juce::String name)
 {
     setActiveDevice (getDeviceByName (name));
 }
 
-void PizLooper::setActiveDevice (MidiDeviceInfo device)
+void PizLooper::setActiveDevice (juce::MidiDeviceInfo device)
 {
     getCallbackLock().enter();
     if (midiOutput != nullptr)
     {
         midiOutput->stopBackgroundThread();
     }
-    midiOutput = MidiOutput::openDevice (device.identifier);
+    midiOutput = juce::MidiOutput::openDevice (device.identifier);
     if (midiOutput != nullptr)
     {
         midiOutput->startBackgroundThread();
@@ -439,295 +441,295 @@ void PizLooper::setActiveDevice (MidiDeviceInfo device)
         programs[i].device = device;
 }
 
-MidiDeviceInfo PizLooper::getDeviceByName (String name) const
+juce::MidiDeviceInfo PizLooper::getDeviceByName (juce::String name) const
 {
     return devices.findIf ([&] (auto const& device)
                            { return name == device.name; });
 }
 
-const String PizLooper::getParameterName (int index)
+const juce::String PizLooper::getParameterName (int index)
 {
     if (index == kThru)
-        return String ("MidiThru");
+        return juce::String ("MidiThru");
     if (index == kMonitor)
-        return String ("Monitor");
+        return juce::String ("Monitor");
     if (index == kFile)
-        return String ("File");
+        return juce::String ("File");
     if (index == kSave)
-        return String ("Save");
+        return juce::String ("Save");
     if (index == kSync)
-        return String ("SyncMode");
+        return juce::String ("SyncMode");
     if (index == kRecStep)
-        return String ("LoopStepsize");
+        return juce::String ("LoopStepsize");
     if (index == kQuantize)
-        return String ("InputQuantize");
+        return juce::String ("InputQuantize");
     if (index == kFixedLength)
-        return String ("FixedLengh");
+        return juce::String ("FixedLengh");
     if (index == kRecMode)
-        return String ("RecMode");
+        return juce::String ("RecMode");
     if (index == kSingleLoop)
-        return String ("SingleMode");
+        return juce::String ("SingleMode");
     if (index == kPlayMain)
-        return String ("MasterPlay");
+        return juce::String ("MasterPlay");
     if (index == kRecordMain)
-        return String ("MasterRecord");
+        return juce::String ("MasterRecord");
     if (index == kMasterVelocity)
-        return String ("MasterVelocity");
+        return juce::String ("MasterVelocity");
     if (index == kMasterTranspose)
-        return String ("MasterTranspose");
+        return juce::String ("MasterTranspose");
     if (index == kMidiOutDevice)
-        return String ("MidiOutDevice");
+        return juce::String ("MidiOutDevice");
     if (index == kParamsToHost)
-        return String ("HostAutomation");
+        return juce::String ("HostAutomation");
     if (index == kPlayCC)
-        return String ("MasterPlayCC");
+        return juce::String ("MasterPlayCC");
     if (index == kRecCC)
-        return String ("MasterRecCC");
+        return juce::String ("MasterRecCC");
     for (int i = 0; i < numSlots; i++)
     {
         int p = index - i * numParamsPerSlot;
         switch (p)
         {
             case kRecord:
-                return String ("Record") + String (i + 1);
+                return juce::String ("Record") + juce::String (i + 1);
             case kPlay:
-                return String ("Play") + String (i + 1);
+                return juce::String ("Plajuce::y") + juce::String (i + 1);
             case kTranspose:
-                return String ("Transpose") + String (i + 1);
+                return juce::String ("Transpose") + juce::String (i + 1);
             case kOctave:
-                return String ("OctaveShift") + String (i + 1);
+                return juce::String ("OctaveShift") + juce::String (i + 1);
             case kVelocity:
-                return String ("VelocityScale") + String (i + 1);
+                return juce::String ("VelocityScale") + juce::String (i + 1);
             case kVeloSens:
-                return String ("VelocitySens") + String (i + 1);
+                return juce::String ("VelocitySens") + juce::String (i + 1);
             case kShift:
-                return String ("BeatShift") + String (i + 1);
+                return juce::String ("BeatShift") + juce::String (i + 1);
             case kLoopStart:
-                return String ("LoopStart") + String (i + 1);
+                return juce::String ("LoopStart") + juce::String (i + 1);
             case kLoopEnd:
-                return String ("LoopEnd") + String (i + 1);
+                return juce::String ("LoopEnd") + juce::String (i + 1);
             case kStretch:
-                return String ("Stretch") + String (i + 1);
+                return juce::String ("Stretch") + juce::String (i + 1);
             case kTrigger:
-                return String ("LoopMode") + String (i + 1);
+                return juce::String ("LoopMode") + juce::String (i + 1);
             case kNoteTrig:
-                return String ("NoteTrigger") + String (i + 1);
+                return juce::String ("NoteTrigger") + juce::String (i + 1);
             case kRoot:
-                return String ("RootNote") + String (i + 1);
+                return juce::String ("RootNote") + juce::String (i + 1);
             case kNLow:
-                return String ("LowNote") + String (i + 1);
+                return juce::String ("LowNote") + juce::String (i + 1);
             case kNHigh:
-                return String ("HighNote") + String (i + 1);
+                return juce::String ("HighNote") + juce::String (i + 1);
             case kChannel:
-                return String ("Channel") + String (i + 1);
+                return juce::String ("Channel") + juce::String (i + 1);
             case kTrigChan:
-                return String ("NoteTrigChannel") + String (i + 1);
+                return juce::String ("NoteTrigChannel") + juce::String (i + 1);
             case kFiltChan:
-                return String ("ChannelMode") + String (i + 1);
+                return juce::String ("ChannelMode") + juce::String (i + 1);
             case kFullRelease:
-                return String ("FullRelease") + String (i + 1);
+                return juce::String ("FullRelease") + juce::String (i + 1);
             case kWaitForBar:
-                return String ("WaitForBar") + String (i + 1);
+                return juce::String ("WaitForBar") + juce::String (i + 1);
             case kNumLoops:
-                return String ("NumLoops") + String (i + 1);
+                return juce::String ("NumLoops") + juce::String (i + 1);
             case kNextSlot:
-                return String ("NextSlot") + String (i + 1);
+                return juce::String ("NextSlot") + juce::String (i + 1);
             case kPlayGroup:
-                return String ("PlayGroup") + String (i + 1);
+                return juce::String ("PlayGroup") + juce::String (i + 1);
             case kMuteGroup:
-                return String ("MuteGroup") + String (i + 1);
+                return juce::String ("MuteGroup") + juce::String (i + 1);
             case kForceToKey:
-                return String ("ForceToScale") + String (i + 1);
+                return juce::String ("ForceToScale") + juce::String (i + 1);
             case kForceToScaleMode:
-                return String ("ForceMode") + String (i + 1);
+                return juce::String ("ForceMode") + juce::String (i + 1);
             case kScaleChannel:
-                return String ("ScaleChannel") + String (i + 1);
+                return juce::String ("ScaleChannel") + juce::String (i + 1);
             case kTransposeChannel:
-                return String ("TransposeChannel") + String (i + 1);
+                return juce::String ("TransposeChannel") + juce::String (i + 1);
             case kUseScaleChannel:
-                return String ("UseScaleChan") + String (i + 1);
+                return juce::String ("UseScaleChan") + juce::String (i + 1);
             case kUseTrChannel:
-                return String ("UseTransChan") + String (i + 1);
+                return juce::String ("UseTransChan") + juce::String (i + 1);
             case kNote0:
-                return String ("C") + String (i + 1);
+                return juce::String ("C") + juce::String (i + 1);
             case kNote1:
-                return String ("Csharp") + String (i + 1);
+                return juce::String ("Csharp") + juce::String (i + 1);
             case kNote2:
-                return String ("D") + String (i + 1);
+                return juce::String ("D") + juce::String (i + 1);
             case kNote3:
-                return String ("Dsharp") + String (i + 1);
+                return juce::String ("Dsharp") + juce::String (i + 1);
             case kNote4:
-                return String ("E") + String (i + 1);
+                return juce::String ("E") + juce::String (i + 1);
             case kNote5:
-                return String ("F") + String (i + 1);
+                return juce::String ("F") + juce::String (i + 1);
             case kNote6:
-                return String ("Fsharp") + String (i + 1);
+                return juce::String ("Fsharp") + juce::String (i + 1);
             case kNote7:
-                return String ("G") + String (i + 1);
+                return juce::String ("G") + juce::String (i + 1);
             case kNote8:
-                return String ("Gsharp") + String (i + 1);
+                return juce::String ("Gsharp") + juce::String (i + 1);
             case kNote9:
-                return String ("A") + String (i + 1);
+                return juce::String ("A") + juce::String (i + 1);
             case kNote10:
-                return String ("Asharp") + String (i + 1);
+                return juce::String ("Asharp") + juce::String (i + 1);
             case kNote11:
-                return String ("B") + String (i + 1);
+                return juce::String ("B") + juce::String (i + 1);
             case kImmediateTranspose:
-                return String ("SplitTrnsp") + String (i + 1);
+                return juce::String ("SplitTrnsp") + juce::String (i + 1);
             case kTranspose10:
-                return String ("Ch10Transpose") + String (i + 1);
+                return juce::String ("Ch10Transpose") + juce::String (i + 1);
             case kReverse:
-                return String ("Reverse") + String (i + 1);
+                return juce::String ("Reverse") + juce::String (i + 1);
             case kNoteToggle:
-                return String ("NoteToggle") + String (i + 1);
+                return juce::String ("NoteToggle") + juce::String (i + 1);
             default:
                 break;
         }
     }
-    return String();
+    return juce::String();
 }
 
-const String PizLooper::getParameterText (int index)
+const juce::String PizLooper::getParameterText (int index)
 {
     if (index == kMasterVelocity)
-        return String (roundToInt (getParameter (index) * 200.f)) + String ("%");
+        return juce::String (roundToInt (getParameter (index) * 200.f)) + juce::String ("%");
     if (index == kThru)
     {
         if (getParameter (index) < 0.5f)
-            return String ("Off");
-        return String ("On");
+            return juce::String ("Off");
+        return juce::String ("On");
     }
     if (index == kMonitor)
     {
         if (getParameter (index) < 0.5f)
-            return String ("Off");
-        return String ("On");
+            return juce::String ("Off");
+        return juce::String ("On");
     }
     if (index == kSingleLoop)
     {
         if (getParameter (index) < 0.5f)
-            return String ("Multi");
-        return String ("Single");
+            return juce::String ("Multi");
+        return juce::String ("Single");
     }
     if (index == kPlayMain)
     {
         if (getParameter (index) < 0.5f)
-            return String ("Stopped");
-        return String ("Playing");
+            return juce::String ("Stopped");
+        return juce::String ("Playing");
     }
     if (index == kRecordMain)
     {
         if (getParameter (index) < 0.5f)
-            return String ("Off");
-        return String ("Recording");
+            return juce::String ("Off");
+        return juce::String ("Recording");
     }
     if (index == kPlayCC)
     {
         if (playCC == -2)
-            return String ("Learn...");
+            return juce::String ("Learn...");
         if (playCC == -1)
-            return String ("No CC");
-        return "CC " + String (playCC);
+            return juce::String ("No CC");
+        return "CC " + juce::String (playCC);
     }
     if (index == kRecCC)
     {
         if (recCC == -2)
-            return String ("Learn...");
+            return juce::String ("Learn...");
         if (recCC == -1)
-            return String ("No CC");
-        return "CC " + String (recCC);
+            return juce::String ("No CC");
+        return "CC " + juce::String (recCC);
     }
     if (index == kFile)
     {
         if (getParameter (index) < 0.4f)
-            return String ("<-Clear");
+            return juce::String ("<-Clear");
         if (getParameter (index) > 0.6f)
-            return String ("Load->");
+            return juce::String ("Load->");
         if (getParameter (index) == 0.0f)
-            return String ("Clear!");
+            return juce::String ("Clear!");
         if (getParameter (index) == 1.0f)
-            return String ("Load!");
-        return String ("<-Clear/Load->");
+            return juce::String ("Load!");
+        return juce::String ("<-Clear/Load->");
     }
     if (index == kSave)
     {
-        return String ("Save->");
+        return juce::String ("Save->");
     }
     if (index == kSync)
     {
         if (getParameter (index) < 0.25f)
-            return String ("PPQ (Host 0)");
+            return juce::String ("PPQ (Host 0)");
         if (getParameter (index) < 0.5f)
-            return String ("PPQ (Recstart)");
-        return String ("Sample");
+            return juce::String ("PPQ (Recstart)");
+        return juce::String ("Sample");
     }
     if (index == kRecStep)
     {
         if (getParameter (index) < 0.1)
-            return String ("1 Bar");
+            return juce::String ("1 Bar");
         if (getParameter (index) < 0.2)
-            return String ("3 Beats");
+            return juce::String ("3 Beats");
         if (getParameter (index) < 0.3)
-            return String ("2 Beats");
+            return juce::String ("2 Beats");
         if (getParameter (index) < 0.4)
-            return String ("1 Beat");
+            return juce::String ("1 Beat");
         if (getParameter (index) < 0.5)
-            return String ("8th Note");
+            return juce::String ("8th Note");
         if (getParameter (index) < 0.6)
-            return String ("16th Note");
-        return String ("1 Tick");
+            return juce::String ("16th Note");
+        return juce::String ("1 Tick");
     }
     if (index == kQuantize)
     {
         if (getParameter (index) == 0.0)
-            return String ("Off");
+            return juce::String ("Off");
         if (getParameter (index) < 0.3)
-            return String ("8th");
+            return juce::String ("8th");
         if (getParameter (index) < 0.6)
-            return String ("16th");
+            return juce::String ("16th");
         if (getParameter (index) < 0.9)
-            return String ("32nd");
-        return String ("64th");
+            return juce::String ("32nd");
+        return juce::String ("64th");
     }
     if (index == kFixedLength)
     {
         const int l = roundToInt (getParameter (index) * 32);
         if (l == 0)
-            return String ("Manual");
+            return juce::String ("Manual");
         if (getParameter (kRecStep) < 0.1)
-            return String (l) + String (" Bar") + (l > 1 ? "s" : "");
+            return juce::String (l) + juce::String (" Bar") + (l > 1 ? "s" : "");
         if (getParameter (kRecStep) < 0.2)
-            return String (l * 3) + String (" Beats");
+            return juce::String (l * 3) + juce::String (" Beats");
         if (getParameter (kRecStep) < 0.3)
-            return String (l * 2) + String (" Beats");
+            return juce::String (l * 2) + juce::String (" Beats");
         if (getParameter (kRecStep) < 0.4)
-            return String (l) + String (" Beat") + (l > 1 ? "s" : "");
+            return juce::String (l) + juce::String (" Beat") + (l > 1 ? "s" : "");
         if (getParameter (kRecStep) < 0.5)
-            return String (l) + String (" 8th Note") + (l > 1 ? "s" : "");
+            return juce::String (l) + juce::String (" 8th Note") + (l > 1 ? "s" : "");
         if (getParameter (kRecStep) < 0.6)
-            return String (l) + String (" 16th Note") + (l > 1 ? "s" : "");
+            return juce::String (l) + juce::String (" 16th Note") + (l > 1 ? "s" : "");
         else
-            return String (l) + String (" Tick") + (l > 1 ? "s" : "");
+            return juce::String (l) + juce::String (" Tick") + (l > 1 ? "s" : "");
     }
     if (index == kRecMode)
     {
         if (getParameter (index) < 0.5)
-            return String ("Replace");
+            return juce::String ("Replace");
         if (getParameter (index) < 0.8)
-            return String ("Overdub(Keep Length)");
-        return String ("Overdub");
+            return juce::String ("Overdub(Keep Length)");
+        return juce::String ("Overdub");
     }
     if (index == kMasterTranspose)
     {
         if (roundToInt (getParameter (index) * 24.0f) - 12 < 1)
-            return String (roundToInt (getParameter (index) * 24.0f) - 12);
-        return String ("+") + String (roundToInt (getParameter (index) * 24.0f) - 12);
+            return juce::String (roundToInt (getParameter (index) * 24.0f) - 12);
+        return juce::String ("+") + juce::String (roundToInt (getParameter (index) * 24.0f) - 12);
     }
     if (index == kMidiOutDevice)
     {
         if (param[kMidiOutDevice] > 0.f)
-            return String ("On");
-        return String ("Off");
+            return juce::String ("On");
+        return juce::String ("Off");
     }
 
     for (int i = 0; i < numSlots; i++)
@@ -748,173 +750,173 @@ const String PizLooper::getParameterText (int index)
             case kImmediateTranspose:
             case kTranspose10:
                 if (getParameter (index) < 0.5)
-                    return String ("Off");
-                return String ("On");
+                    return juce::String ("Off");
+                return juce::String ("On");
             case kParamsToHost:
                 if (! getParameter (index))
-                    return String ("Off");
+                    return juce::String ("Off");
                 if (getParameter (index) < 0.5f)
-                    return String ("Only From GUI");
-                return String ("Always");
+                    return juce::String ("Only From GUI");
+                return juce::String ("Always");
             case kTranspose:
                 value = roundToInt (getParameter (index) * 24.0f) - 12;
                 if (value < 1)
-                    return String (value);
-                return String ("+") + String (value);
+                    return juce::String (value);
+                return juce::String ("+") + juce::String (value);
             case kOctave:
                 value = roundToInt (getParameter (index) * 8.0f) - 4;
                 if (value < 1)
-                    return String (value);
-                return String ("+") + String (value);
+                    return juce::String (value);
+                return juce::String ("+") + juce::String (value);
             case kVelocity:
             case kVeloSens:
-                return String (roundToInt (getParameter (index) * 200.f)) + String ("%");
+                return juce::String (roundToInt (getParameter (index) * 200.f)) + juce::String ("%");
             case kShift:
                 value = roundToInt (getParameter (index) * 16.0f) - 8;
                 if (value < 1)
-                    return String (value);
-                return String ("+") + String (value);
+                    return juce::String (value);
+                return juce::String ("+") + juce::String (value);
             case kLoopStart:
                 value = roundToInt (getParameter (index) * 16.0f) - 8;
                 if (value < 1)
-                    return String (value);
-                return String ("+") + String (value);
+                    return juce::String (value);
+                return juce::String ("+") + juce::String (value);
             case kLoopEnd:
                 value = roundToInt (getParameter (index) * 16.0f) - 8;
                 if (value < 1)
-                    return String (value);
-                return String ("+") + String (value);
+                    return juce::String (value);
+                return juce::String ("+") + juce::String (value);
             case kStretch:
                 if (getParameter (index) == 0.00f)
-                    return String ("x 1/16");
+                    return juce::String ("x 1/16");
                 if (getParameter (index) <= 0.05f)
-                    return String ("x 1/12");
+                    return juce::String ("x 1/12");
                 if (getParameter (index) <= 0.10f)
-                    return String ("x 1/8");
+                    return juce::String ("x 1/8");
                 if (getParameter (index) <= 0.15f)
-                    return String ("x 1/6");
+                    return juce::String ("x 1/6");
                 if (getParameter (index) <= 0.20f)
-                    return String ("x 1/5");
+                    return juce::String ("x 1/5");
                 if (getParameter (index) <= 0.25f)
-                    return String ("x 1/4");
+                    return juce::String ("x 1/4");
                 if (getParameter (index) <= 0.30f)
-                    return String ("x 1/3");
+                    return juce::String ("x 1/3");
                 if (getParameter (index) <= 0.35f)
-                    return String ("x 1/2");
+                    return juce::String ("x 1/2");
                 if (getParameter (index) <= 0.40f)
-                    return String ("x 2/3");
+                    return juce::String ("x 2/3");
                 if (getParameter (index) <= 0.45f)
-                    return String ("x 3/4");
+                    return juce::String ("x 3/4");
                 if (getParameter (index) <= 0.50f)
-                    return String ("x 1.0");
+                    return juce::String ("x 1.0");
                 if (getParameter (index) <= 0.55f)
-                    return String ("x 1.33");
+                    return juce::String ("x 1.33");
                 if (getParameter (index) <= 0.60f)
-                    return String ("x 1.5");
+                    return juce::String ("x 1.5");
                 if (getParameter (index) <= 0.65f)
-                    return String ("x 2.0");
+                    return juce::String ("x 2.0");
                 if (getParameter (index) <= 0.70f)
-                    return String ("x 3.0");
+                    return juce::String ("x 3.0");
                 if (getParameter (index) <= 0.75f)
-                    return String ("x 4.0");
+                    return juce::String ("x 4.0");
                 if (getParameter (index) <= 0.80f)
-                    return String ("x 5.0");
+                    return juce::String ("x 5.0");
                 if (getParameter (index) <= 0.85f)
-                    return String ("x 6.0");
+                    return juce::String ("x 6.0");
                 if (getParameter (index) <= 0.90f)
-                    return String ("x 8.0");
+                    return juce::String ("x 8.0");
                 if (getParameter (index) <= 0.95f)
-                    return String ("x 12.0");
-                /*if (getParameter(index)<1.0f)*/ return String ("x 16.0");
+                    return juce::String ("x 12.0");
+                return juce::String ("x 16.0");
             case kTrigger:
                 if (getParameter (index) == 0.0f)
-                    return String ("Loop after rec");
+                    return juce::String ("Loop after rec");
                 if (getParameter (index) < 0.1f)
-                    return String ("Sync loop");
+                    return juce::String ("Sync loop");
                 if (getParameter (index) < 0.2f)
-                    return String ("Unsync 1-shot");
+                    return juce::String ("Unsync 1-shot");
                 if (getParameter (index) < 0.3f)
-                    return String ("Unsync loop");
+                    return juce::String ("Unsync loop");
                 //if (getParameter(index)<0.5f) return String("sync 1-shot");
-                return String();
+                return juce::String();
             case kNoteTrig:
                 if (getParameter (index) == 0.0f)
-                    return String ("Off");
+                    return juce::String ("Off");
                 if (getParameter (index) < 0.1f)
-                    return String ("Mono (Transpose)");
+                    return juce::String ("Mono (Transpose)");
                 if (getParameter (index) < 0.2f)
-                    return String ("Poly (Transpose)");
+                    return juce::String ("Poly (Transpose)");
                 if (getParameter (index) < 0.3f)
-                    return String ("Mono (Orig. Key)");
+                    return juce::String ("Mono (Orig. Key)");
                 //if (getParameter(index)<0.4f) return String("Poly (Orig. Key)");
-                return String();
+                return juce::String();
             case kRoot:
             case kNLow:
             case kNHigh:
                 value = floatToMidi (getParameter (index));
                 if (value == -1)
-                    return String ("Waiting...");
-                return String (value) + String (" (") + getNoteName (value, bottomOctave) + String (")");
+                    return juce::String ("Waiting...");
+                return juce::String (value) + juce::String (" (") + getNoteName (value, bottomOctave) + juce::String (")");
             case kChannel:
                 if (roundToInt (getParameter (index) * 16.0f) == 0)
-                    return String ("All");
-                return String (roundToInt (getParameter (index) * 16.0f));
+                    return juce::String ("All");
+                return juce::String (roundToInt (getParameter (index) * 16.0f));
             case kNumLoops:
                 if (roundToInt (getParameter (index) * 64.0f) == 0)
-                    return String ("Forever");
-                return "x" + String (roundToInt (getParameter (index) * 64.0f));
+                    return juce::String ("Forever");
+                return "x" + juce::String (roundToInt (getParameter (index) * 64.0f));
             case kNextSlot:
                 if (roundToInt (getParameter (index) * (float) numSlots) == 0)
-                    return String ("Stop");
-                return "Play Slot " + String (roundToInt (getParameter (index) * (float) numSlots));
+                    return juce::String ("Stop");
+                return "Play Slot " + juce::String (roundToInt (getParameter (index) * (float) numSlots));
             case kMuteGroup:
             case kPlayGroup:
                 if (roundToInt (getParameter (index) * 16.0f) == 0)
-                    return String ("Off");
-                return String (roundToInt (getParameter (index) * 16.0f));
+                    return juce::String ("Off");
+                return juce::String (roundToInt (getParameter (index) * 16.0f));
             case kTrigChan:
-                return String (roundToInt (getParameter (index) * 15.0f) + 1);
+                return juce::String (roundToInt (getParameter (index) * 15.0f) + 1);
             case kFiltChan:
                 if (getParameter (index) < 0.5f)
-                    return String ("Transform");
-                return String ("Filter");
+                    return juce::String ("Transform");
+                return juce::String ("Filter");
             case kWaitForBar:
                 if (getParameter (index) < 0.5f)
-                    return String ("No");
-                return String ("Yes");
+                    return juce::String ("No");
+                return juce::String ("Yes");
             case kScaleChannel:
                 //if (roundToInt(getParameter(index)*16.0f)==0) return String("Off");
-                return String (roundToInt (getParameter (index) * 15.0f) + 1);
+                return juce::String (roundToInt (getParameter (index) * 15.0f) + 1);
             case kTransposeChannel:
                 //if (roundToInt(getParameter(index)*16.0f)==0) return String("Off");
-                return String (roundToInt (getParameter (index) * 15.0f) + 1);
+                return juce::String (roundToInt (getParameter (index) * 15.0f) + 1);
             case kForceToScaleMode:
                 int mode;
                 mode = roundToInt (getParameter (index) * (float) (numForceToKeyModes - 1));
                 if (mode == nearest)
-                    return String ("Nearest");
+                    return juce::String ("Nearest");
                 else if (mode == alwaysup)
-                    return String ("Up");
+                    return juce::String ("Up");
                 else if (mode == alwaysdown)
-                    return String ("Down");
+                    return juce::String ("Down");
                 else if (mode == block)
-                    return String ("Block");
-                return String();
+                    return juce::String ("Block");
+                return juce::String();
             default:
                 break;
         }
     }
-    return String();
+    return juce::String();
 }
 
-const String PizLooper::getInputChannelName (const int channelIndex) const
+const juce::String PizLooper::getInputChannelName (const int channelIndex) const
 {
-    return String ("Input") + String (channelIndex + 1);
+    return juce::String ("Input") + juce::String (channelIndex + 1);
 }
 
-const String PizLooper::getOutputChannelName (const int channelIndex) const
+const juce::String PizLooper::getOutputChannelName (const int channelIndex) const
 {
-    return String ("Output") + String (channelIndex + 1);
+    return juce::String ("Output") + juce::String (channelIndex + 1);
 }
 
 bool PizLooper::isInputChannelStereoPair (int index) const
@@ -970,7 +972,7 @@ void PizLooper::resetCurrentProgram (int index)
     }
 }
 
-void PizLooper::changeProgramName (int index, const String& newName)
+void PizLooper::changeProgramName (int index, const juce::String& newName)
 {
     if (index < getNumPrograms())
     {
@@ -980,13 +982,13 @@ void PizLooper::changeProgramName (int index, const String& newName)
     }
 }
 
-const String PizLooper::getProgramName (int index)
+const juce::String PizLooper::getProgramName (int index)
 {
     if (index < getNumPrograms())
     {
         return programs[index].name;
     }
-    return String();
+    return juce::String();
 }
 
 int PizLooper::getCurrentProgram()
@@ -995,7 +997,7 @@ int PizLooper::getCurrentProgram()
 }
 
 //==============================================================================
-AudioProcessorEditor* PizLooper::createEditor()
+juce::AudioProcessorEditor* PizLooper::createEditor()
 {
 #if JucePlugin_NoEditor
     return 0;
@@ -1005,7 +1007,7 @@ AudioProcessorEditor* PizLooper::createEditor()
 }
 
 //==============================================================================
-void PizLooper::getStateInformation (MemoryBlock& destData)
+void PizLooper::getStateInformation (juce::MemoryBlock& destData)
 {
     // make sure the non-parameter settings are copied to the current program
     for (int i = 0; i < 12; i++)
@@ -1018,13 +1020,13 @@ void PizLooper::getStateInformation (MemoryBlock& destData)
     {
         if (programs[i].loop.getNumEvents() > 0)
         {
-            MemoryBlock midiData (512, true);
-            MemoryOutputStream m (midiData, false);
+            juce::MemoryBlock midiData (512, true);
+            juce::MemoryOutputStream m (midiData, false);
 
-            MidiFile midifile;
+            juce::MidiFile midifile;
             midifile.setTicksPerQuarterNote (960);
 
-            MidiMessageSequence midi (programs[i].loop.getAsJuceSequence());
+            juce::MidiMessageSequence midi (programs[i].loop.getAsJuceSequence());
             midifile.addTrack (midi);
             midifile.writeTo (m);
             int dataSize = (int) midiData.getSize();
@@ -1038,9 +1040,9 @@ void PizLooper::getStateInformation (MemoryBlock& destData)
         }
     }
 
-    MemoryBlock xmlData (512);
+    juce::MemoryBlock xmlData (512);
 
-    XmlElement xmlState ("midiLooperSettings");
+    juce::XmlElement xmlState ("midiLooperSettings");
     xmlState.setAttribute ("pluginVersion", 4);
     xmlState.setAttribute ("program", getCurrentProgram());
     for (int i = 0; i < numGlobalParams; i++)
@@ -1051,8 +1053,8 @@ void PizLooper::getStateInformation (MemoryBlock& destData)
     xmlState.setAttribute ("uiHeight", lastUIHeight);
     for (int p = 0; p < getNumPrograms(); p++)
     {
-        XmlElement* xmlProgram = new XmlElement ("Slot" + String (p));
-        xmlProgram->setAttribute (String ("name"), programs[p].name);
+        auto* xmlProgram = new juce::XmlElement ("Slot" + juce::String (p));
+        xmlProgram->setAttribute (juce::String ("name"), programs[p].name);
         for (int i = 0; i < numParamsPerSlot; i++)
         {
             int index = i + curProgram * numParamsPerSlot + numGlobalParams;
@@ -1075,7 +1077,7 @@ void PizLooper::getStateInformation (MemoryBlock& destData)
     destData.append (xmlData.getData(), xmlData.getSize());
 #ifdef _DEBUG
     // TODO: macOS/Linux compatibility
-    xmlState.writeTo (File ("C:\\loopergetState.xml"));
+    xmlState.writeTo (juce::File ("C:\\loopergetState.xml"));
 #endif
 }
 
@@ -1098,7 +1100,7 @@ void PizLooper::setStateInformation (const void* data, int sizeInBytes)
     auto xmlState = getXmlFromBinary (data, sizeInBytes);
     if (xmlState == 0)
     {
-        uint8* datab      = (uint8*) data;
+        auto* datab       = (juce::uint8*) data;
         int totalMidiSize = 0;
         bool oldBank      = false;
         for (int i = 0; i < numPrograms; i++)
@@ -1117,15 +1119,15 @@ void PizLooper::setStateInformation (const void* data, int sizeInBytes)
                 if (midiSize > 0)
                 {
                     totalMidiSize += sizeof (midiSize);
-                    MemoryInputStream m (datab, midiSize, true);
-                    MidiFile midifile;
+                    juce::MemoryInputStream m (datab, midiSize, true);
+                    juce::MidiFile midifile;
                     if (midifile.readFrom (m))
                     {
                         programs[i].loop.addSequence (*midifile.getTrack (midifile.getNumTracks() - 1), 0, 0, midifile.getLastTimestamp() + 1);
                         programs[i].loop.updateMatchedPairs();
-                        uint8 bogus[3] = { 0xff, 0x2f, 0x00 };
-                        int lastIndex  = programs[i].loop.getNumEvents() - 1;
-                        const uint8* lastmsg; /* = programs[i].loop.getEventPointer(lastIndex)->message.getRawData();*/
+                        juce::uint8 bogus[3] = { 0xff, 0x2f, 0x00 };
+                        int lastIndex        = programs[i].loop.getNumEvents() - 1;
+                        const juce::uint8* lastmsg; /* = programs[i].loop.getEventPointer(lastIndex)->message.getRawData();*/
                         bool done = false;
                         while (lastIndex >= 0 && ! done)
                         {
@@ -1159,7 +1161,7 @@ void PizLooper::setStateInformation (const void* data, int sizeInBytes)
                 }
                 lastUIWidth  = xmlState->getIntAttribute ("uiWidth", lastUIWidth);
                 lastUIHeight = xmlState->getIntAttribute ("uiHeight", lastUIHeight);
-                XmlElement* xmlProgram (xmlState->getChildByName ("Slot" + String (p)));
+                juce::XmlElement* xmlProgram (xmlState->getChildByName ("Slot" + juce::String (p)));
                 if (xmlProgram)
                 {
                     for (int i = numGlobalParams; i < numParamsPerSlot + numGlobalParams; i++)
@@ -1171,12 +1173,12 @@ void PizLooper::setStateInformation (const void* data, int sizeInBytes)
                     param[kRecord + numParamsPerSlot * p] = programs[p].param[kRecord] = 0.0f;
                     param[kFile] = programs[p].param[kFile] = 0.5f;
                     param[kSave] = programs[p].param[kSave] = 0.f;
-                    setLoopLength (p, xmlProgram->getDoubleAttribute (String ("looplength"), getLoopLength (p)));
-                    setLoopStart (p, xmlProgram->getDoubleAttribute (String ("loopstart1"), getLoopStart (p)));
-                    programs[p].measureFromHere = xmlProgram->getDoubleAttribute (String ("measureFromHere"), programs[p].measureFromHere);
+                    setLoopLength (p, xmlProgram->getDoubleAttribute (juce::String ("looplength"), getLoopLength (p)));
+                    setLoopStart (p, xmlProgram->getDoubleAttribute (juce::String ("loopstart1"), getLoopStart (p)));
+                    programs[p].measureFromHere = xmlProgram->getDoubleAttribute (juce::String ("measureFromHere"), programs[p].measureFromHere);
                     programs[p].denominator     = xmlProgram->getIntAttribute ("denominator", programs[p].denominator);
                     programs[p].numerator       = xmlProgram->getIntAttribute ("numerator", programs[p].numerator);
-                    programs[p].name            = xmlProgram->getStringAttribute (String ("name"), programs[p].name);
+                    programs[p].name            = xmlProgram->getStringAttribute (juce::String ("name"), programs[p].name);
                     programs[p].loop.setSemitones (roundToInt (param[kTranspose + numParamsPerSlot * p] * 24.f) - 12);
                     programs[p].loop.setOctaves (roundToInt (param[kOctave + numParamsPerSlot * p] * 8.f) - 4);
                     programs[p].device = getDeviceByName (xmlProgram->getStringAttribute ("device", programs[p].device.name));
@@ -1188,13 +1190,13 @@ void PizLooper::setStateInformation (const void* data, int sizeInBytes)
                 }
             }
             init = true;
-            resetCurrentProgram (xmlState->getIntAttribute (String ("program"), curProgram));
+            resetCurrentProgram (xmlState->getIntAttribute (juce::String ("program"), curProgram));
         }
         else if (xmlState->hasTagName ("MYPLUGINSETTINGS"))
         {
             for (int p = 0; p < 16; p++)
             {
-                String prefix = String ("Program") + String (p) + String ("_");
+                juce::String prefix = juce::String ("Program") + juce::String (p) + juce::String ("_");
                 for (int i = 0; i < numParamsPerSlot + numGlobalParams; i++)
                 {
                     if (i < numGlobalParams)
@@ -1205,14 +1207,14 @@ void PizLooper::setStateInformation (const void* data, int sizeInBytes)
                 param[kRecord + numParamsPerSlot * p] = programs[p].param[kRecord] = 0.0f;
                 param[kFile] = programs[p].param[kFile] = 0.5f;
                 param[kSave] = programs[p].param[kSave] = 0.f;
-                setLoopLength (p, xmlState->getDoubleAttribute (String ("looplength"), getLoopLength (p)));
-                setLoopStart (p, xmlState->getDoubleAttribute (String ("loopstart1"), getLoopStart (p)));
-                programs[p].measureFromHere = xmlState->getDoubleAttribute (prefix + String ("measureFromHere"), programs[p].measureFromHere);
+                setLoopLength (p, xmlState->getDoubleAttribute (juce::String ("looplength"), getLoopLength (p)));
+                setLoopStart (p, xmlState->getDoubleAttribute (juce::String ("loopstart1"), getLoopStart (p)));
+                programs[p].measureFromHere = xmlState->getDoubleAttribute (prefix + juce::String ("measureFromHere"), programs[p].measureFromHere);
                 lastUIWidth                 = xmlState->getIntAttribute (prefix + "uiWidth", lastUIWidth);
                 lastUIHeight                = xmlState->getIntAttribute (prefix + "uiHeight", lastUIHeight);
                 programs[p].denominator     = xmlState->getIntAttribute (prefix + "denominator", programs[p].denominator);
                 programs[p].numerator       = xmlState->getIntAttribute (prefix + "numerator", programs[p].numerator);
-                programs[p].name            = xmlState->getStringAttribute (prefix + String ("progname"), programs[p].name);
+                programs[p].name            = xmlState->getStringAttribute (prefix + juce::String ("progname"), programs[p].name);
                 programs[p].loop.setSemitones (roundToInt (param[kTranspose + numParamsPerSlot * p] * 24.f) - 12);
                 programs[p].loop.setOctaves (roundToInt (param[kOctave + numParamsPerSlot * p] * 8.f) - 4);
                 programs[p].device = getDeviceByName (xmlState->getStringAttribute (prefix + "device", programs[p].device.name));
@@ -1220,69 +1222,69 @@ void PizLooper::setStateInformation (const void* data, int sizeInBytes)
                 readMidiFile (p, programs[p].name);
             }
             init = true;
-            resetCurrentProgram (xmlState->getIntAttribute (String ("program"), curProgram));
+            resetCurrentProgram (xmlState->getIntAttribute (juce::String ("program"), curProgram));
         }
 #ifdef _DEBUG
-        xmlState->writeTo (File ("C:\\loopersetState.xml"));
+        xmlState->writeTo (juce::File ("C:\\loopersetState.xml"));
 #endif
     }
 }
 
 //==============================================================================
-bool PizLooper::writeMidiFile (int index, File file, bool IncrementFilename)
+bool PizLooper::writeMidiFile (int index, juce::File file, bool IncrementFilename)
 {
-    MidiFile midifile;
+    juce::MidiFile midifile;
     midifile.setTicksPerQuarterNote (960);
 
-    uint8 dd = 0;
-    int d    = getDenominator (index);
+    juce::uint8 dd = 0;
+    int d          = getDenominator (index);
     while (d > 1)
     {
         d = d >> 1;
         dd++;
     }
 
-    MidiMessageSequence timesigtrack;
-    uint8 ts[] = { 0xFF, 0x58, 0x04, (uint8) getNumerator (index), dd, 0x18, 0x08 };
-    timesigtrack.addEvent (MidiMessage (ts, 7, 0));
+    juce::MidiMessageSequence timesigtrack;
+    juce::uint8 ts[] = { 0xFF, 0x58, 0x04, (juce::uint8) getNumerator (index), dd, 0x18, 0x08 };
+    timesigtrack.addEvent (juce::MidiMessage (ts, 7, 0));
     midifile.addTrack (timesigtrack);
 
-    MidiMessageSequence metadata;
-    uint8 ID[] = { 0xFF, 0x03, 9, 'l', 'o', 'o', 'p', ' ', 'a', 'r', 'e', 'a' };
-    metadata.addEvent (MidiMessage (ID, 12, 0));
+    juce::MidiMessageSequence metadata;
+    juce::uint8 ID[] = { 0xFF, 0x03, 9, 'l', 'o', 'o', 'p', ' ', 'a', 'r', 'e', 'a' };
+    metadata.addEvent (juce::MidiMessage (ID, 12, 0));
     int ls = roundToInt ((programs[index].loopstart - programs[index].measureFromHere) * 960.0);
-    metadata.addEvent (MidiMessage (0x9f, 62, 1, 0), (double) ls);
+    metadata.addEvent (juce::MidiMessage (0x9f, 62, 1, 0), (double) ls);
     int ll = int ((programs[index].looplength) * 960.0);
-    metadata.addEvent (MidiMessage (0x8f, 62, 1, 0), (double) (ls + ll));
+    metadata.addEvent (juce::MidiMessage (0x8f, 62, 1, 0), (double) (ls + ll));
     metadata.updateMatchedPairs();
     midifile.addTrack (metadata);
 
-    uint8 tn[] = { 0xFF, 0x03, 4, 'l', 'o', 'o', 'p' };
-    programs[index].loop.addEvent (MidiMessage (tn, 7, 0));
+    juce::uint8 tn[] = { 0xFF, 0x03, 4, 'l', 'o', 'o', 'p' };
+    programs[index].loop.addEvent (juce::MidiMessage (tn, 7, 0));
     midifile.addTrack (programs[index].loop.getAsJuceSequence());
 
-    if (! File (loopDir).exists())
-        File (loopDir).createDirectory();
+    if (! juce::File (loopDir).exists())
+        juce::File (loopDir).createDirectory();
     if (file.isDirectory())
     {
-        String filename = file.getFullPathName() + File::getSeparatorString() + getProgramName (index);
+        juce::String filename = file.getFullPathName() + juce::File::getSeparatorString() + getProgramName (index);
         if (IncrementFilename)
             filename << "_" << FilenameIndex++;
         filename << ".mid";
-        file = File (filename);
+        file = juce::File (filename);
     }
     if (! file.deleteFile())
-        file.copyFileTo (File (file.getParentDirectory().getFullPathName()
-                               + File::getSeparatorString() + file.getFileNameWithoutExtension() + String ("_old.mid")));
+        file.copyFileTo (juce::File (file.getParentDirectory().getFullPathName()
+                                     + juce::File::getSeparatorString() + file.getFileNameWithoutExtension() + juce::String ("_old.mid")));
     if (file.create())
     {
-        FileOutputStream f (file);
+        juce::FileOutputStream f (file);
         midifile.writeTo (f);
     }
     return true;
 }
 
-void PizLooper::loadMidiFile (File file)
+void PizLooper::loadMidiFile (juce::File file)
 {
     if (readMidiFile (curProgram, getProgramName (curProgram), file))
     {
@@ -1292,30 +1294,30 @@ void PizLooper::loadMidiFile (File file)
     }
 }
 
-bool PizLooper::readMidiFile (int index, String progname, File mid)
+bool PizLooper::readMidiFile (int index, juce::String progname, juce::File mid)
 {
     double ppqPerBar = 4.0;
     double l         = ppqPerBar * (double) getPRSetting ("bars");
     if (! mid.exists())
     {
-        String path = ((File::getSpecialLocation (File::currentExecutableFile)).getParentDirectory()).getFullPathName()
-                    + File::getSeparatorString() + String ("midiloops");
-        mid = File (path + File::getSeparatorString() + getProgramName (index) + String (".mid"));
+        juce::String path = ((juce::File::getSpecialLocation (juce::File::currentExecutableFile)).getParentDirectory()).getFullPathName()
+                          + juce::File::getSeparatorString() + juce::String ("midiloops");
+        mid = juce::File (path + juce::File::getSeparatorString() + getProgramName (index) + juce::String (".mid"));
     }
     if (mid.exists())
     {
         programs[index].loop.clear();
         programs[index].looplength = 0;
         programs[index].loopstart  = 0;
-        MidiFile midifile;
+        juce::MidiFile midifile;
         {
-            FileInputStream f (mid);
+            juce::FileInputStream f (mid);
             midifile.readFrom (f);
         }
         //look for time signature & tempo
         for (int i = 0; i < midifile.getTrack (0)->getNumEvents(); i++)
         {
-            const MidiMessage ID = midifile.getTrack (0)->getEventPointer (i)->message;
+            const juce::MidiMessage ID = midifile.getTrack (0)->getEventPointer (i)->message;
             if (ID.isTimeSignatureMetaEvent())
             {
                 ID.getTimeSignatureInfo (programs[index].numerator, programs[index].denominator);
@@ -1333,21 +1335,21 @@ bool PizLooper::readMidiFile (int index, String progname, File mid)
         {
             for (int t = 0; t < midifile.getNumTracks(); t++)
             {
-                bool loopAreaTrack               = false;
-                const MidiMessageSequence* track = midifile.getTrack (t);
+                bool loopAreaTrack                     = false;
+                const juce::MidiMessageSequence* track = midifile.getTrack (t);
                 for (int i = 0; i < track->getNumEvents(); i++)
                 {
-                    const MidiMessage ID = track->getEventPointer (i)->message;
+                    const juce::MidiMessage ID = track->getEventPointer (i)->message;
                     if (ID.isTrackNameEvent())
                     {
-                        if (ID.getTextFromTextMetaEvent() == String ("loop area"))
+                        if (ID.getTextFromTextMetaEvent() == juce::String ("loop area"))
                         {
                             //track->convertTimeBase(midifile.getTimeFormat());
                             double t1 = 0;
                             double t2 = 0;
                             for (int e = 0; e < track->getNumEvents(); e++)
                             {
-                                MidiMessage mm = track->getEventPointer (e)->message;
+                                juce::MidiMessage mm = track->getEventPointer (e)->message;
                                 if (mm.isNoteOn())
                                 {
                                     t1 = mm.getTimeStamp();

--- a/pizjuce/midiLooper/PizLooper.h
+++ b/pizjuce/midiLooper/PizLooper.h
@@ -3,8 +3,8 @@
 
 #include <memory>
 
-#include "juce_audio_devices/juce_audio_devices.h"
-#include "juce_data_structures/juce_data_structures.h"
+#include <juce_audio_devices/juce_audio_devices.h>
+#include <juce_data_structures/juce_data_structures.h>
 
 #include "../_common/key.h"
 #include "../_common/PizArray.h"
@@ -105,17 +105,17 @@ public:
                                                                          undo_manager_ (nullptr),
                                                                          fallback_settings_ (fallback_settings)
     {
-        ValueTree tree ("PRSettings");
+        juce::ValueTree tree ("PRSettings");
         values_.addChild (tree, 0, undo_manager_);
         loadDefaults();
     }
 
-    ValueTree& set (const Identifier& name, const var& newValue)
+    juce::ValueTree& set (const juce::Identifier& name, const juce::var& newValue)
     {
         return values_.getChild (0).setProperty (name, newValue, undo_manager_);
     }
 
-    var get (const Identifier& name)
+    juce::var get (const juce::Identifier& name)
     {
         if (values_.getChild (0).hasProperty (name) && fallback_settings_ != nullptr)
         {
@@ -127,18 +127,18 @@ public:
         }
     }
 
-    std::unique_ptr<XmlElement> createXml() const
+    std::unique_ptr<juce::XmlElement> createXml() const
     {
         return values_.getChild (0).createXml();
     }
 
-    void loadXml (XmlElement const& xmlProgram)
+    void loadXml (juce::XmlElement const& xmlProgram)
     {
         values_.removeChild (0, undo_manager_);
         auto tree = xmlProgram.getChildByName ("PRSettings");
         if (tree != nullptr)
         {
-            values_.addChild (ValueTree::fromXml (*tree), 0, undo_manager_);
+            values_.addChild (juce::ValueTree::fromXml (*tree), 0, undo_manager_);
         }
     }
 
@@ -157,8 +157,8 @@ private:
         set ("bars", 4);
     }
 
-    ValueTree values_;
-    UndoManager* undo_manager_;
+    juce::ValueTree values_;
+    juce::UndoManager* undo_manager_;
     PianoRollSettings* fallback_settings_;
 };
 
@@ -177,16 +177,16 @@ private:
     double loopstart;
     double looplength;
     double measureFromHere;
-    String name;
+    juce::String name;
     int numerator, denominator;
     PianoRollSettings PRSettings;
-    MidiDeviceInfo device;
+    juce::MidiDeviceInfo device;
 };
 
 //==============================================================================
 class PizLooper : public PizAudioProcessor,
-                  public ChangeBroadcaster,
-                  public MidiKeyboardStateListener
+                  public juce::ChangeBroadcaster,
+                  public juce::MidiKeyboardStateListener
 {
 public:
     //==============================================================================
@@ -197,13 +197,13 @@ public:
     void prepareToPlay (double sampleRate, int samplesPerBlock) override;
     void releaseResources() override;
 
-    void processBlock (AudioSampleBuffer& buffer, MidiBuffer& midiMessages) override;
+    void processBlock (juce::AudioSampleBuffer& buffer, juce::MidiBuffer& midiMessages) override;
 
     //==============================================================================
-    AudioProcessorEditor* createEditor() override;
+    juce::AudioProcessorEditor* createEditor() override;
     bool hasEditor (void) const override { return true; }
     //==============================================================================
-    const String getName() const override;
+    const juce::String getName() const override;
 
     int getNumParameters() override { return numParams; }
     inline float getParameterForSlot (int parameter, int slot)
@@ -265,17 +265,17 @@ public:
         else
             setParameterNotifyingHost (parameter + curProgram * numParamsPerSlot, value);
     }
-    const String getParameterName (int index) override;
-    const String getParameterText (int index) override;
-    const String getCurrentSlotParameterText (int parameter)
+    const juce::String getParameterName (int index) override;
+    const juce::String getParameterText (int index) override;
+    const juce::String getCurrentSlotParameterText (int parameter)
     {
         if (parameter < numGlobalParams)
             return getParameterText (parameter);
         return getParameterText (parameter + curProgram * numParamsPerSlot);
     }
 
-    const String getInputChannelName (int channelIndex) const override;
-    const String getOutputChannelName (int channelIndex) const override;
+    const juce::String getInputChannelName (int channelIndex) const override;
+    const juce::String getOutputChannelName (int channelIndex) const override;
     bool isInputChannelStereoPair (int index) const override;
     bool isOutputChannelStereoPair (int index) const override;
 
@@ -291,8 +291,8 @@ public:
         setActiveSlot (index);
     }
     void resetCurrentProgram (int index);
-    const String getProgramName (int index) override;
-    void changeProgramName (int index, const String& newName) override;
+    const juce::String getProgramName (int index) override;
+    void changeProgramName (int index, const juce::String& newName) override;
     void setActiveSlot (int slot);
 
     void setSize (int w, int h)
@@ -321,20 +321,20 @@ public:
     //==============================================================================
     //void getCurrentProgramStateInformation (MemoryBlock& destData);
     //void setCurrentProgramStateInformation (const void* data, int sizeInBytes);
-    void getStateInformation (MemoryBlock& destData) override;
+    void getStateInformation (juce::MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
 
-    void handleNoteOn (MidiKeyboardState* source, int midiChannel, int midiNoteNumber, float velocity) override
+    void handleNoteOn (juce::MidiKeyboardState* source, int midiChannel, int midiNoteNumber, float velocity) override
     {
         setParameterForSlot (kNote0 + midiNoteNumber % 12, curProgram, 1.f);
     }
-    void handleNoteOff (MidiKeyboardState* source, int midiChannel, int midiNoteNumber, float velocity) override
+    void handleNoteOff (juce::MidiKeyboardState* source, int midiChannel, int midiNoteNumber, float velocity) override
     {
         setParameterForSlot (kNote0 + midiNoteNumber % 12, curProgram, 0.f);
     }
 
     //==============================================================================
-    AudioPlayHead::CurrentPositionInfo lastPosInfo;
+    juce::AudioPlayHead::CurrentPositionInfo lastPosInfo;
 
     int lastUIWidth, lastUIHeight;
     double currentLength;
@@ -342,13 +342,13 @@ public:
     class Info : public ChangeBroadcaster
     {
     public:
-        String s;
+        juce::String s;
     };
     Info* info;
     void killNotes (int slot);
     bool newLoop;
 
-    void loadMidiFile (File file);
+    void loadMidiFile (juce::File file);
     Loop* getActiveLoop();
     void updateLoopInfo();
     void setLoopLength (int slot, double newLength)
@@ -379,7 +379,7 @@ public:
     {
         return programs[slot].loop.getNumEvents() == 0;
     }
-    MidiKeyboardState keySelectorState;
+    juce::MidiKeyboardState keySelectorState;
 
     int getNumerator (int slot) { return programs[slot].numerator; }
     int getDenominator (int slot) { return programs[slot].denominator; }
@@ -390,20 +390,20 @@ public:
     }
 
     //midi out stuff
-    PizArray<MidiDeviceInfo> devices;
-    void setActiveDevice (String name);
-    void setActiveDevice (MidiDeviceInfo device);
-    MidiDeviceInfo getActiveDevice() { return activeDevice; }
-    MidiDeviceInfo getDeviceByName (String name) const;
+    PizArray<juce::MidiDeviceInfo> devices;
+    void setActiveDevice (juce::String name);
+    void setActiveDevice (juce::MidiDeviceInfo device);
+    juce::MidiDeviceInfo getActiveDevice() { return activeDevice; }
+    juce::MidiDeviceInfo getDeviceByName (juce::String name) const;
 
-    void setPRSetting (const Identifier& name, const var& value, bool updateEditor = true)
+    void setPRSetting (const juce::Identifier& name, const juce::var& value, bool updateEditor = true)
     {
         programs[curProgram].PRSettings.set (name, value);
         if (updateEditor)
             sendChangeMessage();
     }
 
-    const var getPRSetting (const Identifier& name)
+    const juce::var getPRSetting (const juce::Identifier& name)
     {
         return programs[curProgram].PRSettings.get (name);
     }
@@ -414,16 +414,14 @@ public:
         recording = getParameterForSlot (kRecord, curProgram) >= 0.5f;
         return loopPpq[curProgram];
     }
-    MidiKeyboardState kbstate;
+    juce::MidiKeyboardState kbstate;
 
-    String loopDir;
-    bool writeMidiFile (int index, File file, bool IncrementFilename = false);
-    bool readMidiFile (int index, String progname, File mid = File());
+    juce::String loopDir;
+    bool writeMidiFile (int index, juce::File file, bool IncrementFilename = false);
+    bool readMidiFile (int index, juce::String progname, juce::File mid = juce::File());
 
-    //==============================================================================
-    juce_UseDebuggingNewOperator
-
-        private : float param[numParams];
+private:
+    float param[numParams];
     int recCC, playCC;
 
     JuceProgram* programs;
@@ -455,7 +453,7 @@ public:
     int polytrigger[numPrograms][polyphony]; // note numbers of polyphonic triggers
     int currentPoly[numPrograms];            // number of playing instances of current pattern
 
-    void endHangingNotesInLoop (MidiBuffer& buffer, int samplePos, int slot, int voice = -1, bool kill = false);
+    void endHangingNotesInLoop (juce::MidiBuffer& buffer, int samplePos, int slot, int voice = -1, bool kill = false);
     class TransposeRules
     {
     public:
@@ -503,8 +501,8 @@ public:
                 memcpy (&oldrules, &rules, sizeof (Rules));
             else if (memcmp (&rules, &oldrules, sizeof (Rules)) == 0)
                 return false;
-            rules.semitones         = roundToInt (plugin->getParameterForSlot (kTranspose, slot) * 24.f) - 12;
-            rules.octaves           = roundToInt (plugin->getParameterForSlot (kOctave, slot) * 8.f) - 4;
+            rules.semitones         = juce::roundToInt (plugin->getParameterForSlot (kTranspose, slot) * 24.f) - 12;
+            rules.octaves           = juce::roundToInt (plugin->getParameterForSlot (kOctave, slot) * 8.f) - 4;
             rules.forceToScale      = plugin->getParameterForSlot (kForceToKey, slot) >= 0.5f;
             rules.noteswitch[0]     = plugin->getParameterForSlot (kNote0, slot) >= 0.5f;
             rules.noteswitch[1]     = plugin->getParameterForSlot (kNote1, slot) >= 0.5f;
@@ -522,8 +520,8 @@ public:
             rules.transposedTrigger = plugin->getParameterForSlot (kNoteTrig, slot) > 0.0
                                    && plugin->getParameterForSlot (kNoteTrig, slot) < 0.2f
                                    && rules.root > -1;
-            rules.masterTranspose = roundToInt (plugin->getParameter (kMasterTranspose) * 24.f) - 12;
-            rules.mode            = roundToInt (plugin->getParameterForSlot (kForceToScaleMode, slot) * (float) (numForceToKeyModes - 1));
+            rules.masterTranspose = juce::roundToInt (plugin->getParameter (kMasterTranspose) * 24.f) - 12;
+            rules.mode            = juce::roundToInt (plugin->getParameterForSlot (kForceToScaleMode, slot) * (float) (numForceToKeyModes - 1));
             rules.transpose10     = plugin->getParameterForSlot (kTranspose10, slot) >= 0.5f;
             if (initialize)
                 memcpy (&oldrules, &rules, sizeof (Rules));
@@ -740,16 +738,16 @@ public:
         int slot;
     };
     TransposeRules* tRules[numSlots];
-    void transposePlayingNotes (MidiBuffer& buffer, int samplePos, int slot, int voice, int numSamples);
+    void transposePlayingNotes (juce::MidiBuffer& buffer, int samplePos, int slot, int voice, int numSamples);
 
     void processGroups (int slot)
     {
-        int pgroup = roundToInt (getParameterForSlot (kPlayGroup, slot) * 16.f) - 1;
-        int mgroup = roundToInt (getParameterForSlot (kMuteGroup, slot) * 16.f) - 1;
+        int pgroup = juce::roundToInt (getParameterForSlot (kPlayGroup, slot) * 16.f) - 1;
+        int mgroup = juce::roundToInt (getParameterForSlot (kMuteGroup, slot) * 16.f) - 1;
         if (mgroup != -1 && getParameterForSlot (kPlay, slot) >= 0.5f)
         {
             for (int i = 0; i < numSlots; i++)
-                if (i != slot && mgroup == (roundToInt (getParameterForSlot (kMuteGroup, i) * 16.f) - 1))
+                if (i != slot && mgroup == (juce::roundToInt (getParameterForSlot (kMuteGroup, i) * 16.f) - 1))
                 {
                     for (int v = 0; v < polyphony; v++)
                         if (slot != i)
@@ -760,7 +758,7 @@ public:
         if (pgroup != -1)
         {
             for (int i = 0; i < numSlots; i++)
-                if (i != slot && pgroup == (roundToInt (getParameterForSlot (kPlayGroup, i) * 16.f) - 1))
+                if (i != slot && pgroup == (juce::roundToInt (getParameterForSlot (kPlayGroup, i) * 16.f) - 1))
                     notifyHost (kPlay, i, getParameterForSlot (kPlay, slot));
         }
     }
@@ -773,12 +771,12 @@ public:
     int capturingTranspose[numSlots];
     int lowestScaleInputNote[numSlots];
     int playingNote[16][128]; //keep track of the actual notes that are output
-    int64 barTriggerSample[numSlots][polyphony];
-    int64 barStopSample[numSlots][polyphony];
+    juce::int64 barTriggerSample[numSlots][polyphony];
+    juce::int64 barStopSample[numSlots][polyphony];
     int lastPlayedIndex[numSlots][polyphony];
     int lastLoopCount[numSlots][polyphony];
     int startLoopCount[numSlots][polyphony];
-    Array<LoopNote> noteOffBuffer[numSlots];
+    juce::Array<LoopNote> noteOffBuffer[numSlots];
     int getIndexOfNoteOff (PizMidiMessageSequence::MidiEventHolder* n, int slot, int v)
     {
         for (int i = 0; i < noteOffBuffer[slot].size(); i++)
@@ -792,24 +790,26 @@ public:
     }
     bool recordAndPlay[numSlots];
 
-    uint64 samples;
+    juce::uint64 samples;
     int samplesInLastBuffer;
 
-    MidiDeviceInfo activeDevice;
-    std::unique_ptr<MidiOutput> midiOutput;
+    juce::MidiDeviceInfo activeDevice;
+    std::unique_ptr<juce::MidiOutput> midiOutput;
 
     PianoRollSettings defaultPRSettings;
 
     double getStretchMultiplier (int slot);
-    bool isNoteTriggeringAnySlot (MidiMessage const& message);
-    bool processTriggerNote (const int slot, MidiMessage& message, int root, MidiBuffer& midiout, const int sample, const double ppqOfNextBar, const double ppqPerSample, const double ppqOfLastStep, const double looplengthstep);
-    void processNoteOffBuffer (int slot, MidiBuffer& midiout, int numSamples);
-    void playLoopEvent (int slot, int instance, int eventindex, int channel, double stretch, int samplepos, double samplesPerPpq, MidiBuffer& midiout);
+    bool isNoteTriggeringAnySlot (juce::MidiMessage const& message);
+    bool processTriggerNote (const int slot, juce::MidiMessage& message, int root, juce::MidiBuffer& midiout, const int sample, const double ppqOfNextBar, const double ppqPerSample, const double ppqOfLastStep, const double looplengthstep);
+    void processNoteOffBuffer (int slot, juce::MidiBuffer& midiout, int numSamples);
+    void playLoopEvent (int slot, int instance, int eventindex, int channel, double stretch, int samplepos, double samplesPerPpq, juce::MidiBuffer& midiout);
     double getLoopLengthStep();
     double getPpqOfLastLoopStart (double ppq, int slot);
-    void recordMessage (const MidiMessage& midi_message, int slot, bool playing, double ppq, double eventoffset, double ppqPerSample, int sample_number);
+    void recordMessage (const juce::MidiMessage& midi_message, int slot, bool playing, double ppq, double eventoffset, double ppqPerSample, int sample_number);
 
     int slotLimit;
+
+    JUCE_LEAK_DETECTOR (PizLooper)
 };
 
 #endif

--- a/pizjuce/midiLooper/PizLooperEditor.cpp
+++ b/pizjuce/midiLooper/PizLooperEditor.cpp
@@ -23,6 +23,9 @@
 #include "PizLooperEditor.h"
 
 //[MiscUserDefs] You can add your own user definitions and misc code here...
+using juce::jmax;
+using juce::jmin;
+using juce::roundToInt;
 //[/MiscUserDefs]
 
 //==============================================================================
@@ -766,7 +769,7 @@ PizLooperEditor::PizLooperEditor (PizLooper* const ownerFilter)
     viewport->setScrollBarThickness (16);
     viewport->setViewedComponent (new PianoRoll (this->getFilter(), this, timeline.get()));
 
-    resizer.reset (new ResizableCornerComponent (this, &resizeLimits));
+    resizer.reset (new juce::ResizableCornerComponent (this, &resizeLimits));
     addAndMakeVisible (resizer.get());
 
     b_NoteToggle.reset (new juce::TextButton ("new button"));
@@ -1164,7 +1167,7 @@ PizLooperEditor::PizLooperEditor (PizLooper* const ownerFilter)
     addAndMakeVisible (kbport.get());
     kbport->setScrollBarsShown (false, false);
     kbport->setScrollBarThickness (16);
-    kbport->setViewedComponent (new MidiKeyboardComponent (ownerFilter->kbstate, MidiKeyboardComponent::verticalKeyboardFacingRight));
+    kbport->setViewedComponent (new juce::MidiKeyboardComponent (ownerFilter->kbstate, juce::MidiKeyboardComponent::verticalKeyboardFacingRight));
 
     b_RemoveBar.reset (new juce::TextButton ("RemoveBar"));
     addAndMakeVisible (b_RemoveBar.get());
@@ -2209,7 +2212,7 @@ PizLooperEditor::PizLooperEditor (PizLooper* const ownerFilter)
 
     //[UserPreSize]
     DBG ("PizLooperEditor()");
-    aboutButton->setTooltip (L"Insert Piz Here-> midiLooper v" + String (JucePlugin_VersionString) + " http://thepiz.org/plugins/?p=midiLooper");
+    aboutButton->setTooltip (L"Insert Piz Here-> midiLooper v" + juce::String (JucePlugin_VersionString) + " http://thepiz.org/plugins/?p=midiLooper");
     viewport->setTimeline (timeline.get());
     viewport->setKeyboard (kbport.get());
     this->setMouseClickGrabsKeyboardFocus (false);
@@ -2368,14 +2371,14 @@ PizLooperEditor::PizLooperEditor (PizLooper* const ownerFilter)
     viewport->addChangeListener (this);
 
     midiOutDeviceBox->setMouseClickGrabsKeyboardFocus (false);
-    midiOutDeviceBox->addItem (String ("--"), 1);
+    midiOutDeviceBox->addItem (juce::String ("--"), 1);
     for (int i = 0; i < ownerFilter->devices.size(); i++)
     {
         midiOutDeviceBox->addItem (ownerFilter->devices[i].name, i + 2);
     }
     midiOutDeviceBox->setSelectedId (1);
 
-    loopinfoLabel2->setText ("Stopped", dontSendNotification);
+    loopinfoLabel2->setText ("Stopped", juce::dontSendNotification);
 
     resizeLimits.setSizeLimits (385, 248, 1600, 900);
     ownerFilter->addChangeListener (this);
@@ -2385,7 +2388,7 @@ PizLooperEditor::PizLooperEditor (PizLooper* const ownerFilter)
     pianoRoll->setSize (500, 1200);
     pianoRoll->setSequence (ownerFilter->getActiveLoop());
     pianoRoll->addChangeListener (this);
-    keyboard = (MidiKeyboardComponent*) kbport->getViewedComponent();
+    keyboard = (juce::MidiKeyboardComponent*) kbport->getViewedComponent();
     keyboard->setScrollButtonsVisible (false);
     keyboard->setBounds (0, 0, 25, pianoRoll->getHeight());
     keyboard->setKeyWidth ((float) pianoRoll->getHeight() / 74.75f);
@@ -2978,13 +2981,13 @@ void PizLooperEditor::paint (juce::Graphics& g)
     //[UserPaint] Add your own custom painting code here..
     if (getFilter()->getParameterForSlot (kUseTrChannel, getFilter()->getCurrentProgram()) >= 0.5f)
     {
-        g.setColour (Colour (0xff5b5b5b));
-        g.strokePath (internalPath1, PathStrokeType (5.0000f));
+        g.setColour (juce::Colour (0xff5b5b5b));
+        g.strokePath (internalPath1, juce::PathStrokeType (5.0000f));
     }
     if (getFilter()->getParameterForSlot (kUseScaleChannel, getFilter()->getCurrentProgram()) >= 0.5f)
     {
-        g.setColour (Colour (0xff5b5b5b));
-        g.strokePath (internalPath2, PathStrokeType (5.0000f));
+        g.setColour (juce::Colour (0xff5b5b5b));
+        g.strokePath (internalPath2, juce::PathStrokeType (5.0000f));
     }
     //[/UserPaint]
 }
@@ -3018,14 +3021,14 @@ void PizLooperEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     int index = getButtonIndex (buttonThatWasClicked);
     if (index > -1)
     {
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             getFilter()->toggleSlotPlaying (index);
         }
         else
         {
             getFilter()->setActiveSlot (index);
-            buttonThatWasClicked->setToggleState (true, dontSendNotification);
+            buttonThatWasClicked->setToggleState (true, juce::dontSendNotification);
         }
     }
     //[/UserbuttonClicked_Pre]
@@ -3039,7 +3042,7 @@ void PizLooperEditor::buttonClicked (juce::Button* buttonThatWasClicked)
         }
         else
         {
-            if (ModifierKeys::getCurrentModifiers().isAltDown())
+            if (juce::ModifierKeys::getCurrentModifiers().isAltDown())
                 getFilter()->setParameter (kRecMode, 1.0f);
             else
                 getFilter()->setParameter (kRecMode, 0.7f);
@@ -3068,18 +3071,18 @@ void PizLooperEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     else if (buttonThatWasClicked == b_Reload.get())
     {
         //[UserButtonCode_b_Reload] -- add your button handler code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
             getFilter()->setParameter (kFile, 1.0f);
 
         else
         {
-            FileChooser myChooser ("Load MIDI File...",
-                                   File (getFilter()->loopDir),
-                                   "*.mid");
+            juce::FileChooser myChooser ("Load MIDI File...",
+                                         juce::File (getFilter()->loopDir),
+                                         "*.mid");
 
             if (myChooser.browseForFileToOpen())
             {
-                File midiFile (myChooser.getResult());
+                juce::File midiFile (myChooser.getResult());
                 getFilter()->loadMidiFile (midiFile);
             }
         }
@@ -3088,24 +3091,24 @@ void PizLooperEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     else if (buttonThatWasClicked == b_Save.get())
     {
         //[UserButtonCode_b_Save] -- add your button handler code here..
-        if (ModifierKeys::getCurrentModifiers().isShiftDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isShiftDown())
         {
             //save with filename incremented
             getFilter()->setParameter (kSave, 1.0f);
         }
-        else if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        else if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             getFilter()->setParameter (kSave, 0.9f);
         }
         else
         {
-            FileChooser myChooser ("Save MIDI File...",
-                                   File (getFilter()->loopDir + File::getSeparatorString() + nameLabel->getText()),
-                                   "*.mid");
+            juce::FileChooser myChooser ("Save MIDI File...",
+                                         juce::File (getFilter()->loopDir + juce::File::getSeparatorString() + nameLabel->getText()),
+                                         "*.mid");
 
             if (myChooser.browseForFileToSave (true))
             {
-                File midiFile (myChooser.getResult());
+                juce::File midiFile (myChooser.getResult());
                 if (! midiFile.hasFileExtension ("mid"))
                     midiFile = midiFile.withFileExtension ("mid");
 
@@ -3128,7 +3131,7 @@ void PizLooperEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     else if (buttonThatWasClicked == b_NoteToggle.get())
     {
         //[UserButtonCode_b_NoteToggle] -- add your button handler code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
                 getFilter()->notifyHost (kNoteToggle, i, b_NoteToggle->getToggleState() ? 0.f : 1.f);
@@ -3149,7 +3152,7 @@ void PizLooperEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     else if (buttonThatWasClicked == b_Snap.get())
     {
         //[UserButtonCode_b_Snap] -- add your button handler code here..
-        b_Snap->setToggleState (! getFilter()->getPRSetting ("snap"), dontSendNotification);
+        b_Snap->setToggleState (! getFilter()->getPRSetting ("snap"), juce::dontSendNotification);
         getFilter()->setPRSetting ("snap", b_Snap->getToggleState());
         pianoRoll->repaintBG();
         //[/UserButtonCode_b_Snap]
@@ -3157,7 +3160,7 @@ void PizLooperEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     else if (buttonThatWasClicked == b_ForceToKey.get())
     {
         //[UserButtonCode_b_ForceToKey] -- add your button handler code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
                 getFilter()->notifyHost (kForceToKey, i, buttonThatWasClicked->getToggleState() ? 1.f : 0.f);
@@ -3246,13 +3249,13 @@ void PizLooperEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     else if (buttonThatWasClicked == aboutButton.get())
     {
         //[UserButtonCode_aboutButton] -- add your button handler code here..
-        URL ("http://thepiz.org/plugins/?p=midiLooper").launchInDefaultBrowser();
+        juce::URL ("http://thepiz.org/plugins/?p=midiLooper").launchInDefaultBrowser();
         //[/UserButtonCode_aboutButton]
     }
     else if (buttonThatWasClicked == b_Triplet.get())
     {
         //[UserButtonCode_b_Triplet] -- add your button handler code here..
-        buttonThatWasClicked->setToggleState (! getFilter()->getPRSetting ("triplet"), dontSendNotification);
+        buttonThatWasClicked->setToggleState (! getFilter()->getPRSetting ("triplet"), juce::dontSendNotification);
         getFilter()->setPRSetting ("triplet", buttonThatWasClicked->getToggleState());
         pianoRoll->repaintBG();
         //[/UserButtonCode_b_Triplet]
@@ -3260,7 +3263,7 @@ void PizLooperEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     else if (buttonThatWasClicked == b_Dotted.get())
     {
         //[UserButtonCode_b_Dotted] -- add your button handler code here..
-        buttonThatWasClicked->setToggleState (! getFilter()->getPRSetting ("dotted"), dontSendNotification);
+        buttonThatWasClicked->setToggleState (! getFilter()->getPRSetting ("dotted"), juce::dontSendNotification);
         getFilter()->setPRSetting ("dotted", buttonThatWasClicked->getToggleState());
         pianoRoll->repaintBG();
         //[/UserButtonCode_b_Dotted]
@@ -3270,7 +3273,7 @@ void PizLooperEditor::buttonClicked (juce::Button* buttonThatWasClicked)
         //[UserButtonCode_b_ZoomOut] -- add your button handler code here..
         double y = (double) viewport->getViewPositionY() / ((double) pianoRoll->getHeight() - viewport->getHeight());
         double x = (double) viewport->getViewPositionX() / ((double) pianoRoll->getWidth() - viewport->getWidth());
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             pianoRoll->setSize (pianoRoll->getWidth(), jmax (366, (int) (pianoRoll->getHeight() * 0.75)));
             keyboard->setSize (25, pianoRoll->getHeight());
@@ -3293,7 +3296,7 @@ void PizLooperEditor::buttonClicked (juce::Button* buttonThatWasClicked)
         //[UserButtonCode_b_ZoomIn] -- add your button handler code here..
         double y = (double) viewport->getViewPositionY() / ((double) pianoRoll->getHeight() - viewport->getHeight());
         double x = (double) viewport->getViewPositionX() / ((double) pianoRoll->getWidth() - viewport->getWidth());
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             pianoRoll->setSize (pianoRoll->getWidth(), jmin (25600, (int) (pianoRoll->getHeight() * 1.33333333333)));
             keyboard->setSize (25, pianoRoll->getHeight());
@@ -3314,7 +3317,7 @@ void PizLooperEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     else if (buttonThatWasClicked == b_UseScaleChannel.get())
     {
         //[UserButtonCode_b_UseScaleChannel] -- add your button handler code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
                 getFilter()->notifyHost (kUseScaleChannel, i, buttonThatWasClicked->getToggleState() ? 1.f : 0.f);
@@ -3336,7 +3339,7 @@ void PizLooperEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     else if (buttonThatWasClicked == b_WaitForBar.get())
     {
         //[UserButtonCode_b_WaitForBar] -- add your button handler code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
                 getFilter()->notifyHost (kWaitForBar, i, buttonThatWasClicked->getToggleState() ? 1.f : 0.f);
@@ -3357,7 +3360,7 @@ void PizLooperEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     else if (buttonThatWasClicked == b_UseTrChannel.get())
     {
         //[UserButtonCode_b_UseTrChannel] -- add your button handler code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
                 getFilter()->notifyHost (kUseTrChannel, i, buttonThatWasClicked->getToggleState() ? 1.f : 0.f);
@@ -3379,7 +3382,7 @@ void PizLooperEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     else if (buttonThatWasClicked == b_ImmediateTranspose.get())
     {
         //[UserButtonCode_b_ImmediateTranspose] -- add your button handler code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
                 getFilter()->notifyHost (kImmediateTranspose, i, buttonThatWasClicked->getToggleState() ? 1.f : 0.f);
@@ -3401,7 +3404,7 @@ void PizLooperEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     {
         //[UserButtonCode_b_RemoveBar] -- add your button handler code here..
         pianoRoll->removeBar();
-        LengthLabel->setText (String (pianoRoll->getDisplayLength()), dontSendNotification);
+        LengthLabel->setText (juce::String (pianoRoll->getDisplayLength()), juce::dontSendNotification);
         getFilter()->setPRSetting ("bars", pianoRoll->getDisplayLength(), false);
         getFilter()->setPRSetting ("width", pianoRoll->getWidth(), false);
         //[/UserButtonCode_b_RemoveBar]
@@ -3410,7 +3413,7 @@ void PizLooperEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     {
         //[UserButtonCode_b_AddBar] -- add your button handler code here..
         pianoRoll->addBar();
-        LengthLabel->setText (String (pianoRoll->getDisplayLength()), dontSendNotification);
+        LengthLabel->setText (juce::String (pianoRoll->getDisplayLength()), juce::dontSendNotification);
         getFilter()->setPRSetting ("bars", pianoRoll->getDisplayLength(), false);
         getFilter()->setPRSetting ("width", pianoRoll->getWidth(), false);
         //[/UserButtonCode_b_AddBar]
@@ -3418,7 +3421,7 @@ void PizLooperEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     else if (buttonThatWasClicked == b_Transpose10.get())
     {
         //[UserButtonCode_b_Transpose10] -- add your button handler code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
                 getFilter()->notifyHost (kTranspose10, i, b_Transpose10->getToggleState() ? 0.f : 1.f);
@@ -3470,7 +3473,7 @@ void PizLooperEditor::buttonClicked (juce::Button* buttonThatWasClicked)
 void PizLooperEditor::comboBoxChanged (juce::ComboBox* comboBoxThatHasChanged)
 {
     //[UsercomboBoxChanged_Pre]
-    const String selection = comboBoxThatHasChanged->getText();
+    const juce::String selection = comboBoxThatHasChanged->getText();
     //[/UsercomboBoxChanged_Pre]
 
     if (comboBoxThatHasChanged == stepsizeBox.get())
@@ -3495,7 +3498,7 @@ void PizLooperEditor::comboBoxChanged (juce::ComboBox* comboBoxThatHasChanged)
     else if (comboBoxThatHasChanged == loopmodeBox.get())
     {
         //[UserComboBoxCode_loopmodeBox] -- add your combo box handling code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
             {
@@ -3525,7 +3528,7 @@ void PizLooperEditor::comboBoxChanged (juce::ComboBox* comboBoxThatHasChanged)
     else if (comboBoxThatHasChanged == notetriggerBox.get())
     {
         //[UserComboBoxCode_notetriggerBox] -- add your combo box handling code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
             {
@@ -3613,7 +3616,7 @@ void PizLooperEditor::comboBoxChanged (juce::ComboBox* comboBoxThatHasChanged)
     else if (comboBoxThatHasChanged == forceModeBox.get())
     {
         //[UserComboBoxCode_forceModeBox] -- add your combo box handling code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
             {
@@ -3654,7 +3657,7 @@ void PizLooperEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
     if (sliderThatWasMoved == s_Transpose.get())
     {
         //[UserSliderCode_s_Transpose] -- add your slider handling code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
                 getFilter()->notifyHost (kTranspose, i, slider->mapToVSTRange());
@@ -3666,7 +3669,7 @@ void PizLooperEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
     else if (sliderThatWasMoved == s_Octave.get())
     {
         //[UserSliderCode_s_Octave] -- add your slider handling code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
                 getFilter()->notifyHost (kOctave, i, slider->mapToVSTRange());
@@ -3678,7 +3681,7 @@ void PizLooperEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
     else if (sliderThatWasMoved == s_Velocity.get())
     {
         //[UserSliderCode_s_Velocity] -- add your slider handling code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
                 getFilter()->notifyHost (kVelocity, i, slider->mapToVSTRange());
@@ -3690,7 +3693,7 @@ void PizLooperEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
     else if (sliderThatWasMoved == s_Start.get())
     {
         //[UserSliderCode_s_Start] -- add your slider handling code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
                 getFilter()->notifyHost (kLoopStart, i, slider->mapToVSTRange());
@@ -3702,7 +3705,7 @@ void PizLooperEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
     else if (sliderThatWasMoved == s_End.get())
     {
         //[UserSliderCode_s_End] -- add your slider handling code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
                 getFilter()->notifyHost (kLoopEnd, i, slider->mapToVSTRange());
@@ -3714,7 +3717,7 @@ void PizLooperEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
     else if (sliderThatWasMoved == s_Stretch.get())
     {
         //[UserSliderCode_s_Stretch] -- add your slider handling code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
                 getFilter()->notifyHost (kStretch, i, slider->mapToVSTRange());
@@ -3726,7 +3729,7 @@ void PizLooperEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
     else if (sliderThatWasMoved == s_Root.get())
     {
         //[UserSliderCode_s_Root] -- add your slider handling code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
                 getFilter()->notifyHost (kRoot, i, slider->mapToVSTRange());
@@ -3738,16 +3741,16 @@ void PizLooperEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
     else if (sliderThatWasMoved == s_Low.get())
     {
         //[UserSliderCode_s_Low] -- add your slider handling code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
             {
                 getFilter()->notifyHost (kNLow, i, slider->mapToVSTRange());
-                if (ModifierKeys::getCurrentModifiers().isShiftDown())
+                if (juce::ModifierKeys::getCurrentModifiers().isShiftDown())
                     getFilter()->notifyHost (kNHigh, i, slider->mapToVSTRange());
             }
         }
-        else if (ModifierKeys::getCurrentModifiers().isShiftDown())
+        else if (juce::ModifierKeys::getCurrentModifiers().isShiftDown())
         {
             getFilter()->notifyHostForActiveSlot (kNLow, slider->mapToVSTRange());
             getFilter()->notifyHostForActiveSlot (kNHigh, slider->mapToVSTRange());
@@ -3761,16 +3764,16 @@ void PizLooperEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
     else if (sliderThatWasMoved == s_High.get())
     {
         //[UserSliderCode_s_High] -- add your slider handling code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
             {
                 getFilter()->notifyHost (kNHigh, i, slider->mapToVSTRange());
-                if (ModifierKeys::getCurrentModifiers().isShiftDown())
+                if (juce::ModifierKeys::getCurrentModifiers().isShiftDown())
                     getFilter()->notifyHost (kNLow, i, slider->mapToVSTRange());
             }
         }
-        else if (ModifierKeys::getCurrentModifiers().isShiftDown())
+        else if (juce::ModifierKeys::getCurrentModifiers().isShiftDown())
         {
             getFilter()->notifyHostForActiveSlot (kNHigh, slider->mapToVSTRange());
             getFilter()->notifyHostForActiveSlot (kNLow, slider->mapToVSTRange());
@@ -3782,7 +3785,7 @@ void PizLooperEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
     else if (sliderThatWasMoved == s_TrigChan.get())
     {
         //[UserSliderCode_s_TrigChan] -- add your slider handling code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
                 getFilter()->notifyHost (kTrigChan, i, slider->mapToVSTRange());
@@ -3794,7 +3797,7 @@ void PizLooperEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
     else if (sliderThatWasMoved == s_Shift.get())
     {
         //[UserSliderCode_s_Shift] -- add your slider handling code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
                 getFilter()->notifyHost (kShift, i, slider->mapToVSTRange());
@@ -3806,7 +3809,7 @@ void PizLooperEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
     else if (sliderThatWasMoved == s_Channel.get())
     {
         //[UserSliderCode_s_Channel] -- add your slider handling code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
                 getFilter()->notifyHost (kChannel, i, slider->mapToVSTRange());
@@ -3824,7 +3827,7 @@ void PizLooperEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
     else if (sliderThatWasMoved == s_PlayGroup.get())
     {
         //[UserSliderCode_s_PlayGroup] -- add your slider handling code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
                 getFilter()->notifyHost (kPlayGroup, i, slider->mapToVSTRange());
@@ -3836,7 +3839,7 @@ void PizLooperEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
     else if (sliderThatWasMoved == s_MuteGroup.get())
     {
         //[UserSliderCode_s_MuteGroup] -- add your slider handling code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
                 getFilter()->notifyHost (kMuteGroup, i, slider->mapToVSTRange());
@@ -3854,9 +3857,9 @@ void PizLooperEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
     else if (sliderThatWasMoved == s_ScaleChannel.get())
     {
         //[UserSliderCode_s_ScaleChannel] -- add your slider handling code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
-            if (ModifierKeys::getCurrentModifiers().isShiftDown())
+            if (juce::ModifierKeys::getCurrentModifiers().isShiftDown())
             {
                 for (int i = 0; i < numSlots; i++)
                 {
@@ -3873,7 +3876,7 @@ void PizLooperEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
         else
         {
             getFilter()->notifyHostForActiveSlot (kScaleChannel, slider->mapToVSTRange());
-            if (ModifierKeys::getCurrentModifiers().isShiftDown())
+            if (juce::ModifierKeys::getCurrentModifiers().isShiftDown())
                 getFilter()->notifyHostForActiveSlot (kTransposeChannel, slider->mapToVSTRange());
         }
         //[/UserSliderCode_s_ScaleChannel]
@@ -3887,7 +3890,7 @@ void PizLooperEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
     else if (sliderThatWasMoved == s_NumLoops.get())
     {
         //[UserSliderCode_s_NumLoops] -- add your slider handling code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
                 getFilter()->notifyHost (kNumLoops, i, slider->mapToVSTRange());
@@ -3899,7 +3902,7 @@ void PizLooperEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
     else if (sliderThatWasMoved == s_NextSlot.get())
     {
         //[UserSliderCode_s_NextSlot] -- add your slider handling code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
                 getFilter()->notifyHost (kNextSlot, i, slider->mapToVSTRange());
@@ -3923,7 +3926,7 @@ void PizLooperEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
     else if (sliderThatWasMoved == s_VelocitySens.get())
     {
         //[UserSliderCode_s_VelocitySens] -- add your slider handling code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
             for (int i = 0; i < numSlots; i++)
                 getFilter()->notifyHost (kVeloSens, i, slider->mapToVSTRange());
@@ -3935,9 +3938,9 @@ void PizLooperEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
     else if (sliderThatWasMoved == s_TransposeChannel.get())
     {
         //[UserSliderCode_s_TransposeChannel] -- add your slider handling code here..
-        if (ModifierKeys::getCurrentModifiers().isCommandDown())
+        if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
         {
-            if (ModifierKeys::getCurrentModifiers().isShiftDown())
+            if (juce::ModifierKeys::getCurrentModifiers().isShiftDown())
             {
                 for (int i = 0; i < numSlots; i++)
                 {
@@ -3954,7 +3957,7 @@ void PizLooperEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
         else
         {
             getFilter()->notifyHostForActiveSlot (kTransposeChannel, slider->mapToVSTRange());
-            if (ModifierKeys::getCurrentModifiers().isShiftDown())
+            if (juce::ModifierKeys::getCurrentModifiers().isShiftDown())
                 getFilter()->notifyHostForActiveSlot (kScaleChannel, slider->mapToVSTRange());
         }
         //[/UserSliderCode_s_TransposeChannel]
@@ -3986,7 +3989,7 @@ void PizLooperEditor::labelTextChanged (juce::Label* labelThatHasChanged)
             pianoRoll->repaintBG();
         }
         else
-            numerator->setText (String (getFilter()->getNumerator (lastActiveLoop)), dontSendNotification);
+            numerator->setText (juce::String (getFilter()->getNumerator (lastActiveLoop)), juce::dontSendNotification);
         //[/UserLabelCode_numerator]
     }
     else if (labelThatHasChanged == denominator.get())
@@ -4000,7 +4003,7 @@ void PizLooperEditor::labelTextChanged (juce::Label* labelThatHasChanged)
             pianoRoll->repaintBG();
         }
         else
-            denominator->setText (String (getFilter()->getDenominator (lastActiveLoop)), dontSendNotification);
+            denominator->setText (juce::String (getFilter()->getDenominator (lastActiveLoop)), juce::dontSendNotification);
         //[/UserLabelCode_denominator]
     }
     else if (labelThatHasChanged == LengthLabel.get())
@@ -4021,22 +4024,22 @@ void PizLooperEditor::labelTextChanged (juce::Label* labelThatHasChanged)
 void PizLooperEditor::buttonStateChanged (juce::Button* button)
 {
 }
-void PizLooperEditor::mouseDown (const MouseEvent& e)
+void PizLooperEditor::mouseDown (const juce::MouseEvent& e)
 {
     int index = getButtonIndex (e.eventComponent);
     if (e.mods.isPopupMenu() && index != -1)
     {
         for (int i = 0; i < numSlots; i++)
             getFilter()->notifyHost (kPlay, i, index == i ? 1.f : 0.f);
-        ((Button*) e.eventComponent)->setToggleState (true, dontSendNotification);
+        ((juce::Button*) e.eventComponent)->setToggleState (true, juce::dontSendNotification);
     }
 }
 
-void PizLooperEditor::mouseDrag (const MouseEvent& e)
+void PizLooperEditor::mouseDrag (const juce::MouseEvent& e)
 {
 }
 
-void PizLooperEditor::mouseUp (const MouseEvent& e)
+void PizLooperEditor::mouseUp (const juce::MouseEvent& e)
 {
     Component* p = e.eventComponent->getParentComponent();
     if (e.eventComponent == b_Play.get())
@@ -4086,35 +4089,35 @@ void PizLooperEditor::mouseUp (const MouseEvent& e)
     }
     else if (p == s_Root.get() || p == s_High.get() || p == s_Low.get())
     {
-        Slider* slider = ((Slider*) p);
+        auto* slider = (juce::Slider*) p;
         if (e.mods.isMiddleButtonDown())
         {
             //middle-click midi learn
-            slider->setValue (-1, sendNotification);
+            slider->setValue (-1, juce::sendNotification);
         }
         else if (e.mods.isPopupMenu())
         {
             if (slider->isDoubleClickReturnEnabled())
             {
                 double value = slider->getDoubleClickReturnValue();
-                slider->setValue (value, sendNotification);
+                slider->setValue (value, juce::sendNotification);
             }
         }
     }
     else if (p == s_PlayCC.get() || p == s_RecCC.get())
     {
-        Slider* slider = ((Slider*) p);
+        auto* slider = (juce::Slider*) p;
         if (e.mods.isMiddleButtonDown())
         {
             //middle-click midi learn
-            slider->setValue (-2, sendNotification);
+            slider->setValue (-2, juce::sendNotification);
         }
         else if (e.mods.isPopupMenu())
         {
             if (slider->isDoubleClickReturnEnabled())
             {
                 double value = slider->getDoubleClickReturnValue();
-                slider->setValue (value, sendNotification);
+                slider->setValue (value, juce::sendNotification);
             }
         }
     }
@@ -4124,25 +4127,25 @@ void PizLooperEditor::mouseUp (const MouseEvent& e)
     {
         if (e.mods.isPopupMenu())
         {
-            Slider* slider = ((Slider*) p);
+            auto* slider = (juce::Slider*) p;
             if (slider->isDoubleClickReturnEnabled())
             {
                 double value = slider->getDoubleClickReturnValue();
-                slider->setValue (value, sendNotification);
+                slider->setValue (value, juce::sendNotification);
             }
         }
     }
 }
 
-void PizLooperEditor::filesDropped (const StringArray& filenames, int mouseX, int mouseY)
+void PizLooperEditor::filesDropped (const juce::StringArray& filenames, int mouseX, int mouseY)
 {
-    if (File (filenames[0]).hasFileExtension ("mid"))
-        getFilter()->loadMidiFile (File (filenames[0]));
+    if (juce::File (filenames[0]).hasFileExtension ("mid"))
+        getFilter()->loadMidiFile (juce::File (filenames[0]));
 }
 
-bool PizLooperEditor::isInterestedInFileDrag (const StringArray& files)
+bool PizLooperEditor::isInterestedInFileDrag (const juce::StringArray& files)
 {
-    File file = File (files[0]);
+    juce::File file = juce::File (files[0]);
     if (file.hasFileExtension ("mid"))
         return true;
     if (file.getFileName() == "midiLooperKey.txt")
@@ -4155,7 +4158,7 @@ void PizLooperEditor::timerCallback()
     pianoRoll->setPlayTime (960.0 * getFilter()->getPlayPosition (pianoRoll->playing, pianoRoll->recording));
 }
 
-void PizLooperEditor::handleNoteOn (MidiKeyboardState* source, int midiChannel, int midiNoteNumber, float velocity)
+void PizLooperEditor::handleNoteOn (juce::MidiKeyboardState* source, int midiChannel, int midiNoteNumber, float velocity)
 {
     if (source == &(getFilter()->keySelectorState))
     {
@@ -4164,7 +4167,7 @@ void PizLooperEditor::handleNoteOn (MidiKeyboardState* source, int midiChannel, 
     }
 }
 
-void PizLooperEditor::handleNoteOff (MidiKeyboardState* source, int midiChannel, int midiNoteNumber, float velocity)
+void PizLooperEditor::handleNoteOff (juce::MidiKeyboardState* source, int midiChannel, int midiNoteNumber, float velocity)
 {
     if (source == &(getFilter()->keySelectorState))
     {
@@ -4174,7 +4177,7 @@ void PizLooperEditor::handleNoteOff (MidiKeyboardState* source, int midiChannel,
 }
 
 //==============================================================================
-void PizLooperEditor::changeListenerCallback (ChangeBroadcaster* source)
+void PizLooperEditor::changeListenerCallback (juce::ChangeBroadcaster* source)
 {
     if (source == getFilter() || getFilter()->newLoop)
     {
@@ -4182,7 +4185,7 @@ void PizLooperEditor::changeListenerCallback (ChangeBroadcaster* source)
     }
     else if (source == getFilter()->info)
     {
-        loopinfoLabel2->setText (getFilter()->info->s, sendNotification);
+        loopinfoLabel2->setText (getFilter()->info->s, juce::sendNotification);
     }
     else if (source == keySelector.get())
     {
@@ -4199,21 +4202,21 @@ void PizLooperEditor::changeListenerCallback (ChangeBroadcaster* source)
         getFilter()->updateLoopInfo();
         if (getFilter()->currentNumEvents == 0)
         {
-            loopinfoLabel->setText ("No Loop", dontSendNotification);
-            getButtonForSlot (lastActiveLoop)->setColour (TextButton::textColourOffId, Colour (0xff979797));
-            getButtonForSlot (lastActiveLoop)->setColour (TextButton::textColourOnId, Colour (0xff555555));
+            loopinfoLabel->setText ("No Loop", juce::dontSendNotification);
+            getButtonForSlot (lastActiveLoop)->setColour (juce::TextButton::textColourOffId, juce::Colour (0xff979797));
+            getButtonForSlot (lastActiveLoop)->setColour (juce::TextButton::textColourOnId, juce::Colour (0xff555555));
         }
         else
         {
-            String loopinfo = "Loop length: ";
+            juce::String loopinfo = "Loop length: ";
             if (getFilter()->currentLength == 1.0)
                 loopinfo << "1 Beat (";
             else
                 loopinfo << getFilter()->currentLength << " Beats (";
             loopinfo << getFilter()->currentNumEvents << " Events)";
-            loopinfoLabel->setText (loopinfo, dontSendNotification);
-            getButtonForSlot (lastActiveLoop)->setColour (TextButton::textColourOffId, Colours::black);
-            getButtonForSlot (lastActiveLoop)->setColour (TextButton::textColourOnId, Colours::black);
+            loopinfoLabel->setText (loopinfo, juce::dontSendNotification);
+            getButtonForSlot (lastActiveLoop)->setColour (juce::TextButton::textColourOffId, juce::Colours::black);
+            getButtonForSlot (lastActiveLoop)->setColour (juce::TextButton::textColourOnId, juce::Colours::black);
         }
     }
     else if (source == viewport.get())
@@ -4235,20 +4238,20 @@ void PizLooperEditor::updateControls (int param, float value, bool forCurProgram
     switch (param)
     {
         case kThru:
-            b_Thru->setToggleState (value >= 0.5f, dontSendNotification);
+            b_Thru->setToggleState (value >= 0.5f, juce::dontSendNotification);
             b_Monitor->setEnabled (b_Thru->getToggleState());
             break;
         case kMonitor:
-            b_Monitor->setToggleState (value >= 0.5f, dontSendNotification);
+            b_Monitor->setToggleState (value >= 0.5f, juce::dontSendNotification);
             break;
         case kSync:
-            syncmodeBox->setText (getFilter()->getCurrentSlotParameterText (kSync), dontSendNotification);
+            syncmodeBox->setText (getFilter()->getCurrentSlotParameterText (kSync), juce::dontSendNotification);
             break;
         case kRecStep:
-            stepsizeBox->setText (getFilter()->getCurrentSlotParameterText (kRecStep), dontSendNotification);
+            stepsizeBox->setText (getFilter()->getCurrentSlotParameterText (kRecStep), juce::dontSendNotification);
             break;
         case kQuantize:
-            quantizeBox->setText (getFilter()->getCurrentSlotParameterText (kQuantize), dontSendNotification);
+            quantizeBox->setText (getFilter()->getCurrentSlotParameterText (kQuantize), juce::dontSendNotification);
             break;
         case kFixedLength:
             s_FixedLength->setVSTSlider (value);
@@ -4256,19 +4259,19 @@ void PizLooperEditor::updateControls (int param, float value, bool forCurProgram
         case kRecMode:
             if (value >= 0.8f)
             {
-                b_Overdub->setColour (TextButton::buttonOnColourId, getLookAndFeel().findColour (TextButton::buttonOnColourId));
-                b_KeepLength->setToggleState (false, dontSendNotification);
+                b_Overdub->setColour (juce::TextButton::buttonOnColourId, getLookAndFeel().findColour (juce::TextButton::buttonOnColourId));
+                b_KeepLength->setToggleState (false, juce::dontSendNotification);
             }
             else
             {
-                b_Overdub->setColour (TextButton::buttonOnColourId, Colours::green);
-                b_KeepLength->setToggleState (true, dontSendNotification);
+                b_Overdub->setColour (juce::TextButton::buttonOnColourId, juce::Colours::green);
+                b_KeepLength->setToggleState (true, juce::dontSendNotification);
             }
-            b_Overdub->setToggleState (value >= 0.5f, dontSendNotification);
+            b_Overdub->setToggleState (value >= 0.5f, juce::dontSendNotification);
             b_KeepLength->setVisible (value >= 0.5f);
             break;
         case kSingleLoop:
-            b_SingleLoop->setToggleState (value >= 0.5f, dontSendNotification);
+            b_SingleLoop->setToggleState (value >= 0.5f, juce::dontSendNotification);
             break;
         case kMasterVelocity:
             s_MasterVelocity->setVSTSlider (value);
@@ -4277,7 +4280,7 @@ void PizLooperEditor::updateControls (int param, float value, bool forCurProgram
             s_MasterTranspose->setVSTSlider (value);
             break;
         case kImmediateTranspose:
-            b_ImmediateTranspose->setToggleState (value >= 0.5f, dontSendNotification);
+            b_ImmediateTranspose->setToggleState (value >= 0.5f, juce::dontSendNotification);
             break;
         case kRecCC:
             s_RecCC->setVSTSlider (value);
@@ -4287,10 +4290,10 @@ void PizLooperEditor::updateControls (int param, float value, bool forCurProgram
             break;
 
         case kRecord:
-            b_Record->setToggleState (value >= 0.5f, dontSendNotification);
+            b_Record->setToggleState (value >= 0.5f, juce::dontSendNotification);
             break;
         case kPlay:
-            b_Play->setToggleState (value >= 0.5f, dontSendNotification);
+            b_Play->setToggleState (value >= 0.5f, juce::dontSendNotification);
             b_Play->setButtonText (value >= 0.5f ? "STOP" : "PLAY");
             updateSlotButtons();
             break;
@@ -4327,10 +4330,10 @@ void PizLooperEditor::updateControls (int param, float value, bool forCurProgram
             s_Stretch->setVSTSlider (value);
             break;
         case kTrigger:
-            loopmodeBox->setText (getFilter()->getCurrentSlotParameterText (kTrigger), dontSendNotification);
+            loopmodeBox->setText (getFilter()->getCurrentSlotParameterText (kTrigger), juce::dontSendNotification);
             break;
         case kNoteTrig:
-            notetriggerBox->setText (getFilter()->getCurrentSlotParameterText (kNoteTrig), dontSendNotification);
+            notetriggerBox->setText (getFilter()->getCurrentSlotParameterText (kNoteTrig), juce::dontSendNotification);
             break;
         case kRoot:
             s_Root->setIndex (lastActiveLoop * numParamsPerSlot + kRoot);
@@ -4361,7 +4364,7 @@ void PizLooperEditor::updateControls (int param, float value, bool forCurProgram
                 b_Filt->setButtonText ("Filter");
             break;
         case kWaitForBar:
-            b_WaitForBar->setToggleState (value >= 0.5f, dontSendNotification);
+            b_WaitForBar->setToggleState (value >= 0.5f, juce::dontSendNotification);
             break;
         case kNumLoops:
             s_NumLoops->setIndex (lastActiveLoop * numParamsPerSlot + kNumLoops);
@@ -4380,7 +4383,7 @@ void PizLooperEditor::updateControls (int param, float value, bool forCurProgram
             s_MuteGroup->setVSTSlider (value);
             break;
         case kForceToKey:
-            b_ForceToKey->setToggleState (value >= 0.5f, dontSendNotification);
+            b_ForceToKey->setToggleState (value >= 0.5f, juce::dontSendNotification);
             break;
         case kScaleChannel:
             s_ScaleChannel->setIndex (lastActiveLoop * numParamsPerSlot + kScaleChannel);
@@ -4391,19 +4394,19 @@ void PizLooperEditor::updateControls (int param, float value, bool forCurProgram
             s_TransposeChannel->setVSTSlider (value);
             break;
         case kUseScaleChannel:
-            b_UseScaleChannel->setToggleState (value >= 0.5f, dontSendNotification);
+            b_UseScaleChannel->setToggleState (value >= 0.5f, juce::dontSendNotification);
             break;
         case kUseTrChannel:
-            b_UseTrChannel->setToggleState (value >= 0.5f, dontSendNotification);
+            b_UseTrChannel->setToggleState (value >= 0.5f, juce::dontSendNotification);
             break;
         case kNoteToggle:
-            b_NoteToggle->setToggleState (value >= 0.5f, dontSendNotification);
+            b_NoteToggle->setToggleState (value >= 0.5f, juce::dontSendNotification);
             break;
         case kForceToScaleMode:
-            forceModeBox->setText (getFilter()->getCurrentSlotParameterText (kForceToScaleMode), dontSendNotification);
+            forceModeBox->setText (getFilter()->getCurrentSlotParameterText (kForceToScaleMode), juce::dontSendNotification);
             break;
         case kTranspose10:
-            b_Transpose10->setToggleState (value >= 0.5f, dontSendNotification);
+            b_Transpose10->setToggleState (value >= 0.5f, juce::dontSendNotification);
         default:
             break;
     }
@@ -4414,28 +4417,28 @@ void PizLooperEditor::updateSlotButtons()
     PizLooper* const filter = getFilter();
     for (int i = 0; i < numSlots; i++)
     {
-        TextButton* b = getButtonForSlot (i);
+        juce::TextButton* b = getButtonForSlot (i);
         if (filter->isSlotPlaying (i))
         {
-            b->setColour (TextButton::buttonColourId, Colour (0xff17e617));
-            b->setColour (TextButton::buttonOnColourId, Colour (0xff17e617));
+            b->setColour (juce::TextButton::buttonColourId, juce::Colour (0xff17e617));
+            b->setColour (juce::TextButton::buttonOnColourId, juce::Colour (0xff17e617));
         }
         else
         {
-            b->setColour (TextButton::buttonColourId, Colour (0xffd3d3d3));
-            b->setColour (TextButton::buttonOnColourId, Colour (0xff979797));
+            b->setColour (juce::TextButton::buttonColourId, juce::Colour (0xffd3d3d3));
+            b->setColour (juce::TextButton::buttonOnColourId, juce::Colour (0xff979797));
         }
         if (filter->isLoopEmpty (i))
         {
-            b->setColour (TextButton::textColourOffId, Colour (0xff979797));
-            b->setColour (TextButton::textColourOnId, Colour (0xff555555));
+            b->setColour (juce::TextButton::textColourOffId, juce::Colour (0xff979797));
+            b->setColour (juce::TextButton::textColourOnId, juce::Colour (0xff555555));
         }
         else
         {
-            b->setColour (TextButton::textColourOffId, Colours::black);
-            b->setColour (TextButton::textColourOnId, Colours::black);
+            b->setColour (juce::TextButton::textColourOffId, juce::Colours::black);
+            b->setColour (juce::TextButton::textColourOnId, juce::Colours::black);
         }
-        b->setButtonText (String (i + 1));
+        b->setButtonText (juce::String (i + 1));
     }
 }
 
@@ -4467,21 +4470,21 @@ void PizLooperEditor::updateParametersFromFilter()
 
     // ..and after releasing the lock, we're free to do the time-consuming UI stuff..
     {
-        b_Snap->setToggleState (filter->getPRSetting ("snap"), dontSendNotification);
+        b_Snap->setToggleState (filter->getPRSetting ("snap"), juce::dontSendNotification);
         pianoRoll->setSnap (b_Snap->getToggleState());
         float q = filter->getPRSetting ("stepsize");
         if (q == 0.0)
-            quantizeBox2->setText ("4th", dontSendNotification);
+            quantizeBox2->setText ("4th", juce::dontSendNotification);
         else if (q < 0.3)
-            quantizeBox2->setText ("8th", dontSendNotification);
+            quantizeBox2->setText ("8th", juce::dontSendNotification);
         else if (q < 0.6)
-            quantizeBox2->setText ("16th", dontSendNotification);
+            quantizeBox2->setText ("16th", juce::dontSendNotification);
         else if (q < 0.9)
-            quantizeBox2->setText ("32nd", dontSendNotification);
+            quantizeBox2->setText ("32nd", juce::dontSendNotification);
         else
-            quantizeBox2->setText ("64th", dontSendNotification);
-        b_Dotted->setToggleState (filter->getPRSetting ("dotted"), dontSendNotification);
-        b_Triplet->setToggleState (filter->getPRSetting ("triplet"), dontSendNotification);
+            quantizeBox2->setText ("64th", juce::dontSendNotification);
+        b_Dotted->setToggleState (filter->getPRSetting ("dotted"), juce::dontSendNotification);
+        b_Triplet->setToggleState (filter->getPRSetting ("triplet"), juce::dontSendNotification);
         float tord = (filter->getPRSetting ("triplet")) ? 1.5f : 1.f;
         if (filter->getPRSetting ("dotted"))
             tord = 0.666666667f;
@@ -4503,10 +4506,10 @@ void PizLooperEditor::updateParametersFromFilter()
                                    filter->getPRSetting ("y"));
     }
     pianoRoll->setTimeSig (n, d);
-    numerator->setText (String (n), dontSendNotification);
-    denominator->setText (String (d), dontSendNotification);
+    numerator->setText (juce::String (n), juce::dontSendNotification);
+    denominator->setText (juce::String (d), juce::dontSendNotification);
 
-    midiOutDeviceBox->setSelectedItemIndex (newDevice + 1, dontSendNotification);
+    midiOutDeviceBox->setSelectedItemIndex (newDevice + 1, juce::dontSendNotification);
 
     for (int i = 0; i < numParamsPerSlot + numGlobalParams; i++)
         updateControls (i, param[i], true);
@@ -4514,61 +4517,61 @@ void PizLooperEditor::updateParametersFromFilter()
     //loop selector buttons
     for (int i = 0; i < numSlots; i++)
     {
-        TextButton* b = getButtonForSlot (i);
+        juce::TextButton* b = getButtonForSlot (i);
         if (slotPlayState[i])
         {
-            b->setColour (TextButton::buttonColourId, Colour (0xff17e617));
-            b->setColour (TextButton::buttonOnColourId, Colour (0xff17e617));
+            b->setColour (juce::TextButton::buttonColourId, juce::Colour (0xff17e617));
+            b->setColour (juce::TextButton::buttonOnColourId, juce::Colour (0xff17e617));
         }
         else
         {
-            b->setColour (TextButton::buttonColourId, Colour (0xffd3d3d3));
-            b->setColour (TextButton::buttonOnColourId, Colour (0xff979797));
+            b->setColour (juce::TextButton::buttonColourId, juce::Colour (0xffd3d3d3));
+            b->setColour (juce::TextButton::buttonOnColourId, juce::Colour (0xff979797));
         }
         if (filter->isLoopEmpty (i))
         {
-            b->setColour (TextButton::textColourOffId, Colour (0xff979797));
-            b->setColour (TextButton::textColourOnId, Colour (0xff555555));
+            b->setColour (juce::TextButton::textColourOffId, juce::Colour (0xff979797));
+            b->setColour (juce::TextButton::textColourOnId, juce::Colour (0xff555555));
         }
         else
         {
-            b->setColour (TextButton::textColourOffId, Colours::black);
-            b->setColour (TextButton::textColourOnId, Colours::black);
+            b->setColour (juce::TextButton::textColourOffId, juce::Colours::black);
+            b->setColour (juce::TextButton::textColourOnId, juce::Colours::black);
         }
-        b->setButtonText (String (i + 1));
+        b->setButtonText (juce::String (i + 1));
     }
-    getButtonForSlot (lastActiveLoop)->setToggleState (true, dontSendNotification);
+    getButtonForSlot (lastActiveLoop)->setToggleState (true, juce::dontSendNotification);
 
-    nameLabel->setText (filter->getProgramName (lastActiveLoop), dontSendNotification);
+    nameLabel->setText (filter->getProgramName (lastActiveLoop), juce::dontSendNotification);
 
     if (filter->currentNumEvents == 0)
-        loopinfoLabel->setText ("No Loop", dontSendNotification);
+        loopinfoLabel->setText ("No Loop", juce::dontSendNotification);
     else
     {
-        String loopinfo = "Loop length: ";
+        juce::String loopinfo = "Loop length: ";
         if (filter->currentLength == 1.0)
             loopinfo << "1 Beat (";
         else
             loopinfo << filter->currentLength << " Beats (";
         loopinfo << filter->currentNumEvents << " Events)";
-        loopinfoLabel->setText (loopinfo, dontSendNotification);
+        loopinfoLabel->setText (loopinfo, juce::dontSendNotification);
     }
     noSnap = true;
     timeline->setLoop (filter->getLoopStart (lastActiveLoop), filter->getLoopLength (lastActiveLoop));
     noSnap = false;
 
-    loopinfoLabel2->setText (filter->info->s, dontSendNotification);
+    loopinfoLabel2->setText (filter->info->s, juce::dontSendNotification);
 
     if (newloop)
     {
         pianoRoll->setSequence (filter->getActiveLoop());
         filter->newLoop = false;
     }
-    LengthLabel->setText (String (pianoRoll->getDisplayLength()), dontSendNotification);
+    LengthLabel->setText (juce::String (pianoRoll->getDisplayLength()), juce::dontSendNotification);
     setSize (w, h);
 }
 
-TextButton* PizLooperEditor::getButtonForSlot (int slot)
+juce::TextButton* PizLooperEditor::getButtonForSlot (int slot)
 {
     switch (slot)
     {

--- a/pizjuce/midiLooper/PizLooperEditor.h
+++ b/pizjuce/midiLooper/PizLooperEditor.h
@@ -20,8 +20,8 @@
 #pragma once
 
 //[Headers]     -- You can add your own extra header files here --
-#include "juce_audio_utils/juce_audio_utils.h"
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_audio_utils/juce_audio_utils.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
 #include "../_common/ClickableLabel.h"
 #include "../_common/VSTSlider.h"
@@ -29,19 +29,19 @@
 #include "PianoRoll.h"
 #include "PizLooper.h"
 
-class KeySelector : public MidiKeyboardComponent
+class KeySelector : public juce::MidiKeyboardComponent
 {
 public:
-    KeySelector (MidiKeyboardState& state)
+    KeySelector (juce::MidiKeyboardState& state)
         : MidiKeyboardComponent (state, MidiKeyboardComponent::horizontalKeyboard)
     {
         s = &state;
-        this->setColour (MidiKeyboardComponent::textLabelColourId, Colours::transparentBlack);
+        this->setColour (MidiKeyboardComponent::textLabelColourId, juce::Colours::transparentBlack);
     }
     ~KeySelector() override {}
 
 private:
-    bool mouseDownOnKey (int midiNoteNumber, const MouseEvent& e) override
+    bool mouseDownOnKey (int midiNoteNumber, const juce::MouseEvent& e) override
     {
         if (s->isNoteOn (this->getMidiChannel(), midiNoteNumber))
         {
@@ -53,7 +53,7 @@ private:
         }
         return false;
     }
-    MidiKeyboardState* s;
+    juce::MidiKeyboardState* s;
 };
 
 //[/Headers]
@@ -66,12 +66,12 @@ private:
     Describe your class and how it works here!
                                                                     //[/Comments]
 */
-class PizLooperEditor : public AudioProcessorEditor,
-                        public ChangeListener,
-                        public FileDragAndDropTarget,
+class PizLooperEditor : public juce::AudioProcessorEditor,
+                        public juce::ChangeListener,
+                        public juce::FileDragAndDropTarget,
                         public ClickableLabelListener,
-                        public Timer,
-                        public MidiKeyboardStateListener,
+                        public juce::Timer,
+                        public juce::MidiKeyboardStateListener,
                         public juce::Button::Listener,
                         public juce::ComboBox::Listener,
                         public juce::Slider::Listener,
@@ -84,24 +84,24 @@ public:
 
     //==============================================================================
     //[UserMethods]     -- You can add your own custom methods in this section.
-    void changeListenerCallback (ChangeBroadcaster* source) override;
-    bool isInterestedInFileDrag (const StringArray& files) override;
-    void filesDropped (const StringArray& filenames, int mouseX, int mouseY) override;
+    void changeListenerCallback (juce::ChangeBroadcaster* source) override;
+    bool isInterestedInFileDrag (const juce::StringArray& files) override;
+    void filesDropped (const juce::StringArray& filenames, int mouseX, int mouseY) override;
     //    void sliderDragStarted (Slider* slider); //slider mousedown
     //    void sliderDragEnded (Slider* slider); //slider mouseup
     void timerCallback() override;
-    void buttonStateChanged (Button* button) override;
-    void mouseDrag (const MouseEvent& e) override;
-    void mouseDown (const MouseEvent& e) override;
-    void mouseUp (const MouseEvent& e) override;
-    void clickableLabelMouseDown (ClickableLabel* label, const MouseEvent& e) override {}
-    void clickableLabelMouseDoubleClick (ClickableLabel* label, const MouseEvent& e) override
+    void buttonStateChanged (juce::Button* button) override;
+    void mouseDrag (const juce::MouseEvent& e) override;
+    void mouseDown (const juce::MouseEvent& e) override;
+    void mouseUp (const juce::MouseEvent& e) override;
+    void clickableLabelMouseDown (ClickableLabel* label, const juce::MouseEvent& e) override {}
+    void clickableLabelMouseDoubleClick (ClickableLabel* label, const juce::MouseEvent& e) override
     {
         if (label == nameLabel.get())
             label->edit();
     }
-    void handleNoteOn (MidiKeyboardState* source, int midiChannel, int midiNoteNumber, float velocity) override;
-    void handleNoteOff (MidiKeyboardState* source, int midiChannel, int midiNoteNumber, float velocity) override;
+    void handleNoteOn (juce::MidiKeyboardState* source, int midiChannel, int midiNoteNumber, float velocity) override;
+    void handleNoteOff (juce::MidiKeyboardState* source, int midiChannel, int midiNoteNumber, float velocity) override;
     //[/UserMethods]
 
     void paint (juce::Graphics& g) override;
@@ -117,21 +117,21 @@ public:
 
 private:
     //[UserVariables]   -- You can add your own custom variables in this section.
-    TooltipWindow tooltipWindow;
+    juce::TooltipWindow tooltipWindow;
     void updateParametersFromFilter();
     void updateControls (int param, float value, bool forCurProgram);
     void updateSlotButtons();
-    ComponentBoundsConstrainer resizeLimits;
-    TextButton* getButtonForSlot (int slot);
+    juce::ComponentBoundsConstrainer resizeLimits;
+    juce::TextButton* getButtonForSlot (int slot);
     int getButtonIndex (Component* button);
     int lastActiveLoop;
     PianoRoll* pianoRoll;
     bool noSnap;
     int loopDragStart;
-    MidiKeyboardState keySelectorState;
-    MidiKeyboardComponent* keyboard;
-    Path internalPath1;
-    Path internalPath2;
+    juce::MidiKeyboardState keySelectorState;
+    juce::MidiKeyboardComponent* keyboard;
+    juce::Path internalPath1;
+    juce::Path internalPath2;
 
     // handy wrapper method to avoid having to cast the filter to a PizLooper
     // every time we need it..
@@ -205,7 +205,7 @@ private:
     std::unique_ptr<VSTSlider> s_FixedLength;
     std::unique_ptr<juce::TextButton> b_Filt;
     std::unique_ptr<PianoPort> viewport;
-    std::unique_ptr<ResizableCornerComponent> resizer;
+    std::unique_ptr<juce::ResizableCornerComponent> resizer;
     std::unique_ptr<juce::TextButton> b_NoteToggle;
     std::unique_ptr<VSTSlider> s_PlayGroup;
     std::unique_ptr<juce::Label> label13;

--- a/pizjuce/midiLooper/Timeline.cpp
+++ b/pizjuce/midiLooper/Timeline.cpp
@@ -1,8 +1,11 @@
 #include "PianoRoll.h"
 
+using juce::jlimit;
+using juce::jmax;
+
 Timeline::Timeline()
     : Component(),
-      roll (0),
+      roll (nullptr),
       scrollOffset (0)
 {
     setLoop (0, 0);
@@ -11,15 +14,15 @@ Timeline::Timeline()
 
 Timeline::~Timeline() { dispatchPendingMessages(); }
 
-void Timeline::paint (Graphics& g)
+void Timeline::paint (juce::Graphics& g)
 {
-    g.fillAll (Colour (0x0));
+    g.fillAll (juce::Colour (0x0));
     if (roll && getLength() != 0)
     {
-        g.setColour (Colour (0x79006b00));
+        g.setColour (juce::Colour (0x79006b00));
         g.fillRect (getStartPixel(), 0.f, getEndPixel() - getStartPixel(), (float) getHeight());
-        g.setColour (Colours::white);
-        g.drawFittedText ("LOOP AREA", (int) getStartPixel(), 0, (int) (getEndPixel() - getStartPixel()), getHeight(), Justification::centred, 2);
+        g.setColour (juce::Colours::white);
+        g.drawFittedText ("LOOP AREA", (int) getStartPixel(), 0, (int) (getEndPixel() - getStartPixel()), getHeight(), juce::Justification::centred, 2);
     }
 }
 float Timeline::getStartPixel() { return roll->ppqToPixels (loopStart) - scrollOffset; }
@@ -40,7 +43,7 @@ void Timeline::setPianoRoll (PianoRoll* pr)
     setSize (pr->getWidth(), getHeight());
 }
 
-void Timeline::mouseDown (const MouseEvent& e)
+void Timeline::mouseDown (const juce::MouseEvent& e)
 {
     bool snap = roll->getSnap() != e.mods.isShiftDown();
     if (e.mods.isPopupMenu())
@@ -51,7 +54,7 @@ void Timeline::mouseDown (const MouseEvent& e)
     sendChangeMessage();
 }
 
-void Timeline::mouseDrag (const MouseEvent& e)
+void Timeline::mouseDrag (const juce::MouseEvent& e)
 {
     bool snap = roll->getSnap() != e.mods.isShiftDown();
     if (e.mods.isPopupMenu())

--- a/pizjuce/midiLooper/piz_MidiMessageSequence.cpp
+++ b/pizjuce/midiLooper/piz_MidiMessageSequence.cpp
@@ -13,7 +13,7 @@ PizMidiMessageSequence::PizMidiMessageSequence (const PizMidiMessageSequence& ot
         list.add (new MidiEventHolder (other.list.getUnchecked (i)->message));
 }
 
-PizMidiMessageSequence::PizMidiMessageSequence (const MidiMessageSequence& other)
+PizMidiMessageSequence::PizMidiMessageSequence (const juce::MidiMessageSequence& other)
 {
     //list.ensureStorageAllocated (other.getNumEvents());
 
@@ -28,16 +28,16 @@ PizMidiMessageSequence& PizMidiMessageSequence::operator= (const PizMidiMessageS
     return *this;
 }
 
-PizMidiMessageSequence& PizMidiMessageSequence::operator= (const MidiMessageSequence& other)
+PizMidiMessageSequence& PizMidiMessageSequence::operator= (const juce::MidiMessageSequence& other)
 {
     PizMidiMessageSequence otherCopy (other);
     swapWith (otherCopy);
     return *this;
 }
 
-MidiMessageSequence PizMidiMessageSequence::getAsJuceSequence()
+juce::MidiMessageSequence PizMidiMessageSequence::getAsJuceSequence()
 {
-    MidiMessageSequence copy;
+    juce::MidiMessageSequence copy;
     for (int i = 0; i < list.size(); ++i)
         copy.addEvent (list.getUnchecked (i)->message);
 
@@ -132,7 +132,7 @@ double PizMidiMessageSequence::getEventTime (const int index) const
 }
 
 //==============================================================================
-void PizMidiMessageSequence::addEvent (const MidiMessage& newMessage,
+void PizMidiMessageSequence::addEvent (const juce::MidiMessage& newMessage,
                                        double timeAdjustment)
 {
     mehPtr const newOne = new MidiEventHolder (newMessage);
@@ -148,7 +148,7 @@ void PizMidiMessageSequence::addEvent (const MidiMessage& newMessage,
     list.insert (i + 1, newOne);
 }
 
-void PizMidiMessageSequence::addNote (const MidiMessage& noteOn, const MidiMessage& noteOff, double timeAdjustment)
+void PizMidiMessageSequence::addNote (const juce::MidiMessage& noteOn, const juce::MidiMessage& noteOff, double timeAdjustment)
 {
     mehPtr const on = new MidiEventHolder (noteOn);
     double t        = timeAdjustment + noteOn.getTimeStamp();
@@ -175,11 +175,11 @@ void PizMidiMessageSequence::moveEvent (int index, double timeAdjustment, const 
 {
     if (((unsigned int) index) < (unsigned int) list.size())
     {
-        MidiMessage& message1 = list.getUnchecked (index)->message;
+        juce::MidiMessage& message1 = list.getUnchecked (index)->message;
         message1.addToTimeStamp (timeAdjustment);
         if (moveMatchingNoteUp && message1.isNoteOn())
         {
-            MidiMessage& message2 = list.getUnchecked (index)->noteOffObject->message;
+            juce::MidiMessage& message2 = list.getUnchecked (index)->noteOffObject->message;
             timeAdjustment += message2.getTimeStamp();
             message2.addToTimeStamp (timeAdjustment);
         }
@@ -191,14 +191,14 @@ void PizMidiMessageSequence::transposeEvent (int index, int semitones)
 {
     if (((unsigned int) index) < (unsigned int) list.size())
     {
-        MidiMessage& message1 = list.getUnchecked (index)->message;
+        juce::MidiMessage& message1 = list.getUnchecked (index)->message;
         if (message1.isNoteOn() || message1.isAftertouch())
         {
             const int newNote = message1.getNoteNumber() + semitones;
             message1.setNoteNumber (newNote);
             if (message1.isNoteOn())
             {
-                MidiMessage& message2 = list.getUnchecked (index)->noteOffObject->message;
+                juce::MidiMessage& message2 = list.getUnchecked (index)->noteOffObject->message;
                 message2.setNoteNumber (newNote);
             }
         }
@@ -227,8 +227,8 @@ void PizMidiMessageSequence::addSequence (const PizMidiMessageSequence& other,
 
     for (int i = 0; i < other.list.size(); ++i)
     {
-        const MidiMessage& m = other.list.getUnchecked (i)->message;
-        const double t       = m.getTimeStamp();
+        const juce::MidiMessage& m = other.list.getUnchecked (i)->message;
+        const double t             = m.getTimeStamp();
 
         if (t >= firstAllowableTime && t < endOfAllowableDestTimes)
         {
@@ -246,8 +246,8 @@ void PizMidiMessageSequence::addSequence (const PizMidiMessageSequence& other)
 {
     for (int i = 0; i < other.list.size(); ++i)
     {
-        const MidiMessage& m = other.list.getUnchecked (i)->message;
-        const double t       = m.getTimeStamp();
+        const juce::MidiMessage& m = other.list.getUnchecked (i)->message;
+        const double t             = m.getTimeStamp();
 
         mehPtr const newOne = new MidiEventHolder (m);
         newOne->message.setTimeStamp (t);
@@ -281,7 +281,7 @@ void PizMidiMessageSequence::updateMatchedPairs (bool sortEvents)
         sort();
     for (int i = 0; i < list.size(); ++i)
     {
-        const MidiMessage& m1 = list.getUnchecked (i)->message;
+        const juce::MidiMessage& m1 = list.getUnchecked (i)->message;
 
         if (m1.isNoteOn())
         {
@@ -292,7 +292,7 @@ void PizMidiMessageSequence::updateMatchedPairs (bool sortEvents)
 
             for (int j = i + 1; j < len; ++j)
             {
-                const MidiMessage& m = list.getUnchecked (j)->message;
+                const juce::MidiMessage& m = list.getUnchecked (j)->message;
 
                 if (m.getNoteNumber() == note && m.getChannel() == chan)
                 {
@@ -330,7 +330,7 @@ void PizMidiMessageSequence::extractMidiChannelMessages (const int channelNumber
 {
     for (int i = 0; i < list.size(); ++i)
     {
-        const MidiMessage& mm = list.getUnchecked (i)->message;
+        const juce::MidiMessage& mm = list.getUnchecked (i)->message;
 
         if (mm.isForChannel (channelNumberToExtract)
             || (alsoIncludeMetaEvents && mm.isMetaEvent()))
@@ -344,7 +344,7 @@ void PizMidiMessageSequence::extractSysExMessages (PizMidiMessageSequence& destS
 {
     for (int i = 0; i < list.size(); ++i)
     {
-        const MidiMessage& mm = list.getUnchecked (i)->message;
+        const juce::MidiMessage& mm = list.getUnchecked (i)->message;
 
         if (mm.isSysEx())
             destSequence.addEvent (mm);
@@ -368,16 +368,16 @@ void PizMidiMessageSequence::deleteSysExMessages()
 //==============================================================================
 void PizMidiMessageSequence::createControllerUpdatesForTime (const int channelNumber,
                                                              const double time,
-                                                             OwnedArray<MidiMessage>& dest)
+                                                             juce::OwnedArray<juce::MidiMessage>& dest)
 {
     bool doneProg       = false;
     bool donePitchWheel = false;
-    Array<int> doneControllers;
+    juce::Array<int> doneControllers;
     doneControllers.ensureStorageAllocated (32);
 
     for (int i = list.size(); --i >= 0;)
     {
-        const MidiMessage& mm = list.getUnchecked (i)->message;
+        const juce::MidiMessage& mm = list.getUnchecked (i)->message;
 
         if (mm.isForChannel (channelNumber)
             && mm.getTimeStamp() <= time)
@@ -386,7 +386,7 @@ void PizMidiMessageSequence::createControllerUpdatesForTime (const int channelNu
             {
                 if (! doneProg)
                 {
-                    dest.add (new MidiMessage (mm, 0.0));
+                    dest.add (new juce::MidiMessage (mm, 0.0));
                     doneProg = true;
                 }
             }
@@ -394,7 +394,7 @@ void PizMidiMessageSequence::createControllerUpdatesForTime (const int channelNu
             {
                 if (! doneControllers.contains (mm.getControllerNumber()))
                 {
-                    dest.add (new MidiMessage (mm, 0.0));
+                    dest.add (new juce::MidiMessage (mm, 0.0));
                     doneControllers.add (mm.getControllerNumber());
                 }
             }
@@ -402,7 +402,7 @@ void PizMidiMessageSequence::createControllerUpdatesForTime (const int channelNu
             {
                 if (! donePitchWheel)
                 {
-                    dest.add (new MidiMessage (mm, 0.0));
+                    dest.add (new juce::MidiMessage (mm, 0.0));
                     donePitchWheel = true;
                 }
             }
@@ -411,7 +411,7 @@ void PizMidiMessageSequence::createControllerUpdatesForTime (const int channelNu
 }
 
 //==============================================================================
-PizMidiMessageSequence::MidiEventHolder::MidiEventHolder (const MidiMessage& message_)
+PizMidiMessageSequence::MidiEventHolder::MidiEventHolder (const juce::MidiMessage& message_)
     : message (message_),
       noteOffObject (nullptr)
 {

--- a/pizjuce/midiLooper/piz_MidiMessageSequence.h
+++ b/pizjuce/midiLooper/piz_MidiMessageSequence.h
@@ -1,10 +1,8 @@
 #ifndef __PIZ_MIDIMESSAGESEQUENCE_JUCEHEADER__
 #define __PIZ_MIDIMESSAGESEQUENCE_JUCEHEADER__
 
-#include "juce_audio_basics/juce_audio_basics.h"
-#include "juce_core/juce_core.h"
-
-using namespace juce;
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_core/juce_core.h>
 
 //==============================================================================
 /**
@@ -24,13 +22,13 @@ public:
 
     /** Creates a copy of another sequence. */
     PizMidiMessageSequence (const PizMidiMessageSequence& other);
-    PizMidiMessageSequence (const MidiMessageSequence& other);
+    PizMidiMessageSequence (const juce::MidiMessageSequence& other);
 
     /** Replaces this sequence with another one. */
     PizMidiMessageSequence& operator= (const PizMidiMessageSequence& other);
-    PizMidiMessageSequence& operator= (const MidiMessageSequence& other);
+    PizMidiMessageSequence& operator= (const juce::MidiMessageSequence& other);
 
-    MidiMessageSequence getAsJuceSequence();
+    juce::MidiMessageSequence getAsJuceSequence();
 
     /** Destructor. */
     ~PizMidiMessageSequence();
@@ -44,7 +42,7 @@ public:
         @see PizMidiMessageSequence::getEventPointer
     */
 
-    class MidiEventHolder : public ReferenceCountedObject
+    class MidiEventHolder : public juce::ReferenceCountedObject
     {
     public:
         //==============================================================================
@@ -53,7 +51,7 @@ public:
 
         /** The message itself, whose timestamp is used to specify the event's time.
         */
-        MidiMessage message;
+        juce::MidiMessage message;
 
         /** The matching note-off event (if this is a note-on event).
 
@@ -63,16 +61,16 @@ public:
             note-offs up-to-date after events have been moved around in the sequence
             or deleted.
         */
-        ReferenceCountedObjectPtr<MidiEventHolder> noteOffObject;
+        juce::ReferenceCountedObjectPtr<MidiEventHolder> noteOffObject;
 
-        //==============================================================================
-        juce_UseDebuggingNewOperator
+    private:
+        friend class PizMidiMessageSequence;
+        MidiEventHolder (const juce::MidiMessage& message);
 
-            private : friend class PizMidiMessageSequence;
-        MidiEventHolder (const MidiMessage& message);
+        JUCE_LEAK_DETECTOR (MidiEventHolder)
     };
 
-    typedef ReferenceCountedObjectPtr<MidiEventHolder> mehPtr;
+    typedef juce::ReferenceCountedObjectPtr<MidiEventHolder> mehPtr;
     //==============================================================================
     /** Clears the sequence. */
     void clear();
@@ -141,8 +139,8 @@ public:
                                 that will be inserted
         @see updateMatchedPairs
     */
-    void addEvent (const MidiMessage& newMessage, double timeAdjustment = 0);
-    void addNote (const MidiMessage& noteOn, const MidiMessage& noteOff, double timeAdjustment = 0);
+    void addEvent (const juce::MidiMessage& newMessage, double timeAdjustment = 0);
+    void addNote (const juce::MidiMessage& noteOn, const juce::MidiMessage& noteOff, double timeAdjustment = 0);
 
     void moveEvent (int index, double timeAdjustment, bool moveMatchingNoteUp);
     void transposeEvent (int index, int semitones);
@@ -244,7 +242,7 @@ public:
                                 will be the minimum number of controller changes to recreate the
                                 state at the required time.
     */
-    void createControllerUpdatesForTime (int channelNumber, double time, OwnedArray<MidiMessage>& resultMessages);
+    void createControllerUpdatesForTime (int channelNumber, double time, juce::OwnedArray<juce::MidiMessage>& resultMessages);
 
     //==============================================================================
     /** Swaps this sequence with another one. */
@@ -252,18 +250,17 @@ public:
 
     void sort();
 
-    //==============================================================================
-    juce_UseDebuggingNewOperator
-
-        /** @internal */
-        static int
+    /** @internal */
+    static int
         compareElements (const mehPtr first,
                          const mehPtr second) throw();
 
 private:
     //==============================================================================
     friend class MidiFile;
-    ReferenceCountedArray<MidiEventHolder> list;
+    juce::ReferenceCountedArray<MidiEventHolder> list;
+
+    JUCE_LEAK_DETECTOR (PizMidiMessageSequence)
 };
 
 #endif // __JUCE_MIDIMESSAGESEQUENCE_JUCEHEADER__

--- a/pizjuce/midiMonitor/MidiMonitor.cpp
+++ b/pizjuce/midiMonitor/MidiMonitor.cpp
@@ -10,6 +10,8 @@ http://www.anticore.org/jucetice/
 #include "MidiMonitor.h"
 #include "MidiMonitorEditor.h"
 
+using juce::roundToInt;
+
 //==============================================================================
 /**
     This function must be implemented to create the actual plugin object that
@@ -27,8 +29,8 @@ MidiMonitorPlugin::MidiMonitorPlugin()
     iter         = 0;
     lastUIWidth  = 392;
     lastUIHeight = 250;
-    loop         = new MidiMessageSequence();
-    messages     = new MidiMessageSequence();
+    loop         = new juce::MidiMessageSequence();
+    messages     = new juce::MidiMessageSequence();
 
     useNotes = true;
     useCC    = true;
@@ -56,7 +58,7 @@ MidiMonitorPlugin::MidiMonitorPlugin()
     mode     = 0.f;
     maxLines = 5000;
 
-    programName = "midiMonitor " + String (JucePlugin_VersionString);
+    programName = "midiMonitor " + juce::String (JucePlugin_VersionString);
 
     if (! loadDefaultFxb())
         loadDefaultFxp();
@@ -176,105 +178,105 @@ void MidiMonitorPlugin::setParameter (int index, float newValue)
     sendChangeMessage();
 }
 
-const String MidiMonitorPlugin::getParameterName (int index)
+const juce::String MidiMonitorPlugin::getParameterName (int index)
 {
     switch (index)
     {
         case kBgHue:
-            return String ("Hue");
+            return juce::String ("Hue");
             break;
         case kBgSat:
-            return String ("Saturation");
+            return juce::String ("Saturation");
             break;
         case kBgBri:
-            return String ("Brightness");
+            return juce::String ("Brightness");
             break;
         case kContrast:
-            return String ("Contrast");
+            return juce::String ("Contrast");
             break;
         case kPower:
-            return String ("Power");
+            return juce::String ("Power");
             break;
         case kThru:
-            return String ("Thru");
+            return juce::String ("Thru");
             break;
         case kBytes:
-            return String ("ShowBytes");
+            return juce::String ("ShowBytes");
             break;
         case kWrap:
-            return String ("WordWrap");
+            return juce::String ("WordWrap");
             break;
         case kTime:
-            return String ("ShowTime");
+            return juce::String ("ShowTime");
             break;
         case kTicks:
-            return String ("TicksPerBeat");
+            return juce::String ("TicksPerBeat");
             break;
         case kTimeMode:
-            return String ("TimeMode");
+            return juce::String ("TimeMode");
             break;
         case kFrames:
-            return String ("FramesPerSec");
+            return juce::String ("FramesPerSec");
             break;
         default:
-            return String();
+            return juce::String();
             break;
     }
 }
 
-const String MidiMonitorPlugin::getParameterText (int index)
+const juce::String MidiMonitorPlugin::getParameterText (int index)
 {
     switch (index)
     {
         case kBgHue:
-            return String (roundToInt (100.f * bghue));
+            return juce::String (roundToInt (100.f * bghue));
             break;
         case kBgSat:
-            return String (roundToInt (100.f * bgsat));
+            return juce::String (roundToInt (100.f * bgsat));
             break;
         case kBgBri:
-            return String (roundToInt (100.f * bgbri));
+            return juce::String (roundToInt (100.f * bgbri));
             break;
         case kContrast:
-            return String (roundToInt (100.f * contrast));
+            return juce::String (roundToInt (100.f * contrast));
             break;
         case kPower:
-            return String (power);
+            return juce::String (power);
             break;
         case kThru:
-            return String (thru);
+            return juce::String (thru);
             break;
         case kBytes:
-            return String (bytes);
+            return juce::String (bytes);
             break;
         case kWrap:
-            return String (wrap);
+            return juce::String (wrap);
             break;
         case kTime:
-            return String (showtime);
+            return juce::String (showtime);
             break;
         case kTicks:
-            return String (ticks);
+            return juce::String (ticks);
             break;
         case kTimeMode:
-            return String (mode);
+            return juce::String (mode);
             break;
         case kFrames:
-            return String (frames);
+            return juce::String (frames);
             break;
         default:
-            return String();
+            return juce::String();
             break;
     }
 }
-const String MidiMonitorPlugin::getInputChannelName (const int channelIndex) const
+const juce::String MidiMonitorPlugin::getInputChannelName (const int channelIndex) const
 {
-    return String (channelIndex + 1);
+    return juce::String (channelIndex + 1);
 }
 
-const String MidiMonitorPlugin::getOutputChannelName (const int channelIndex) const
+const juce::String MidiMonitorPlugin::getOutputChannelName (const int channelIndex) const
 {
-    return String (channelIndex + 1);
+    return juce::String (channelIndex + 1);
 }
 
 bool MidiMonitorPlugin::isInputChannelStereoPair (int index) const
@@ -298,8 +300,8 @@ void MidiMonitorPlugin::releaseResources()
     midiCollector.reset (44100);
 }
 
-void MidiMonitorPlugin::processBlock (AudioSampleBuffer& buffer,
-                                      MidiBuffer& midiMessages)
+void MidiMonitorPlugin::processBlock (juce::AudioSampleBuffer& buffer,
+                                      juce::MidiBuffer& midiMessages)
 {
     ++iter;
     for (int i = getNumInputChannels(); i < getNumOutputChannels(); ++i)
@@ -308,7 +310,7 @@ void MidiMonitorPlugin::processBlock (AudioSampleBuffer& buffer,
     }
     if (power >= 0.5f)
     {
-        AudioPlayHead::CurrentPositionInfo pos;
+        juce::AudioPlayHead::CurrentPositionInfo pos;
         if (getPlayHead() != 0 && getPlayHead()->getCurrentPosition (pos))
         {
             if (memcmp (&pos, &lastPosInfo, sizeof (pos)) != 0)
@@ -334,7 +336,7 @@ void MidiMonitorPlugin::processBlock (AudioSampleBuffer& buffer,
         n = lastPosInfo.timeSigNumerator;
         d = lastPosInfo.timeSigDenominator;
 
-        double counter = Time::getMillisecondCounterHiRes();
+        double counter = juce::Time::getMillisecondCounterHiRes();
         for (auto&& msgMetadata : midiMessages)
         {
             auto message   = msgMetadata.getMessage();
@@ -389,13 +391,13 @@ void MidiMonitorPlugin::processBlock (AudioSampleBuffer& buffer,
 }
 
 //==============================================================================
-AudioProcessorEditor* MidiMonitorPlugin::createEditor()
+juce::AudioProcessorEditor* MidiMonitorPlugin::createEditor()
 {
     return new MidiMonitorEditor (this);
 }
 
 //==============================================================================
-void MidiMonitorPlugin::getStateInformation (MemoryBlock& destData)
+void MidiMonitorPlugin::getStateInformation (juce::MemoryBlock& destData)
 {
     // you can store your parameters as binary data if you want to or if you've got
     // a load of binary to put in there, but if you're not doing anything too heavy,
@@ -403,7 +405,7 @@ void MidiMonitorPlugin::getStateInformation (MemoryBlock& destData)
     // params as XML..
 
     // create an outer XML element..
-    XmlElement xmlState ("MYPLUGINSETTINGS");
+    juce::XmlElement xmlState ("MYPLUGINSETTINGS");
 
     // add some attributes to it..
     xmlState.setAttribute ("pluginVersion", 1);
@@ -484,17 +486,17 @@ void MidiMonitorPlugin::setStateInformation (const void* data, int sizeInBytes)
     this->dispatchPendingMessages();
 }
 
-bool MidiMonitorPlugin::writeMidiFile (File mid)
+bool MidiMonitorPlugin::writeMidiFile (juce::File mid)
 {
-    MidiFile midifile;
+    juce::MidiFile midifile;
     midifile.setTicksPerQuarterNote (960);
-    MidiMessageSequence metadata;
+    juce::MidiMessageSequence metadata;
 
-    MidiMessage nstart = MidiMessage (0x9f, 62, 1, 0);
+    juce::MidiMessage nstart = juce::MidiMessage (0x9f, 62, 1, 0);
     metadata.addEvent (nstart, 0.0);
 
-    uint8 tn[]            = { 0xFF, 0x03, 11, 'm', 'i', 'd', 'i', 'M', 'o', 'n', 'i', 't', 'o', 'r' };
-    MidiMessage trackname = MidiMessage (tn, 14, 0);
+    juce::uint8 tn[]            = { 0xFF, 0x03, 11, 'm', 'i', 'd', 'i', 'M', 'o', 'n', 'i', 't', 'o', 'r' };
+    juce::MidiMessage trackname = juce::MidiMessage (tn, 14, 0);
     loop->addEvent (trackname);
 
     midifile.addTrack (*loop);
@@ -503,7 +505,7 @@ bool MidiMonitorPlugin::writeMidiFile (File mid)
         mid.deleteFile();
     if (mid.create())
     {
-        FileOutputStream file (mid);
+        juce::FileOutputStream file (mid);
         midifile.writeTo (file);
     }
     return true;

--- a/pizjuce/midiMonitor/MidiMonitor.h
+++ b/pizjuce/midiMonitor/MidiMonitor.h
@@ -1,11 +1,9 @@
 #ifndef MIDIMONITORPLUGINFILTER_H
 #define MIDIMONITORPLUGINFILTER_H
 
-#include "juce_audio_devices/juce_audio_devices.h"
+#include <juce_audio_devices/juce_audio_devices.h>
 
 #include "../_common/PizAudioProcessor.h"
-
-using namespace juce;
 
 enum parameters
 {
@@ -29,7 +27,7 @@ enum parameters
 };
 //==============================================================================
 class MidiMonitorPlugin : public PizAudioProcessor,
-                          public ChangeBroadcaster
+                          public juce::ChangeBroadcaster
 {
 public:
     //==============================================================================
@@ -40,13 +38,13 @@ public:
     void prepareToPlay (double sampleRate, int samplesPerBlock) override;
     void releaseResources() override;
 
-    void processBlock (AudioSampleBuffer& buffer, MidiBuffer& midiMessages) override;
+    void processBlock (juce::AudioSampleBuffer& buffer, juce::MidiBuffer& midiMessages) override;
 
     //==============================================================================
-    AudioProcessorEditor* createEditor() override;
+    juce::AudioProcessorEditor* createEditor() override;
 
     //==============================================================================
-    const String getName() const override { return JucePlugin_Name; }
+    const juce::String getName() const override { return JucePlugin_Name; }
     bool acceptsMidi() const override { return JucePlugin_WantsMidiInput != 0; }
     bool producesMidi() const override { return JucePlugin_ProducesMidiOutput != 0; }
     bool hasEditor() const override { return true; }
@@ -56,10 +54,10 @@ public:
     float getParameter (int index) override;
     void setParameter (int index, float newValue) override;
 
-    const String getParameterName (int index) override;
-    const String getParameterText (int index) override;
-    const String getInputChannelName (int channelIndex) const override;
-    const String getOutputChannelName (int channelIndex) const override;
+    const juce::String getParameterName (int index) override;
+    const juce::String getParameterText (int index) override;
+    const juce::String getInputChannelName (int channelIndex) const override;
+    const juce::String getOutputChannelName (int channelIndex) const override;
     bool isInputChannelStereoPair (int index) const override;
     bool isOutputChannelStereoPair (int index) const override;
 
@@ -67,38 +65,36 @@ public:
     int getNumPrograms() override { return kNumPrograms; }
     int getCurrentProgram() override { return 0; }
     void setCurrentProgram (int index) override {}
-    const String getProgramName (int index) override { return programName; }
-    void changeProgramName (int index, const String& newName) override { programName = newName; }
+    const juce::String getProgramName (int index) override { return programName; }
+    void changeProgramName (int index, const juce::String& newName) override { programName = newName; }
     double getTailLengthSeconds() const override { return 0; }
 
     //==============================================================================
-    void getStateInformation (MemoryBlock& destData) override;
+    void getStateInformation (juce::MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
 
     //==============================================================================
     int lastUIWidth, lastUIHeight;
 
     bool useNotes, useCC, usePB, usePA, useCP, usePC, useSysEx, useOther, useClock;
-    AudioPlayHead::CurrentPositionInfo lastPosInfo;
+    juce::AudioPlayHead::CurrentPositionInfo lastPosInfo;
 
-    MidiMessageCollector* getMessageCollector() { return &midiCollector; }
-    MidiMessageSequence* getMessages() { return messages; }
+    juce::MidiMessageCollector* getMessageCollector() { return &midiCollector; }
+    juce::MidiMessageSequence* getMessages() { return messages; }
 
-    bool writeMidiFile (File mid);
+    bool writeMidiFile (juce::File mid);
     void clearLoop();
     void setMaxLines (int lines)
     {
-        maxLines = jlimit (1, 5000000, lines);
+        maxLines = juce::jlimit (1, 5000000, lines);
         sendChangeMessage();
     }
     int getMaxLines() { return maxLines; }
     int getTimeSigNumerator() { return n; }
     int getTimeSigDenominator() { return d; }
 
-    //==============================================================================
-    juce_UseDebuggingNewOperator
-
-        private : float bghue;
+private:
+    float bghue;
     float bgsat;
     float bgbri;
     float contrast;
@@ -114,14 +110,16 @@ public:
     int maxLines;
     int n, d;
 
-    MidiMessageCollector midiCollector;
-    MidiMessageSequence* loop;
-    MidiMessageSequence* messages;
-    uint64 samples;
-    uint64 iter;
+    juce::MidiMessageCollector midiCollector;
+    juce::MidiMessageSequence* loop;
+    juce::MidiMessageSequence* messages;
+    juce::uint64 samples;
+    juce::uint64 iter;
     bool waitingForFirstMessage;
 
-    String programName;
+    juce::String programName;
+
+    JUCE_LEAK_DETECTOR (MidiMonitorPlugin)
 };
 
 #endif

--- a/pizjuce/midiMonitor/MidiMonitorEditor.cpp
+++ b/pizjuce/midiMonitor/MidiMonitorEditor.cpp
@@ -23,6 +23,7 @@
 #include "MidiMonitorEditor.h"
 
 //[MiscUserDefs] You can add your own user definitions and misc code here...
+using juce::roundToInt;
 //[/MiscUserDefs]
 
 //==============================================================================
@@ -87,7 +88,7 @@ MidiMonitorEditor::MidiMonitorEditor (MidiMonitorPlugin* const ownerFilter)
 
     lightnessSlider->setBounds (288, -16, 40, 12);
 
-    resizer.reset (new ResizableCornerComponent (this, &resizeLimits));
+    resizer.reset (new juce::ResizableCornerComponent (this, &resizeLimits));
     addAndMakeVisible (resizer.get());
 
     saveButton.reset (new juce::TextButton ("save"));
@@ -164,10 +165,10 @@ MidiMonitorEditor::MidiMonitorEditor (MidiMonitorPlugin* const ownerFilter)
     aboutBox->setVisible (false);
     aboutBox->addMouseListener (this, false);
 
-    addAndMakeVisible (maxLinesEditor = new Slider (L"new slider"));
+    addAndMakeVisible (maxLinesEditor = new juce::Slider (L"new slider"));
     maxLinesEditor->setRange (1, 500000, 1);
-    maxLinesEditor->setSliderStyle (Slider::LinearHorizontal);
-    maxLinesEditor->setTextBoxStyle (Slider::TextBoxLeft, false, 80, 20);
+    maxLinesEditor->setSliderStyle (juce::Slider::LinearHorizontal);
+    maxLinesEditor->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 80, 20);
     maxLinesEditor->addListener (this);
     maxLinesEditor->setSkewFactor (0.2);
 
@@ -190,8 +191,8 @@ MidiMonitorEditor::MidiMonitorEditor (MidiMonitorPlugin* const ownerFilter)
     startTimer (1000 / 10); // 10fps
     numLines = 0;
 
-    bgcolor = Colour (getFilter()->getParameter (0), getFilter()->getParameter (1), getFilter()->getParameter (2), 1.0f);
-    fgcolor = Colour (bgcolor.contrasting (getFilter()->getParameter (3)));
+    bgcolor = juce::Colour (getFilter()->getParameter (0), getFilter()->getParameter (1), getFilter()->getParameter (2), 1.0f);
+    fgcolor = juce::Colour (bgcolor.contrasting (getFilter()->getParameter (3)));
 #if 0
     //[/UserPreSize]
 
@@ -239,7 +240,7 @@ MidiMonitorEditor::~MidiMonitorEditor()
 void MidiMonitorEditor::paint (juce::Graphics& g)
 {
     //[UserPrePaint] Add your own custom painting code here..
-    g.fillAll (Colour (bgcolor.contrasting (0.2f * (getFilter()->getParameter (3)))));
+    g.fillAll (juce::Colour (bgcolor.contrasting (0.2f * (getFilter()->getParameter (3)))));
 #if 0
     //[/UserPrePaint]
 
@@ -307,11 +308,11 @@ void MidiMonitorEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     else if (buttonThatWasClicked == saveButton.get())
     {
         //[UserButtonCode_saveButton] -- add your button handler code here..
-        FileChooser myChooser ("Save MIDI file/log...", File ("midiMonitorLog"), "*.txt; *.mid");
+        juce::FileChooser myChooser ("Save MIDI file/log...", juce::File ("midiMonitorLog"), "*.txt; *.mid");
 
         if (myChooser.browseForFileToSave (true))
         {
-            File logFile (myChooser.getResult());
+            juce::File logFile (myChooser.getResult());
             if (logFile.getFileExtension().isEmpty())
             {
                 getFilter()->writeMidiFile (logFile.withFileExtension ("mid"));
@@ -329,7 +330,7 @@ void MidiMonitorEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     else if (buttonThatWasClicked == menuButton.get())
     {
         //[UserButtonCode_menuButton] -- add your button handler code here..
-        PopupMenu m, sub2, sub3;
+        juce::PopupMenu m, sub2, sub3;
         m.addSectionHeader ("Time Mode:");
         m.addItem (101, "Bars|Beats|Ticks", true, timemode == 0);
         float ppqn = getFilter()->getParameter (kTicks);
@@ -370,15 +371,15 @@ void MidiMonitorEditor::buttonClicked (juce::Button* buttonThatWasClicked)
         m.addSeparator();
 
         m.addSectionHeader ("Filter Events:");
-        m.addItem (1, String ("Notes"), true, getFilter()->useNotes);
-        m.addItem (2, String ("CCs"), true, getFilter()->useCC);
-        m.addItem (3, String ("Pitch Wheel"), true, getFilter()->usePB);
-        m.addItem (4, String ("Program Change"), true, getFilter()->usePC);
-        m.addItem (5, String ("Poly Aftertouch"), true, getFilter()->usePA);
-        m.addItem (6, String ("Channel Pressure"), true, getFilter()->useCP);
-        m.addItem (7, String ("Clock"), true, getFilter()->useClock);
-        m.addItem (8, String ("SysEx"), true, getFilter()->useSysEx);
-        m.addItem (9, String ("Other"), true, getFilter()->useOther);
+        m.addItem (1, juce::String ("Notes"), true, getFilter()->useNotes);
+        m.addItem (2, juce::String ("CCs"), true, getFilter()->useCC);
+        m.addItem (3, juce::String ("Pitch Wheel"), true, getFilter()->usePB);
+        m.addItem (4, juce::String ("Program Change"), true, getFilter()->usePC);
+        m.addItem (5, juce::String ("Poly Aftertouch"), true, getFilter()->usePA);
+        m.addItem (6, juce::String ("Channel Pressure"), true, getFilter()->useCP);
+        m.addItem (7, juce::String ("Clock"), true, getFilter()->useClock);
+        m.addItem (8, juce::String ("SysEx"), true, getFilter()->useSysEx);
+        m.addItem (9, juce::String ("Other"), true, getFilter()->useOther);
         m.addSeparator();
         m.addItem (9999, "About...");
 
@@ -528,7 +529,7 @@ void MidiMonitorEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     else if (buttonThatWasClicked == colorButton.get())
     {
         //[UserButtonCode_colorButton] -- add your button handler code here..
-        PopupMenu m;
+        juce::PopupMenu m;
         m.addCustomItem (-1, *hueSlider, 100, 16, false);
         m.addCustomItem (-1, *saturationSlider, 100, 16, false);
         m.addCustomItem (-1, *lightnessSlider, 100, 16, false);
@@ -582,7 +583,7 @@ void MidiMonitorEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
 }
 
 //[MiscUserCode] You can add your own definitions of your custom methods or any other code here...
-void MidiMonitorEditor::mouseDown (const MouseEvent& e)
+void MidiMonitorEditor::mouseDown (const juce::MouseEvent& e)
 {
     if (e.eventComponent == aboutBox.get())
     {
@@ -593,25 +594,25 @@ void MidiMonitorEditor::mouseDown (const MouseEvent& e)
 void MidiMonitorEditor::timerCallback()
 {
     int hours, minutes, seconds, frames;
-    MidiMessage::SmpteTimecodeType timeCode;
+    juce::MidiMessage::SmpteTimecodeType timeCode;
     bool showtime = getFilter()->getParameter (kTime) >= 0.5f;
 
     getFilter()->getCallbackLock().enter();
-    MidiMessageSequence messages (*getFilter()->getMessages());
+    juce::MidiMessageSequence messages (*getFilter()->getMessages());
     getFilter()->getMessages()->clear();
     getFilter()->getCallbackLock().exit();
 
     for (int i = 0; i < messages.getNumEvents(); i++)
     {
-        String midiLine = String();
-        MidiMessage msg = messages.getEventPointer (i)->message;
+        juce::String midiLine = juce::String();
+        juce::MidiMessage msg = messages.getEventPointer (i)->message;
         {
             bool ignore = true;
             if (msg.isNoteOnOrOff() && getFilter()->useNotes)
             {
                 ignore = false;
                 if (msg.getChannel() > 0)
-                    midiLine = "Ch." + String (msg.getChannel()) + "  ";
+                    midiLine = "Ch." + juce::String (msg.getChannel()) + "  ";
                 midiLine += "Note ";
                 if (msg.isNoteOn())
                 {
@@ -621,65 +622,65 @@ void MidiMonitorEditor::timerCallback()
                 {
                     midiLine += "Off: ";
                 }
-                midiLine += MidiMessage::getMidiNoteName (msg.getNoteNumber(), true, true, 3)
-                          + " (" + String (msg.getNoteNumber()) + "), Velocity: "
-                          + String (msg.getVelocity());
+                midiLine += juce::MidiMessage::getMidiNoteName (msg.getNoteNumber(), true, true, 3)
+                          + " (" + juce::String (msg.getNoteNumber()) + "), Velocity: "
+                          + juce::String (msg.getVelocity());
             }
             else if (msg.isController() && getFilter()->useCC)
             {
                 ignore = false;
                 if (msg.getChannel() > 0)
-                    midiLine = "Ch." + String (msg.getChannel()) + "  ";
-                midiLine += "CC #" + String (msg.getControllerNumber());
+                    midiLine = "Ch." + juce::String (msg.getChannel()) + "  ";
+                midiLine += "CC #" + juce::String (msg.getControllerNumber());
                 auto controllerDescription = msg.getControllerName (msg.getControllerNumber());
                 if (controllerDescription != nullptr)
                 {
-                    midiLine += " (" + String (controllerDescription) + "),";
+                    midiLine += " (" + juce::String (controllerDescription) + "),";
                 }
-                midiLine += " Value: " + String (msg.getControllerValue());
+                midiLine += " Value: " + juce::String (msg.getControllerValue());
             }
             else if (msg.isPitchWheel() && getFilter()->usePB)
             {
                 ignore = false;
                 if (msg.getChannel() > 0)
-                    midiLine = "Ch." + String (msg.getChannel()) + "  ";
-                midiLine += "Pitch Wheel: " + String (msg.getPitchWheelValue());
+                    midiLine = "Ch." + juce::String (msg.getChannel()) + "  ";
+                midiLine += "Pitch Wheel: " + juce::String (msg.getPitchWheelValue());
                 if (msg.getPitchWheelValue() == 0x2000)
                     midiLine += " (Center)";
                 else if (msg.getPitchWheelValue() > 0x2000)
-                    midiLine += " (+" + String (msg.getPitchWheelValue() - 0x2000) + ")";
+                    midiLine += " (+" + juce::String (msg.getPitchWheelValue() - 0x2000) + ")";
                 else
-                    midiLine += " (" + String (msg.getPitchWheelValue() - 0x2000) + ")";
+                    midiLine += " (" + juce::String (msg.getPitchWheelValue() - 0x2000) + ")";
             }
             else if (msg.isAftertouch() && getFilter()->usePA)
             {
                 ignore = false;
                 if (msg.getChannel() > 0)
-                    midiLine = "Ch." + String (msg.getChannel()) + "  ";
+                    midiLine = "Ch." + juce::String (msg.getChannel()) + "  ";
                 midiLine += "Poly Aftertouch: "
-                          + MidiMessage::getMidiNoteName (msg.getNoteNumber(), true, true, 3)
-                          + " (" + String (msg.getNoteNumber()) + "), Value: "
-                          + String (msg.getAfterTouchValue());
+                          + juce::MidiMessage::getMidiNoteName (msg.getNoteNumber(), true, true, 3)
+                          + " (" + juce::String (msg.getNoteNumber()) + "), Value: "
+                          + juce::String (msg.getAfterTouchValue());
             }
             else if (msg.isChannelPressure() && getFilter()->useCP)
             {
                 ignore = false;
                 if (msg.getChannel() > 0)
-                    midiLine = "Ch." + String (msg.getChannel()) + "  ";
-                midiLine += "Channel Pressure: " + String (msg.getChannelPressureValue());
+                    midiLine = "Ch." + juce::String (msg.getChannel()) + "  ";
+                midiLine += "Channel Pressure: " + juce::String (msg.getChannelPressureValue());
             }
             else if (msg.isProgramChange() && getFilter()->usePC)
             {
                 ignore = false;
                 if (msg.getChannel() > 0)
-                    midiLine = "Ch." + String (msg.getChannel()) + "  ";
-                midiLine += "Program Change: " + String (msg.getProgramChangeNumber() + 1);
+                    midiLine = "Ch." + juce::String (msg.getChannel()) + "  ";
+                midiLine += "Program Change: " + juce::String (msg.getProgramChangeNumber() + 1);
             }
             else if (msg.isSysEx() && getFilter()->useSysEx)
             {
                 ignore   = false;
                 midiLine = "Sysex: ";
-                midiLine += String (msg.getSysExDataSize());
+                midiLine += juce::String (msg.getSysExDataSize());
                 midiLine += " bytes";
             }
             else if (msg.isTimeSignatureMetaEvent() && getFilter()->useOther)
@@ -689,15 +690,15 @@ void MidiMonitorEditor::timerCallback()
                 msg.getTimeSignatureInfo (newNumerator, newDenominator);
 
                 midiLine = "Time Signature: ";
-                midiLine += String (newNumerator);
+                midiLine += juce::String (newNumerator);
                 midiLine += " / ";
-                midiLine += String (newDenominator);
+                midiLine += juce::String (newDenominator);
             }
             else if (msg.isTempoMetaEvent() && getFilter()->useOther)
             {
                 ignore   = false;
                 midiLine = "Tempo: ";
-                midiLine += String (msg.getTempoSecondsPerQuarterNote());
+                midiLine += juce::String (msg.getTempoSecondsPerQuarterNote());
                 //midiLine += " ";
                 //midiLine += String (msg.getTempoMetaEventTickLength (ticksPerQuarterNote));
             }
@@ -708,28 +709,28 @@ void MidiMonitorEditor::timerCallback()
 
                 switch (msg.getMidiMachineControlCommand())
                 {
-                    case MidiMessage::mmc_stop:
+                    case juce::MidiMessage::mmc_stop:
                         midiLine += "stop";
                         break;
-                    case MidiMessage::mmc_play:
+                    case juce::MidiMessage::mmc_play:
                         midiLine += "play";
                         break;
-                    case MidiMessage::mmc_deferredplay:
+                    case juce::MidiMessage::mmc_deferredplay:
                         midiLine += "deferredplay";
                         break;
-                    case MidiMessage::mmc_fastforward:
+                    case juce::MidiMessage::mmc_fastforward:
                         midiLine += "fastforward";
                         break;
-                    case MidiMessage::mmc_rewind:
+                    case juce::MidiMessage::mmc_rewind:
                         midiLine += "rewind";
                         break;
-                    case MidiMessage::mmc_recordStart:
+                    case juce::MidiMessage::mmc_recordStart:
                         midiLine += "recordStart";
                         break;
-                    case MidiMessage::mmc_recordStop:
+                    case juce::MidiMessage::mmc_recordStop:
                         midiLine += "recordStop";
                         break;
-                    case MidiMessage::mmc_pause:
+                    case juce::MidiMessage::mmc_pause:
                         midiLine += "pause";
                         break;
                 }
@@ -753,15 +754,15 @@ void MidiMonitorEditor::timerCallback()
             {
                 ignore   = false;
                 midiLine = "Song Position: ";
-                midiLine += String (msg.getSongPositionPointerMidiBeat());
+                midiLine += juce::String (msg.getSongPositionPointerMidiBeat());
             }
             else if (msg.isQuarterFrame() && getFilter()->useOther)
             {
                 ignore   = false;
                 midiLine = "MTC Quarter Frame: ";
-                midiLine += String (msg.getQuarterFrameSequenceNumber());
+                midiLine += juce::String (msg.getQuarterFrameSequenceNumber());
                 midiLine += " ";
-                midiLine += String (msg.getQuarterFrameValue());
+                midiLine += juce::String (msg.getQuarterFrameValue());
             }
             else if (msg.isFullFrame() && getFilter()->useOther)
             {
@@ -770,27 +771,27 @@ void MidiMonitorEditor::timerCallback()
 
                 msg.getFullFrameParameters (hours, minutes, seconds, frames, timeCode);
 
-                midiLine += String (hours);
+                midiLine += juce::String (hours);
                 midiLine += ":";
-                midiLine += String (minutes);
+                midiLine += juce::String (minutes);
                 midiLine += ":";
-                midiLine += String (seconds);
+                midiLine += juce::String (seconds);
                 midiLine += ":";
-                midiLine += String (frames);
+                midiLine += juce::String (frames);
 
                 midiLine += " timecode: ";
                 switch (timeCode)
                 {
-                    case MidiMessage::fps24:
+                    case juce::MidiMessage::fps24:
                         midiLine += "fps24";
                         break;
-                    case MidiMessage::fps25:
+                    case juce::MidiMessage::fps25:
                         midiLine += "fps25";
                         break;
-                    case MidiMessage::fps30drop:
+                    case juce::MidiMessage::fps30drop:
                         midiLine += "fps30drop";
                         break;
-                    case MidiMessage::fps30:
+                    case juce::MidiMessage::fps30:
                         midiLine += "fps30";
                         break;
                 }
@@ -799,13 +800,13 @@ void MidiMonitorEditor::timerCallback()
             {
                 ignore   = false;
                 midiLine = "MMC GOTO: ";
-                midiLine += String (hours);
+                midiLine += juce::String (hours);
                 midiLine += ":";
-                midiLine += String (minutes);
+                midiLine += juce::String (minutes);
                 midiLine += ":";
-                midiLine += String (seconds);
+                midiLine += juce::String (seconds);
                 midiLine += ":";
-                midiLine += String (frames);
+                midiLine += juce::String (frames);
             }
             else if (msg.isMidiClock() && getFilter()->useClock)
             {
@@ -830,7 +831,7 @@ void MidiMonitorEditor::timerCallback()
             else if (getFilter()->useOther)
             {
                 ignore = false;
-                midiLine += "??? (" + String (msg.getRawDataSize()) + " bytes)";
+                midiLine += "??? (" + juce::String (msg.getRawDataSize()) + " bytes)";
             }
 
             if (! ignore)
@@ -839,7 +840,7 @@ void MidiMonitorEditor::timerCallback()
                 {
                     //int end = midiOutputEditor->getText().upToFirstOccurrenceOf("\n",true,true).length();
                     //const Range<int> firstLine(0,end);
-                    midiOutputEditor->setHighlightedRegion (Range<int> (0, midiOutputEditor->getText().upToFirstOccurrenceOf ("\n", true, true).length()));
+                    midiOutputEditor->setHighlightedRegion (juce::Range<int> (0, midiOutputEditor->getText().upToFirstOccurrenceOf ("\n", true, true).length()));
                     midiOutputEditor->setReadOnly (false);
                     midiOutputEditor->cut();
                     midiOutputEditor->setReadOnly (true);
@@ -851,19 +852,19 @@ void MidiMonitorEditor::timerCallback()
 
                 if (showbytes)
                 {
-                    Font defaultFont   = midiOutputEditor->getFont();
-                    String bytesString = numLines > 1 ? "\n" : String();
-                    bytesString += String::toHexString (msg.getRawData(), msg.getRawDataSize()).toUpperCase() + "  ";
-                    midiOutputEditor->setFont (Font ("Courier New", midiOutputEditor->getFont().getHeight(), Font::plain));
+                    juce::Font defaultFont   = midiOutputEditor->getFont();
+                    juce::String bytesString = numLines > 1 ? "\n" : juce::String();
+                    bytesString += juce::String::toHexString (msg.getRawData(), msg.getRawDataSize()).toUpperCase() + "  ";
+                    midiOutputEditor->setFont (juce::Font ("Courier New", midiOutputEditor->getFont().getHeight(), juce::Font::plain));
                     midiOutputEditor->insertTextAtCaret (bytesString);
                     midiOutputEditor->setFont (defaultFont);
                 }
                 if (showtime)
                 {
-                    String timeString = (numLines > 1 && ! showbytes) ? "\n" : String();
+                    juce::String timeString = (numLines > 1 && ! showbytes) ? "\n" : juce::String();
                     timeString += ppqToString (msg.getTimeStamp(), getFilter()->getTimeSigNumerator(), getFilter()->getTimeSigDenominator(), getFilter()->lastPosInfo.bpm) + "  ";
-                    Font defaultFont = midiOutputEditor->getFont();
-                    midiOutputEditor->setFont (Font ("Courier New", midiOutputEditor->getFont().getHeight(), Font::bold));
+                    juce::Font defaultFont = midiOutputEditor->getFont();
+                    midiOutputEditor->setFont (juce::Font ("Courier New", midiOutputEditor->getFont().getHeight(), juce::Font::bold));
                     midiOutputEditor->insertTextAtCaret (timeString);
                     midiOutputEditor->setFont (defaultFont);
                 }
@@ -876,7 +877,7 @@ void MidiMonitorEditor::timerCallback()
 }
 
 //==============================================================================
-void MidiMonitorEditor::changeListenerCallback (ChangeBroadcaster* source)
+void MidiMonitorEditor::changeListenerCallback (juce::ChangeBroadcaster* source)
 {
     updateParametersFromFilter();
 }
@@ -912,57 +913,57 @@ void MidiMonitorEditor::updateParametersFromFilter()
         timemode = 2;
 
     //set sliders
-    hueSlider->setValue (hue, sendNotification);
-    saturationSlider->setValue (sat, sendNotification);
-    lightnessSlider->setValue (bri, sendNotification);
+    hueSlider->setValue (hue, juce::sendNotification);
+    saturationSlider->setValue (sat, juce::sendNotification);
+    lightnessSlider->setValue (bri, juce::sendNotification);
     //slider4->setValue(contrast,sendNotification);
-    maxLinesEditor->setValue (maxLines, dontSendNotification);
+    maxLinesEditor->setValue (maxLines, juce::dontSendNotification);
 
     //set button states
     if (power >= 0.5f)
     {
         powerButton->setButtonText ("on");
-        powerButton->setToggleState (true, dontSendNotification);
+        powerButton->setToggleState (true, juce::dontSendNotification);
     }
     else
     {
         powerButton->setButtonText ("off");
-        powerButton->setToggleState (false, dontSendNotification);
+        powerButton->setToggleState (false, juce::dontSendNotification);
     }
-    thruButton->setToggleState (thru >= 0.5f, dontSendNotification);
-    wrapButton->setToggleState (wrap >= 0.5f, dontSendNotification);
-    bytesButton->setToggleState (showbytes, dontSendNotification);
-    timeButton->setToggleState (showtime, dontSendNotification);
+    thruButton->setToggleState (thru >= 0.5f, juce::dontSendNotification);
+    wrapButton->setToggleState (wrap >= 0.5f, juce::dontSendNotification);
+    bytesButton->setToggleState (showbytes, juce::dontSendNotification);
+    timeButton->setToggleState (showtime, juce::dontSendNotification);
 
     setSize (filter->lastUIWidth, filter->lastUIHeight);
 
     //set colors
-    bgcolor = Colour (hue, sat, bri, 1.0f);
-    fgcolor = Colour (bgcolor.contrasting (contrast));
+    bgcolor = juce::Colour (hue, sat, bri, 1.0f);
+    fgcolor = juce::Colour (bgcolor.contrasting (contrast));
 
-    clearButton->setColour (TextButton::textColourOnId, fgcolor);
-    clearButton->setColour (TextButton::textColourOffId, fgcolor);
-    clearButton->setColour (TextButton::buttonColourId, bgcolor);
-    saveButton->setColour (TextButton::textColourOnId, fgcolor);
-    saveButton->setColour (TextButton::textColourOffId, fgcolor);
-    saveButton->setColour (TextButton::buttonColourId, bgcolor);
-    menuButton->setColour (TextButton::textColourOnId, fgcolor);
-    menuButton->setColour (TextButton::textColourOffId, fgcolor);
-    menuButton->setColour (TextButton::buttonColourId, bgcolor);
-    colorButton->setColour (TextButton::textColourOnId, fgcolor);
-    colorButton->setColour (TextButton::textColourOffId, fgcolor);
-    colorButton->setColour (TextButton::buttonColourId, bgcolor);
+    clearButton->setColour (juce::TextButton::textColourOnId, fgcolor);
+    clearButton->setColour (juce::TextButton::textColourOffId, fgcolor);
+    clearButton->setColour (juce::TextButton::buttonColourId, bgcolor);
+    saveButton->setColour (juce::TextButton::textColourOnId, fgcolor);
+    saveButton->setColour (juce::TextButton::textColourOffId, fgcolor);
+    saveButton->setColour (juce::TextButton::buttonColourId, bgcolor);
+    menuButton->setColour (juce::TextButton::textColourOnId, fgcolor);
+    menuButton->setColour (juce::TextButton::textColourOffId, fgcolor);
+    menuButton->setColour (juce::TextButton::buttonColourId, bgcolor);
+    colorButton->setColour (juce::TextButton::textColourOnId, fgcolor);
+    colorButton->setColour (juce::TextButton::textColourOffId, fgcolor);
+    colorButton->setColour (juce::TextButton::buttonColourId, bgcolor);
 
-    midiOutputEditor->setColour (TextEditor::backgroundColourId, bgcolor);
-    midiOutputEditor->setColour (TextEditor::textColourId, fgcolor);
+    midiOutputEditor->setColour (juce::TextEditor::backgroundColourId, bgcolor);
+    midiOutputEditor->setColour (juce::TextEditor::textColourId, fgcolor);
     midiOutputEditor->setMultiLine (true, wrap >= 0.5f);
     repaint();
 }
 
-const String MidiMonitorEditor::ppqToString (const double sppq,
-                                             const int numerator,
-                                             const int denominator,
-                                             const double bpm)
+const juce::String MidiMonitorEditor::ppqToString (const double sppq,
+                                                   const int numerator,
+                                                   const int denominator,
+                                                   const double bpm)
 {
     const wchar_t* const sign = (sppq < 0) ? L"-" : L"";
     const long double absSecs = fabs (sppq * 60.0 / bpm);
@@ -970,13 +971,13 @@ const String MidiMonitorEditor::ppqToString (const double sppq,
     if (timemode == 2)
     {
         //buffer #/sample delta
-        return "b." + String ((int) sppq) + " s." + String (roundToInt (fmod (sppq, 1.0) * 1000000)).paddedLeft ('0', 4);
+        return "b." + juce::String ((int) sppq) + " s." + juce::String (roundToInt (fmod (sppq, 1.0) * 1000000)).paddedLeft ('0', 4);
     }
     else if (timemode == 3)
     {
         //total samples
-        const uint64 samples = roundToInt (getFilter()->getSampleRate() * absSecs);
-        return sign + String (samples);
+        const juce::uint64 samples = roundToInt (getFilter()->getSampleRate() * absSecs);
+        return sign + juce::String (samples);
     }
     else if (timemode == 0)
     {
@@ -1036,7 +1037,7 @@ const String MidiMonitorEditor::ppqToString (const double sppq,
             ticks = (int) tpb - ticks - 1;
         }
 
-        String padding = String();
+        juce::String padding = juce::String();
         if (ticks < 10 && tpb > 100.0)
             padding = L"00";
         else if (ticks < 100 && tpb > 100.0)
@@ -1044,11 +1045,11 @@ const String MidiMonitorEditor::ppqToString (const double sppq,
         else if (ticks < 10 && tpb >= 10.0)
             padding = L"0";
 
-        String s;
+        juce::String s;
         if (tpb > 0.0)
-            return (bar == 0 ? L"" : sign) + String (bar) + "|" + String (beat) + "|" + padding + String (ticks);
+            return (bar == 0 ? L"" : sign) + juce::String (bar) + "|" + juce::String (beat) + "|" + padding + juce::String (ticks);
         else
-            return (bar == 0 ? L"" : sign) + String (bar) + "|" + String (beat);
+            return (bar == 0 ? L"" : sign) + juce::String (bar) + "|" + juce::String (beat);
     }
     else
     {
@@ -1100,68 +1101,68 @@ const String MidiMonitorEditor::ppqToString (const double sppq,
             mins = (int) (absSecs / 60.0);
         const int secs = ((int) absSecs) % 60;
 
-        String s1;
+        juce::String s1;
         if (showhrs)
         {
             if (showms)
             {
                 if (fps == 1000.0)
-                    s1 = String::formatted (L"%s%02d:%02d:%02d.%03d",
-                                            sign,
-                                            hours,
-                                            mins,
-                                            secs,
-                                            int64 (absSecs * 1000) % 1000);
+                    s1 = juce::String::formatted (L"%s%02d:%02d:%02d.%03d",
+                                                  sign,
+                                                  hours,
+                                                  mins,
+                                                  secs,
+                                                  juce::int64 (absSecs * 1000) % 1000);
                 else if (fps <= 10.0)
-                    s1 = String::formatted (L"%s%02d:%02d:%02d:%.1d",
-                                            sign,
-                                            hours,
-                                            mins,
-                                            secs,
-                                            int64 (absSecs * fps) % (int) fps);
+                    s1 = juce::String::formatted (L"%s%02d:%02d:%02d:%.1d",
+                                                  sign,
+                                                  hours,
+                                                  mins,
+                                                  secs,
+                                                  juce::int64 (absSecs * fps) % (int) fps);
                 else if (fps <= 100.0)
                 {
                     if (dropframe)
                     {
-                        int64 frameNumber = int64 (absSecs * 29.97);
+                        juce::int64 frameNumber = juce::int64 (absSecs * 29.97);
                         frameNumber += 18 * (frameNumber / 17982) + 2 * (((frameNumber % 17982) - 2) / 1798);
                         int frames   = int (frameNumber % 30);
                         int dseconds = int ((frameNumber / 30) % 60);
                         int dminutes = int (((frameNumber / 30) / 60) % 60);
                         int dhours   = int ((((frameNumber / 30) / 60) / 60) % 24);
 
-                        s1 = String::formatted (L"%s%02d;%02d;%02d;%.2d",
-                                                sign,
-                                                dhours,
-                                                dminutes,
-                                                dseconds,
-                                                frames);
+                        s1 = juce::String::formatted (L"%s%02d;%02d;%02d;%.2d",
+                                                      sign,
+                                                      dhours,
+                                                      dminutes,
+                                                      dseconds,
+                                                      frames);
                     }
                     else
-                        s1 = String::formatted (L"%s%02d:%02d:%02d:%.2d",
-                                                sign,
-                                                hours,
-                                                mins,
-                                                secs,
-                                                int64 (absSecs * fps) % (int) fps);
+                        s1 = juce::String::formatted (L"%s%02d:%02d:%02d:%.2d",
+                                                      sign,
+                                                      hours,
+                                                      mins,
+                                                      secs,
+                                                      juce::int64 (absSecs * fps) % (int) fps);
                 }
                 else
-                    s1 = String::formatted (L"%s%02d:%02d:%02d:%03d",
-                                            sign,
-                                            hours,
-                                            mins,
-                                            secs,
-                                            int64 (absSecs * fps) % (int) fps);
+                    s1 = juce::String::formatted (L"%s%02d:%02d:%02d:%03d",
+                                                  sign,
+                                                  hours,
+                                                  mins,
+                                                  secs,
+                                                  juce::int64 (absSecs * fps) % (int) fps);
                 if (showsubfr)
-                    s1 += String (L"::") + String::formatted (L"%02d", (int64 (absSecs * fps * 100.0) % 100));
+                    s1 += juce::String (L"::") + juce::String::formatted (L"%02d", (juce::int64 (absSecs * fps * 100.0) % 100));
             }
             else
             {
-                s1 = String::formatted (L"%s%02d:%02d:%02d",
-                                        sign,
-                                        hours,
-                                        mins,
-                                        secs);
+                s1 = juce::String::formatted (L"%s%02d:%02d:%02d",
+                                              sign,
+                                              hours,
+                                              mins,
+                                              secs);
             }
         }
         else
@@ -1169,55 +1170,55 @@ const String MidiMonitorEditor::ppqToString (const double sppq,
             if (showms)
             {
                 if (fps == 1000.0)
-                    s1 = String::formatted (L"%s%d:%02d.%03d",
-                                            sign,
-                                            mins,
-                                            secs,
-                                            int64 (absSecs * 1000) % 1000);
+                    s1 = juce::String::formatted (L"%s%d:%02d.%03d",
+                                                  sign,
+                                                  mins,
+                                                  secs,
+                                                  juce::int64 (absSecs * 1000) % 1000);
                 else if (fps <= 10.0)
-                    s1 = String::formatted (L"%s%d:%02d:%.1d",
-                                            sign,
-                                            mins,
-                                            secs,
-                                            int64 (absSecs * fps) % (int) fps);
+                    s1 = juce::String::formatted (L"%s%d:%02d:%.1d",
+                                                  sign,
+                                                  mins,
+                                                  secs,
+                                                  juce::int64 (absSecs * fps) % (int) fps);
                 else if (fps <= 100.0)
                 {
                     if (dropframe)
                     {
-                        int64 frameNumber = int64 (absSecs * 29.97);
+                        juce::int64 frameNumber = juce::int64 (absSecs * 29.97);
                         frameNumber += 18 * (frameNumber / 17982) + 2 * (((frameNumber % 17982) - 2) / 1798);
                         int frames   = int (frameNumber % 30);
                         int dseconds = int ((frameNumber / 30) % 60);
                         int dminutes = int (((frameNumber / 30) / 60) % 60);
 
-                        s1 = String::formatted (L"%s%d:%02d;%.2d",
-                                                sign,
-                                                dminutes,
-                                                dseconds,
-                                                frames);
+                        s1 = juce::String::formatted (L"%s%d:%02d;%.2d",
+                                                      sign,
+                                                      dminutes,
+                                                      dseconds,
+                                                      frames);
                     }
                     else
-                        s1 = String::formatted (L"%s%d:%02d:%.2d",
-                                                sign,
-                                                mins,
-                                                secs,
-                                                int64 (absSecs * fps) % (int) fps);
+                        s1 = juce::String::formatted (L"%s%d:%02d:%.2d",
+                                                      sign,
+                                                      mins,
+                                                      secs,
+                                                      juce::int64 (absSecs * fps) % (int) fps);
                 }
                 else
-                    s1 = String::formatted (L"%s%d:%02d:%03d",
-                                            sign,
-                                            mins,
-                                            secs,
-                                            int64 (absSecs * fps) % (int) fps);
+                    s1 = juce::String::formatted (L"%s%d:%02d:%03d",
+                                                  sign,
+                                                  mins,
+                                                  secs,
+                                                  juce::int64 (absSecs * fps) % (int) fps);
                 if (showsubfr)
-                    s1 += String (L"::") + String::formatted (L"%02d", (int64 (absSecs * fps * 100.0) % 100));
+                    s1 += juce::String (L"::") + juce::String::formatted (L"%02d", (juce::int64 (absSecs * fps * 100.0) % 100));
             }
             else
             {
-                s1 = String::formatted (L"%s%d:%02d",
-                                        sign,
-                                        mins,
-                                        secs);
+                s1 = juce::String::formatted (L"%s%d:%02d",
+                                              sign,
+                                              mins,
+                                              secs);
             }
         }
         return s1;

--- a/pizjuce/midiMonitor/MidiMonitorEditor.h
+++ b/pizjuce/midiMonitor/MidiMonitorEditor.h
@@ -20,9 +20,9 @@
 #pragma once
 
 //[Headers]     -- You can add your own extra header files here --
-#include "juce_audio_processors/juce_audio_processors.h"
-#include "juce_events/juce_events.h"
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_events/juce_events.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
 #include "MidiMonitor.h"
 //[/Headers]
@@ -48,8 +48,8 @@ public:
 
     //==============================================================================
     //[UserMethods]     -- You can add your own custom methods in this section.
-    void changeListenerCallback (ChangeBroadcaster* source) override;
-    void mouseDown (const MouseEvent& e) override;
+    void changeListenerCallback (juce::ChangeBroadcaster* source) override;
+    void mouseDown (const juce::MouseEvent& e) override;
     void timerCallback() override;
     //[/UserMethods]
 
@@ -60,10 +60,10 @@ public:
 
 private:
     //[UserVariables]   -- You can add your own custom variables in this section.
-    Slider* maxLinesEditor;
-    ComponentBoundsConstrainer resizeLimits;
-    TooltipWindow tooltipWindow;
-    Colour bgcolor, fgcolor;
+    juce::Slider* maxLinesEditor;
+    juce::ComponentBoundsConstrainer resizeLimits;
+    juce::TooltipWindow tooltipWindow;
+    juce::Colour bgcolor, fgcolor;
     bool showbytes;
     bool showtime;
     int timemode;
@@ -76,7 +76,7 @@ private:
         return (MidiMonitorPlugin*) getAudioProcessor();
     }
 
-    const String ppqToString (const double sppq, const int numerator, const int denominator, const double bpm);
+    const juce::String ppqToString (const double sppq, const int numerator, const int denominator, const double bpm);
     //[/UserVariables]
 
     //==============================================================================
@@ -87,7 +87,7 @@ private:
     std::unique_ptr<juce::Slider> hueSlider;
     std::unique_ptr<juce::Slider> saturationSlider;
     std::unique_ptr<juce::Slider> lightnessSlider;
-    std::unique_ptr<ResizableCornerComponent> resizer;
+    std::unique_ptr<juce::ResizableCornerComponent> resizer;
     std::unique_ptr<juce::TextButton> saveButton;
     std::unique_ptr<juce::TextButton> menuButton;
     std::unique_ptr<juce::TextEditor> midiOutputEditor;

--- a/pizjuce/midiOut/MidiPad.cpp
+++ b/pizjuce/midiOut/MidiPad.cpp
@@ -1,13 +1,13 @@
 #include "MidiPad.h"
 
 MidiPad::MidiPad()
-    : drawableButton (0)
+    : drawableButton (nullptr)
 {
     addAndMakeVisible (drawableButton = new DrawablePad ("MidiPad"));
     drawableButton->addListener (this);
-    addAndMakeVisible (label = new Label ("Label", String()));
-    label->setFont (Font (9.0000f, Font::plain));
-    label->setJustificationType (Justification::centred);
+    addAndMakeVisible (label = new juce::Label ("Label", juce::String()));
+    label->setFont (juce::Font (9.0000f, juce::Font::plain));
+    label->setJustificationType (juce::Justification::centred);
     label->setInterceptsMouseClicks (false, false);
     setMouseClickGrabsKeyboardFocus (false);
 }
@@ -18,12 +18,12 @@ MidiPad::~MidiPad()
     deleteAndZero (label);
 }
 
-void MidiPad::setTooltip (String text)
+void MidiPad::setTooltip (juce::String text)
 {
     drawableButton->setTooltip (text);
 }
 
-void MidiPad::paint (Graphics& g)
+void MidiPad::paint (juce::Graphics& g)
 {
 }
 
@@ -38,13 +38,13 @@ void MidiPad::resized()
     label->setBounds (0, 0, proportionOfWidth (1.0000f), proportionOfHeight (1.0000f));
 }
 
-void MidiPad::buttonClicked (Button* buttonThatWasClicked)
+void MidiPad::buttonClicked (juce::Button* buttonThatWasClicked)
 {
 }
 
-bool MidiPad::isInterestedInFileDrag (const StringArray& files)
+bool MidiPad::isInterestedInFileDrag (const juce::StringArray& files)
 {
-    File file = File (files.joinIntoString (String(), 0, 1));
+    juce::File file = juce::File (files.joinIntoString (juce::String(), 0, 1));
     if (file.hasFileExtension ("png") || file.hasFileExtension ("gif") || file.hasFileExtension ("jpg") || file.hasFileExtension ("svg"))
         return true;
     else
@@ -55,20 +55,20 @@ void MidiPad::filesDropped (const juce::StringArray& filenames, int mouseX, int 
 {
     if (isInterestedInFileDrag (filenames))
     {
-        String filename = filenames.joinIntoString (String(), 0, 1);
-        File file       = File (filename);
-        auto image      = Drawable::createFromImageFile (file);
+        juce::String filename = filenames.joinIntoString (juce::String(), 0, 1);
+        juce::File file       = juce::File (filename);
+        auto image            = juce::Drawable::createFromImageFile (file);
         drawableButton->setImages (image.get());
         //save the relative path
-        drawableButton->setName (file.getRelativePathFrom (File::getSpecialLocation (File::currentExecutableFile)));
-        drawableButton->setState (Button::buttonNormal);
-        label->setText (String(), dontSendNotification);
+        drawableButton->setName (file.getRelativePathFrom (juce::File::getSpecialLocation (juce::File::currentExecutableFile)));
+        drawableButton->setState (juce::Button::buttonNormal);
+        label->setText (juce::String(), juce::dontSendNotification);
     }
 }
 
-void MidiPad::setButtonText (const String& newText)
+void MidiPad::setButtonText (const juce::String& newText)
 {
-    label->setText (newText, dontSendNotification);
+    label->setText (newText, juce::dontSendNotification);
 }
 
 void MidiPad::setTriggeredOnMouseDown (const bool isTriggeredOnMouseDown)
@@ -76,14 +76,14 @@ void MidiPad::setTriggeredOnMouseDown (const bool isTriggeredOnMouseDown)
     drawableButton->setTriggeredOnMouseDown (isTriggeredOnMouseDown);
 }
 
-void MidiPad::addButtonListener (Button::Listener* const newListener)
+void MidiPad::addButtonListener (juce::Button::Listener* const newListener)
 {
     drawableButton->addListener (newListener);
 }
 
 void MidiPad::clearIcon()
 {
-    drawableButton->setImages (0);
+    drawableButton->setImages (nullptr);
     drawableButton->setName ("");
-    label->setText ("Drag\nIcon", dontSendNotification);
+    label->setText ("Drag\nIcon", juce::dontSendNotification);
 }

--- a/pizjuce/midiOut/MidiPad.h
+++ b/pizjuce/midiOut/MidiPad.h
@@ -1,40 +1,40 @@
 #ifndef imagePluginFilter_PAD_H
 #define imagePluginFilter_PAD_H
 
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_gui_basics/juce_gui_basics.h>
 
 #include "../_common/DrawablePad.h"
 
-class MidiPad : public Component,
-                public Button::Listener,
-                public FileDragAndDropTarget
+class MidiPad : public juce::Component,
+                public juce::Button::Listener,
+                public juce::FileDragAndDropTarget
 {
 public:
     //==============================================================================
     MidiPad();
     ~MidiPad() override;
 
-    void paint (Graphics&) override;
+    void paint (juce::Graphics&) override;
     void resized() override;
-    void buttonClicked (Button*) override;
-    void filesDropped (const StringArray& files, int x, int y) override;
-    bool isInterestedInFileDrag (const StringArray& files) override;
-    void setButtonText (const String&);
-    void setTooltip (String text);
-    void setColour (const Colour&);
+    void buttonClicked (juce::Button*) override;
+    void filesDropped (const juce::StringArray& files, int x, int y) override;
+    bool isInterestedInFileDrag (const juce::StringArray& files) override;
+    void setButtonText (const juce::String&);
+    void setTooltip (juce::String text);
+    void setColour (const juce::Colour&);
     void setTriggeredOnMouseDown (const bool);
-    void addButtonListener (Button::Listener* const);
-    void addListener (Button::Listener* const);
+    void addButtonListener (juce::Button::Listener* const);
+    void addListener (juce::Button::Listener* const);
     void clearIcon();
 
     DrawablePad* drawableButton;
 
-    //==============================================================================
-    juce_UseDebuggingNewOperator
-
-        private : Label* label;
+private:
+    juce::Label* label;
     MidiPad (const MidiPad&);
     const MidiPad& operator= (const MidiPad&);
+
+    JUCE_LEAK_DETECTOR (MidiPad)
 };
 
 #endif

--- a/pizjuce/midiOut/midiOut.cpp
+++ b/pizjuce/midiOut/midiOut.cpp
@@ -1,6 +1,8 @@
 #include "midiOut.h"
 #include "midiOutEditor.h"
 
+using juce::roundToInt;
+
 //==============================================================================
 juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()
 {
@@ -10,15 +12,15 @@ juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()
 JuceProgram::JuceProgram()
 {
     //default values
-    zeromem (param, sizeof (param));
+    juce::zeromem (param, sizeof (param));
     param[kPower]   = 0.0f;
     param[kClock]   = 1.0f;
     param[kHostOut] = 1.0f;
     param[kStamped] = 1.0f;
     param[kChannel] = 0.0f;
 
-    icon   = String (""); // icon filename
-    device = MidiDeviceInfo();
+    icon   = juce::String (""); // icon filename
+    device = juce::MidiDeviceInfo();
 
     //program name
     name = L"Default";
@@ -29,8 +31,8 @@ MidiOutFilter::MidiOutFilter()
 {
     programs = new JuceProgram[getNumPrograms()];
 
-    devices    = MidiOutput::getAvailableDevices();
-    midiOutput = 0;
+    devices    = juce::MidiOutput::getAvailableDevices();
+    midiOutput = nullptr;
     loadDefaultFxb();
     curProgram = 0;
     init       = true;
@@ -93,12 +95,12 @@ void MidiOutFilter::setParameter (int index, float newValue)
     }
 }
 
-void MidiOutFilter::setActiveDevice (String name)
+void MidiOutFilter::setActiveDevice (juce::String name)
 {
     setActiveDevice (getDeviceByName (name));
 }
 
-void MidiOutFilter::setActiveDevice (MidiDeviceInfo device)
+void MidiOutFilter::setActiveDevice (juce::MidiDeviceInfo device)
 {
     activeDevice = programs[curProgram].device = device;
 
@@ -108,7 +110,7 @@ void MidiOutFilter::setActiveDevice (MidiDeviceInfo device)
         midiOutput.reset();
     }
 
-    midiOutput = MidiOutput::openDevice (device.identifier);
+    midiOutput = juce::MidiOutput::openDevice (device.identifier);
     if (midiOutput != nullptr)
     {
         midiOutput->startBackgroundThread();
@@ -119,13 +121,13 @@ void MidiOutFilter::setActiveDevice (MidiDeviceInfo device)
     }
 }
 
-MidiDeviceInfo MidiOutFilter::getDeviceByName (String name) const
+juce::MidiDeviceInfo MidiOutFilter::getDeviceByName (juce::String name) const
 {
     return devices.findIf ([&] (auto const& device)
                            { return name == device.name; });
 }
 
-const String MidiOutFilter::getParameterName (int index)
+const juce::String MidiOutFilter::getParameterName (int index)
 {
     if (index == kPower)
         return L"Power";
@@ -137,64 +139,64 @@ const String MidiOutFilter::getParameterName (int index)
         return L"HostOut";
     if (index == kStamped)
         return L"Out Mode";
-    return String();
+    return juce::String();
 }
 
-const String MidiOutFilter::getParameterText (int index)
+const juce::String MidiOutFilter::getParameterText (int index)
 {
     if (index == kPower)
     {
         if (param[kPower] > 0.f)
-            return String (L"On");
+            return juce::String (L"On");
         else
-            return String (L"Off");
+            return juce::String (L"Off");
     }
     if (index == kClock)
     {
         if (param[kClock] >= 0.5)
-            return String (L"On");
+            return juce::String (L"On");
         else
-            return String (L"Off");
+            return juce::String (L"Off");
     }
     if (index == kMTC)
     {
         if (param[kMTC] >= 0.5)
-            return String (L"On");
+            return juce::String (L"On");
         else
-            return String (L"Off");
+            return juce::String (L"Off");
     }
     if (index == kHostOut)
     {
         if (param[kHostOut] >= 0.5)
-            return String (L"On");
+            return juce::String (L"On");
         else
-            return String (L"Off");
+            return juce::String (L"Off");
     }
     if (index == kStamped)
     {
         if (param[kStamped] >= 0.5)
-            return String (L"Immediate");
+            return juce::String (L"Immediate");
         else
-            return String (L"Stamped");
+            return juce::String (L"Stamped");
     }
     if (index == kChannel)
     {
         if (roundToInt (param[kChannel] * 16.f) == 0)
-            return String (L"All");
+            return juce::String (L"All");
         else
-            return String (roundToInt (param[kChannel] * 16.f));
+            return juce::String (roundToInt (param[kChannel] * 16.f));
     }
-    return String();
+    return juce::String();
 }
 
-const String MidiOutFilter::getInputChannelName (const int channelIndex) const
+const juce::String MidiOutFilter::getInputChannelName (const int channelIndex) const
 {
-    return String (channelIndex + 1);
+    return juce::String (channelIndex + 1);
 }
 
-const String MidiOutFilter::getOutputChannelName (const int channelIndex) const
+const juce::String MidiOutFilter::getOutputChannelName (const int channelIndex) const
 {
-    return String (channelIndex + 1);
+    return juce::String (channelIndex + 1);
 }
 
 bool MidiOutFilter::isInputChannelStereoPair (int index) const
@@ -230,12 +232,12 @@ void MidiOutFilter::setCurrentProgram (int index)
     icon = ap->icon;
 }
 
-void MidiOutFilter::changeProgramName (int index, const String& newName)
+void MidiOutFilter::changeProgramName (int index, const juce::String& newName)
 {
     programs[curProgram].name = newName;
 }
 
-const String MidiOutFilter::getProgramName (int index)
+const juce::String MidiOutFilter::getProgramName (int index)
 {
     return programs[index].name;
 }
@@ -245,7 +247,7 @@ int MidiOutFilter::getCurrentProgram()
     return curProgram;
 }
 //==============================================================================
-AudioProcessorEditor* MidiOutFilter::createEditor()
+juce::AudioProcessorEditor* MidiOutFilter::createEditor()
 {
     return new MidiOutEditor (this);
 }
@@ -261,8 +263,8 @@ void MidiOutFilter::releaseResources()
     // spare memory, etc.
 }
 
-void MidiOutFilter::processBlock (AudioSampleBuffer& buffer,
-                                  MidiBuffer& midiMessages)
+void MidiOutFilter::processBlock (juce::AudioSampleBuffer& buffer,
+                                  juce::MidiBuffer& midiMessages)
 {
     for (int i = 0; i < getNumOutputChannels(); ++i)
     {
@@ -271,8 +273,8 @@ void MidiOutFilter::processBlock (AudioSampleBuffer& buffer,
 
     const double SR  = getSampleRate();
     const double iSR = 1.0 / SR;
-    AudioPlayHead::CurrentPositionInfo pos;
-    if (getPlayHead() != 0 && getPlayHead()->getCurrentPosition (pos))
+    juce::AudioPlayHead::CurrentPositionInfo pos;
+    if (getPlayHead() != nullptr && getPlayHead()->getCurrentPosition (pos))
     {
         if (memcmp (&pos, &lastPosInfo, sizeof (pos)) != 0)
         {
@@ -290,7 +292,7 @@ void MidiOutFilter::processBlock (AudioSampleBuffer& buffer,
                 int hours, mins, secs, frames;
                 if (frameRate == 29.97)
                 {
-                    int64 frameNumber = int64 (absSecs * 29.97);
+                    juce::int64 frameNumber = juce::int64 (absSecs * 29.97);
                     frameNumber += 18 * (frameNumber / 17982) + 2 * (((frameNumber % 17982) - 2) / 1798);
 
                     hours  = int ((((frameNumber / 30) / 60) / 60) % 24);
@@ -303,7 +305,7 @@ void MidiOutFilter::processBlock (AudioSampleBuffer& buffer,
                     hours  = (int) (absSecs / (60.0 * 60.0));
                     mins   = ((int) (absSecs / 60.0)) % 60;
                     secs   = ((int) absSecs) % 60;
-                    frames = (int) (int64 (absSecs * frameRate) % (int) frameRate);
+                    frames = (int) (juce::int64 (absSecs * frameRate) % (int) frameRate);
                 }
                 if (pos.isPlaying)
                 {
@@ -315,7 +317,7 @@ void MidiOutFilter::processBlock (AudioSampleBuffer& buffer,
                     {
                         //this is so the song position pointer will be sent before any
                         //other data at the beginning of the song
-                        MidiBuffer temp = midiMessages;
+                        juce::MidiBuffer temp = midiMessages;
                         midiMessages.clear();
 
                         if (samplesToNextMTC < buffer.getNumSamples())
@@ -348,7 +350,7 @@ void MidiOutFilter::processBlock (AudioSampleBuffer& buffer,
                                     mtcData = (hours & 0x10) >> 4 | mtcFrameRate;
                                     break;
                             }
-                            MidiMessage midiclock (0xf1, (mtcNumber << 4) | (mtcData));
+                            juce::MidiMessage midiclock (0xf1, (mtcNumber << 4) | (mtcData));
                             ++mtcNumber;
                             mtcNumber &= 0x07;
                             midiMessages.addEvent (midiclock, samplesToNextMTC);
@@ -391,7 +393,7 @@ void MidiOutFilter::processBlock (AudioSampleBuffer& buffer,
                                 mtcData = (hours & 0x10) >> 4 | mtcFrameRate;
                                 break;
                         }
-                        MidiMessage midiclock (0xf1, (mtcNumber << 4) | (mtcData));
+                        juce::MidiMessage midiclock (0xf1, (mtcNumber << 4) | (mtcData));
                         ++mtcNumber;
                         mtcNumber &= 0x07;
                         midiMessages.addEvent (midiclock, samplesToNextMTC);
@@ -432,7 +434,7 @@ void MidiOutFilter::processBlock (AudioSampleBuffer& buffer,
                                     mtcData = (hours & 0x10) >> 4 | mtcFrameRate;
                                     break;
                             }
-                            MidiMessage midiclock (0xf1, (mtcNumber << 4) | (mtcData));
+                            juce::MidiMessage midiclock (0xf1, (mtcNumber << 4) | (mtcData));
                             ++mtcNumber;
                             mtcNumber &= 0x07;
                             midiMessages.addEvent (midiclock, samplesToNextMTC);
@@ -450,8 +452,8 @@ void MidiOutFilter::processBlock (AudioSampleBuffer& buffer,
                         //midiMessages.addEvent(stop,0);
                         sendmtc = false;
                     }
-                    uint8 ffsysexdata[] = { 0xF0, 0x7F, 0x00, 0x01, 0x01, (uint8) (hours & 0xff), (uint8) (mins & 0xff), (uint8) (secs & 0xff), (uint8) (frames & 0xff), 0xF7 };
-                    MidiMessage fullframe (ffsysexdata, 10);
+                    juce::uint8 ffsysexdata[] = { 0xF0, 0x7F, 0x00, 0x01, 0x01, (juce::uint8) (hours & 0xff), (juce::uint8) (mins & 0xff), (juce::uint8) (secs & 0xff), (juce::uint8) (frames & 0xff), 0xF7 };
+                    juce::MidiMessage fullframe (ffsysexdata, 10);
                     if (midiOutput)
                     {
                         midiOutput->sendMessageNow (fullframe);
@@ -476,7 +478,7 @@ void MidiOutFilter::processBlock (AudioSampleBuffer& buffer,
                     {
                         //this is so the song position pointer will be sent before any
                         //other data at the beginning of the song
-                        MidiBuffer temp = midiMessages;
+                        juce::MidiBuffer temp = midiMessages;
                         midiMessages.clear();
 
                         //send song position pointer & continue
@@ -489,7 +491,7 @@ void MidiOutFilter::processBlock (AudioSampleBuffer& buffer,
                         }
                         if (intbeat != 0)
                         {
-                            MidiMessage position (0xf2, intbeat & 0x007f, (intbeat & 0x3f80) >> 7);
+                            juce::MidiMessage position (0xf2, intbeat & 0x007f, (intbeat & 0x3f80) >> 7);
                             midiMessages.addEvent (position, 0);
                         }
                         startAt            = (double) intbeat * 0.25;
@@ -499,15 +501,15 @@ void MidiOutFilter::processBlock (AudioSampleBuffer& buffer,
                         {
                             if (intbeat == 0)
                             {
-                                MidiMessage start (0xfa);
+                                juce::MidiMessage start (0xfa);
                                 midiMessages.addEvent (start, samplesToNextClock);
                             }
                             else
                             {
-                                MidiMessage start (0xfb);
+                                juce::MidiMessage start (0xfb);
                                 midiMessages.addEvent (start, samplesToNextClock);
                             }
-                            MidiMessage midiclock (0xf8);
+                            juce::MidiMessage midiclock (0xf8);
                             midiMessages.addEvent (midiclock, samplesToNextClock);
                             samplesToNextClock = (int) (samplesPerClock * (clockppq + i));
                             i += 1.0;
@@ -522,15 +524,15 @@ void MidiOutFilter::processBlock (AudioSampleBuffer& buffer,
                         samplesToNextClock = (int) (samplesPerPpq * (startAt - pos.ppqPosition));
                         if (pos.ppqPosition == 0.0)
                         {
-                            MidiMessage start (0xfa);
+                            juce::MidiMessage start (0xfa);
                             midiMessages.addEvent (start, samplesToNextClock);
                         }
                         else
                         {
-                            MidiMessage start (0xfb);
+                            juce::MidiMessage start (0xfb);
                             midiMessages.addEvent (start, samplesToNextClock);
                         }
-                        MidiMessage midiclock (0xf8);
+                        juce::MidiMessage midiclock (0xf8);
                         midiMessages.addEvent (midiclock, samplesToNextClock);
                         samplesToNextClock = (int) (samplesPerClock * (clockppq + i));
                         i += 1.0;
@@ -541,7 +543,7 @@ void MidiOutFilter::processBlock (AudioSampleBuffer& buffer,
                     {
                         while (samplesToNextClock < buffer.getNumSamples())
                         {
-                            MidiMessage midiclock (0xf8);
+                            juce::MidiMessage midiclock (0xf8);
                             midiMessages.addEvent (midiclock, samplesToNextClock);
                             samplesToNextClock = (int) (samplesPerClock * (clockppq + i));
                             i += 1.0;
@@ -553,7 +555,7 @@ void MidiOutFilter::processBlock (AudioSampleBuffer& buffer,
                     if (wasPlaying)
                     {
                         //just stopped, send MIDI Stop
-                        MidiMessage stop (0xfc);
+                        juce::MidiMessage stop (0xfc);
                         midiMessages.addEvent (stop, 0);
                         sendclock = false;
                     }
@@ -565,7 +567,7 @@ void MidiOutFilter::processBlock (AudioSampleBuffer& buffer,
                     }
                     if (lastPosInfo.ppqPosition != pos.ppqPosition)
                     {
-                        MidiMessage position (0xf2, intbeat & 0x007f, (intbeat & 0x3f80) >> 7);
+                        juce::MidiMessage position (0xf2, intbeat & 0x007f, (intbeat & 0x3f80) >> 7);
                         midiMessages.addEvent (position, 0);
                     }
                 }
@@ -595,7 +597,7 @@ void MidiOutFilter::processBlock (AudioSampleBuffer& buffer,
                 }
             }
             else
-                midiOutput->sendBlockOfMessages (midiMessages, Time::getMillisecondCounterHiRes() + 1.0, SR);
+                midiOutput->sendBlockOfMessages (midiMessages, juce::Time::getMillisecondCounterHiRes() + 1.0, SR);
         }
 
         if (param[kHostOut] < 0.5f)
@@ -603,7 +605,7 @@ void MidiOutFilter::processBlock (AudioSampleBuffer& buffer,
     }
     else
     {
-        MidiBuffer output;
+        juce::MidiBuffer output;
         for (auto&& msgMetadata : midiMessages)
         {
             auto midi_message = msgMetadata.getMessage();
@@ -617,7 +619,7 @@ void MidiOutFilter::processBlock (AudioSampleBuffer& buffer,
         }
 
         if (midiOutput && param[kStamped] < 0.5f)
-            midiOutput->sendBlockOfMessages (output, Time::getMillisecondCounterHiRes() + 1.0, SR);
+            midiOutput->sendBlockOfMessages (output, juce::Time::getMillisecondCounterHiRes() + 1.0, SR);
 
         if (param[kHostOut] < 0.5f)
             midiMessages.clear();
@@ -627,36 +629,36 @@ void MidiOutFilter::processBlock (AudioSampleBuffer& buffer,
 }
 
 //==============================================================================
-void MidiOutFilter::getCurrentProgramStateInformation (MemoryBlock& destData)
+void MidiOutFilter::getCurrentProgramStateInformation (juce::MemoryBlock& destData)
 {
     // make sure the non-parameter settings are copied to the current program
     programs[curProgram].icon = icon;
 
-    XmlElement xmlState ("MYPLUGINSETTINGS");
+    juce::XmlElement xmlState ("MYPLUGINSETTINGS");
     xmlState.setAttribute ("pluginVersion", 1);
     xmlState.setAttribute ("program", getCurrentProgram());
     xmlState.setAttribute ("progname", getProgramName (getCurrentProgram()));
     for (int i = 0; i < getNumParameters(); i++)
-        xmlState.setAttribute (String (i), param[i]);
+        xmlState.setAttribute (juce::String (i), param[i]);
     xmlState.setAttribute ("icon", icon);
     xmlState.setAttribute ("device", activeDevice.name);
     copyXmlToBinary (xmlState, destData);
 }
 
-void MidiOutFilter::getStateInformation (MemoryBlock& destData)
+void MidiOutFilter::getStateInformation (juce::MemoryBlock& destData)
 {
     // make sure the non-parameter settings are copied to the current program
     programs[curProgram].icon = icon;
 
-    XmlElement xmlState ("MYPLUGINSETTINGS");
+    juce::XmlElement xmlState ("MYPLUGINSETTINGS");
     xmlState.setAttribute ("pluginVersion", 1);
     xmlState.setAttribute ("program", getCurrentProgram());
     for (int p = 0; p < getNumPrograms(); p++)
     {
-        String prefix = "P" + String (p) + ".";
+        juce::String prefix = "P" + juce::String (p) + ".";
         xmlState.setAttribute (prefix + "progname", programs[p].name);
         for (int i = 0; i < getNumParameters(); i++)
-            xmlState.setAttribute (prefix + String (i), programs[p].param[i]);
+            xmlState.setAttribute (prefix + juce::String (i), programs[p].param[i]);
         xmlState.setAttribute (prefix + "icon", programs[p].icon);
         xmlState.setAttribute (prefix + "device", programs[p].device.name);
     }
@@ -674,7 +676,7 @@ void MidiOutFilter::setCurrentProgramStateInformation (const void* data, int siz
             changeProgramName (getCurrentProgram(), xmlState->getStringAttribute ("progname", L"Default"));
             for (int i = 0; i < getNumParameters(); i++)
             {
-                param[i] = (float) xmlState->getDoubleAttribute (String (i), param[i]);
+                param[i] = (float) xmlState->getDoubleAttribute (juce::String (i), param[i]);
             }
             icon = xmlState->getStringAttribute ("icon", icon);
             setActiveDevice (xmlState->getStringAttribute ("device", activeDevice.name));
@@ -688,16 +690,16 @@ void MidiOutFilter::setStateInformation (const void* data, int sizeInBytes)
 {
     auto const xmlState = getXmlFromBinary (data, sizeInBytes);
 
-    if (xmlState != 0)
+    if (xmlState != nullptr)
     {
         if (xmlState->hasTagName ("MYPLUGINSETTINGS"))
         {
             for (int p = 0; p < getNumPrograms(); p++)
             {
-                String prefix = L"P" + String (p) + L".";
+                juce::String prefix = L"P" + juce::String (p) + L".";
                 for (int i = 0; i < getNumParameters(); i++)
                 {
-                    programs[p].param[i] = (float) xmlState->getDoubleAttribute (prefix + String (i), programs[p].param[i]);
+                    programs[p].param[i] = (float) xmlState->getDoubleAttribute (prefix + juce::String (i), programs[p].param[i]);
                 }
                 programs[p].icon   = xmlState->getStringAttribute (prefix + L"icon", programs[p].icon);
                 programs[p].device = getDeviceByName (xmlState->getStringAttribute (prefix + L"device", programs[p].device.name));

--- a/pizjuce/midiOut/midiOut.h
+++ b/pizjuce/midiOut/midiOut.h
@@ -3,12 +3,10 @@
 
 #include <memory>
 
-#include "juce_audio_devices/juce_audio_devices.h"
+#include <juce_audio_devices/juce_audio_devices.h>
 
 #include "../_common/PizArray.h"
 #include "../_common/PizAudioProcessor.h"
-
-using namespace juce;
 
 enum parameters
 {
@@ -31,9 +29,9 @@ public:
 
 private:
     float param[numParams];
-    String icon;
-    MidiDeviceInfo device;
-    String name;
+    juce::String icon;
+    juce::MidiDeviceInfo device;
+    juce::String name;
 };
 
 //==============================================================================
@@ -43,7 +41,7 @@ private:
 
 */
 class MidiOutFilter : public PizAudioProcessor,
-                      public ChangeBroadcaster
+                      public juce::ChangeBroadcaster
 {
 public:
     //==============================================================================
@@ -54,15 +52,15 @@ public:
     void prepareToPlay (double sampleRate, int samplesPerBlock) override;
     void releaseResources() override;
 
-    void processBlock (AudioSampleBuffer& buffer,
-                       MidiBuffer& midiMessages) override;
+    void processBlock (juce::AudioSampleBuffer& buffer,
+                       juce::MidiBuffer& midiMessages) override;
 
     //==============================================================================
-    AudioProcessorEditor* createEditor() override;
+    juce::AudioProcessorEditor* createEditor() override;
 
     //==============================================================================
     double getTailLengthSeconds() const override { return 0; }
-    const String getName() const override { return JucePlugin_Name; }
+    const juce::String getName() const override { return JucePlugin_Name; }
     bool acceptsMidi() const override { return true; }
     bool producesMidi() const override { return true; }
     bool hasEditor() const override { return true; }
@@ -72,11 +70,11 @@ public:
     float getParameter (int index) override;
     void setParameter (int index, float newValue) override;
 
-    const String getParameterName (int index) override;
-    const String getParameterText (int index) override;
+    const juce::String getParameterName (int index) override;
+    const juce::String getParameterText (int index) override;
 
-    const String getInputChannelName (int channelIndex) const override;
-    const String getOutputChannelName (int channelIndex) const override;
+    const juce::String getInputChannelName (int channelIndex) const override;
+    const juce::String getOutputChannelName (int channelIndex) const override;
     bool isInputChannelStereoPair (int index) const override;
     bool isOutputChannelStereoPair (int index) const override;
 
@@ -84,40 +82,37 @@ public:
     int getNumPrograms() override { return 1; }
     int getCurrentProgram() override;
     void setCurrentProgram (int index) override;
-    const String getProgramName (int index) override;
-    void changeProgramName (int index, const String& newName) override;
+    const juce::String getProgramName (int index) override;
+    void changeProgramName (int index, const juce::String& newName) override;
 
     //==============================================================================
-    void getStateInformation (MemoryBlock& destData) override;
+    void getStateInformation (juce::MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
-    void getCurrentProgramStateInformation (MemoryBlock& destData) override;
+    void getCurrentProgramStateInformation (juce::MemoryBlock& destData) override;
     void setCurrentProgramStateInformation (const void* data, int sizeInBytes) override;
 
     //==============================================================================
     // These properties are public so that our editor component can access them
     //  - a bit of a hacky way to do it, but it's only a demo!
 
-    PizArray<MidiDeviceInfo> devices;
-    String icon;
+    PizArray<juce::MidiDeviceInfo> devices;
+    juce::String icon;
 
-    void setActiveDevice (String name);
-    void setActiveDevice (MidiDeviceInfo device);
-    MidiDeviceInfo getActiveDevice() { return activeDevice; }
-    MidiDeviceInfo getDeviceByName (String name) const;
+    void setActiveDevice (juce::String name);
+    void setActiveDevice (juce::MidiDeviceInfo device);
+    juce::MidiDeviceInfo getActiveDevice() { return activeDevice; }
+    juce::MidiDeviceInfo getDeviceByName (juce::String name) const;
 
-    //==============================================================================
-    juce_UseDebuggingNewOperator
-
-        private :
-        // this is our gain - the UI and the host can access this by getting/setting
-        // parameter 0.
-        float param[numParams];
-    MidiDeviceInfo activeDevice;
+private:
+    // this is our gain - the UI and the host can access this by getting/setting
+    // parameter 0.
+    float param[numParams];
+    juce::MidiDeviceInfo activeDevice;
 
     JuceProgram* programs;
     int curProgram;
     bool init;
-    std::unique_ptr<MidiOutput> midiOutput;
+    std::unique_ptr<juce::MidiOutput> midiOutput;
 
     double startAt;
     double startMTCAt;
@@ -129,7 +124,9 @@ public:
     int samplesToNextClock;
     int samplesToNextMTC;
 
-    AudioPlayHead::CurrentPositionInfo lastPosInfo;
+    juce::AudioPlayHead::CurrentPositionInfo lastPosInfo;
+
+    JUCE_LEAK_DETECTOR (MidiOutFilter)
 };
 
 #endif

--- a/pizjuce/midiOut/midiOutEditor.cpp
+++ b/pizjuce/midiOut/midiOutEditor.cpp
@@ -23,6 +23,7 @@
 #include "midiOutEditor.h"
 
 //[MiscUserDefs] You can add your own user definitions and misc code here...
+using juce::roundToInt;
 //[/MiscUserDefs]
 
 //==============================================================================
@@ -114,7 +115,7 @@ MidiOutEditor::MidiOutEditor (MidiOutFilter* const ownerFilter)
     setMouseClickGrabsKeyboardFocus (false);
 
     comboBox->setMouseClickGrabsKeyboardFocus (false);
-    comboBox->addItem (String ("--"), 1);
+    comboBox->addItem (juce::String ("--"), 1);
     for (int i = 0; i < ownerFilter->devices.size(); i++)
     {
         comboBox->addItem (ownerFilter->devices[i].name, i + 2);
@@ -123,7 +124,7 @@ MidiOutEditor::MidiOutEditor (MidiOutFilter* const ownerFilter)
 
     imagepad->setTriggeredOnMouseDown (true);
     imagepad->addButtonListener (this);
-    imagepad->drawableButton->Label = String ("Drag\nIcon");
+    imagepad->drawableButton->Label = juce::String ("Drag\nIcon");
 
     clockButton->setMouseClickGrabsKeyboardFocus (false);
     mtcButton->setMouseClickGrabsKeyboardFocus (false);
@@ -239,15 +240,15 @@ void MidiOutEditor::buttonClicked (juce::Button* buttonThatWasClicked)
 }
 
 //[MiscUserCode] You can add your own definitions of your custom methods or any other code here...
-void MidiOutEditor::buttonStateChanged (Button* buttonThatWasClicked)
+void MidiOutEditor::buttonStateChanged (juce::Button* buttonThatWasClicked)
 {
     getFilter()->icon = imagepad->drawableButton->getName();
     if (imagepad->drawableButton->isDown())
     {
-        ModifierKeys mousebutton = ModifierKeys::getCurrentModifiers();
+        juce::ModifierKeys mousebutton = juce::ModifierKeys::getCurrentModifiers();
         if (mousebutton.isPopupMenu())
         {
-            PopupMenu m, sub1;
+            juce::PopupMenu m, sub1;
             //m.addItem(0,"Text:",false);
             //m.addCustomItem (1, textEditor, 200 , 24, false);
             //m.addSeparator();
@@ -262,7 +263,7 @@ void MidiOutEditor::buttonStateChanged (Button* buttonThatWasClicked)
             {
                 if (result == 66)
                 {
-                    getFilter()->icon = String ("");
+                    getFilter()->icon = juce::String ("");
                     imagepad->clearIcon();
                 }
             }
@@ -271,7 +272,7 @@ void MidiOutEditor::buttonStateChanged (Button* buttonThatWasClicked)
 }
 
 //==============================================================================
-void MidiOutEditor::changeListenerCallback (ChangeBroadcaster* source)
+void MidiOutEditor::changeListenerCallback (juce::ChangeBroadcaster* source)
 {
     if (source == getFilter())
         updateParametersFromFilter();
@@ -287,33 +288,33 @@ void MidiOutEditor::updateParametersFromFilter()
     filter->getCallbackLock().enter();
 
     // take a local copy of the info we need while we've got the lock..
-    const int newDevice = filter->devices.indexOf (filter->getActiveDevice());
-    const float clock   = filter->getParameter (kClock);
-    const float mtc     = filter->getParameter (kMTC);
-    const float hostout = filter->getParameter (kHostOut);
-    const int channel   = roundToInt (filter->getParameter (kChannel) * 16.f);
-    const String icon   = filter->icon;
+    const int newDevice     = filter->devices.indexOf (filter->getActiveDevice());
+    const float clock       = filter->getParameter (kClock);
+    const float mtc         = filter->getParameter (kMTC);
+    const float hostout     = filter->getParameter (kHostOut);
+    const int channel       = roundToInt (filter->getParameter (kChannel) * 16.f);
+    const juce::String icon = filter->icon;
 
     // ..release the lock ASAP
     filter->getCallbackLock().exit();
 
-    comboBox->setSelectedItemIndex (newDevice + 1, dontSendNotification);
-    channelBox->setSelectedItemIndex (channel, dontSendNotification);
+    comboBox->setSelectedItemIndex (newDevice + 1, juce::dontSendNotification);
+    channelBox->setSelectedItemIndex (channel, juce::dontSendNotification);
 
-    clockButton->setToggleState (clock >= 0.5f, dontSendNotification);
-    mtcButton->setToggleState (mtc >= 0.5f, dontSendNotification);
-    hostButton->setToggleState (hostout >= 0.5f, dontSendNotification);
+    clockButton->setToggleState (clock >= 0.5f, juce::dontSendNotification);
+    mtcButton->setToggleState (mtc >= 0.5f, juce::dontSendNotification);
+    hostButton->setToggleState (hostout >= 0.5f, juce::dontSendNotification);
 
-    String fullpath = icon;
-    if (! File::getCurrentWorkingDirectory().getChildFile (fullpath).existsAsFile())
-        fullpath = ((File::getSpecialLocation (File::currentExecutableFile)).getParentDirectory()).getFullPathName()
-                 + File::getSeparatorString() + icon;
-    auto image = Drawable::createFromImageFile (File (fullpath));
+    juce::String fullpath = icon;
+    if (! juce::File::getCurrentWorkingDirectory().getChildFile (fullpath).existsAsFile())
+        fullpath = ((juce::File::getSpecialLocation (juce::File::currentExecutableFile)).getParentDirectory()).getFullPathName()
+                 + juce::File::getSeparatorString() + icon;
+    auto image = juce::Drawable::createFromImageFile (juce::File (fullpath));
     if (image)
     {
         imagepad->drawableButton->setImages (image.get());
         imagepad->drawableButton->setName (icon);
-        imagepad->setButtonText (String());
+        imagepad->setButtonText (juce::String());
     }
     else
         imagepad->setButtonText ("IPH\nmidiOut\n1.3");

--- a/pizjuce/midiOut/midiOutEditor.h
+++ b/pizjuce/midiOut/midiOutEditor.h
@@ -20,7 +20,7 @@
 #pragma once
 
 //[Headers]     -- You can add your own extra header files here --
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_gui_basics/juce_gui_basics.h>
 
 #include "midiOut.h"
 #include "MidiPad.h"
@@ -46,8 +46,8 @@ public:
 
     //==============================================================================
     //[UserMethods]     -- You can add your own custom methods in this section.
-    void changeListenerCallback (ChangeBroadcaster* source) override;
-    void buttonStateChanged (Button* buttonThatWasClicked) override;
+    void changeListenerCallback (juce::ChangeBroadcaster* source) override;
+    void buttonStateChanged (juce::Button* buttonThatWasClicked) override;
     //[/UserMethods]
 
     void paint (juce::Graphics& g) override;

--- a/pizjuce/midiPBCurve/MidiEnvelope.cpp
+++ b/pizjuce/midiPBCurve/MidiEnvelope.cpp
@@ -1,33 +1,37 @@
 #include "MidiEnvelope.h"
 
+using juce::jmax;
+using juce::jmin;
+using juce::roundToInt;
+
 //==============================================================================
 MidiEnvelope::MidiEnvelope (const int envelopeType_,
-                            AudioProcessorEditor* owner_,
+                            juce::AudioProcessorEditor* owner_,
                             MidiCurve* plugin_)
     : owner (owner_),
       plugin (plugin_),
       draggingPoint (-1),
       hoveringPoint (-1),
-      labelX (0),
-      labelY (0)
+      labelX (nullptr),
+      labelY (nullptr)
 {
-    addAndMakeVisible (labelX = new Label ("x label",
-                                           "x: --"));
-    labelX->setFont (Font (15.0000f, Font::plain));
-    labelX->setJustificationType (Justification::centredLeft);
+    addAndMakeVisible (labelX = new juce::Label ("x label",
+                                                 "x: --"));
+    labelX->setFont (juce::Font (15.0000f, juce::Font::plain));
+    labelX->setJustificationType (juce::Justification::centredLeft);
     labelX->setEditable (false, false, false);
-    labelX->setColour (TextEditor::textColourId, Colours::black);
-    labelX->setColour (TextEditor::backgroundColourId, Colour (0x0));
+    labelX->setColour (juce::TextEditor::textColourId, juce::Colours::black);
+    labelX->setColour (juce::TextEditor::backgroundColourId, juce::Colour (0x0));
     labelX->setOpaque (false);
     labelX->setInterceptsMouseClicks (false, false);
 
-    addAndMakeVisible (labelY = new Label ("y label",
-                                           "y: --"));
-    labelY->setFont (Font (15.0000f, Font::plain));
-    labelY->setJustificationType (Justification::centredLeft);
+    addAndMakeVisible (labelY = new juce::Label ("y label",
+                                                 "y: --"));
+    labelY->setFont (juce::Font (15.0000f, juce::Font::plain));
+    labelY->setJustificationType (juce::Justification::centredLeft);
     labelY->setEditable (false, false, false);
-    labelY->setColour (TextEditor::textColourId, Colours::black);
-    labelY->setColour (TextEditor::backgroundColourId, Colour (0x0));
+    labelY->setColour (juce::TextEditor::textColourId, juce::Colours::black);
+    labelY->setColour (juce::TextEditor::backgroundColourId, juce::Colour (0x0));
     labelY->setOpaque (false);
     labelY->setInterceptsMouseClicks (false, false);
 }
@@ -49,12 +53,12 @@ void MidiEnvelope::resized()
 }
 
 //==============================================================================
-void MidiEnvelope::paint (Graphics& g)
+void MidiEnvelope::paint (juce::Graphics& g)
 {
     const int dotSize     = MAX_ENVELOPE_DOT_SIZE;
     const int halfDotSize = dotSize / 2;
 
-    g.fillAll (Colour (0xffffffff));
+    g.fillAll (juce::Colour (0xffffffff));
 
     for (int grid = 1; grid < 16383; grid++)
     {
@@ -64,7 +68,7 @@ void MidiEnvelope::paint (Graphics& g)
         int pbstep2    = pbrange2 == 0.f ? pbstep : roundToInt (8192.f / (jmax (1.f, pbrange2)));
         if (grid == 8192)
         { //center line
-            g.setColour (Colours::blueviolet);
+            g.setColour (juce::Colours::blueviolet);
             g.drawLine (0.f, ((float) (16383 - grid) * inc) * getHeight(), (float) getWidth(), ((float) (16383 - grid) * inc) * getHeight(), 1.f);
             g.drawLine (((float) grid * inc) * getWidth(), 0.f, ((float) grid * inc) * getWidth(), (float) getHeight(), 1.f);
         }
@@ -78,25 +82,25 @@ void MidiEnvelope::paint (Graphics& g)
         //		 grid==15019 || grid==15701 ) { //semitones for +/-12 range
         else if (grid > 8192 && grid % pbstep == 0)
         {
-            g.setColour (Colours::lightgrey);
+            g.setColour (juce::Colours::lightgrey);
             g.drawLine (0.f, ((float) (16383 - grid) * inc) * getHeight(), (float) getWidth(), ((float) (16383 - grid) * inc) * getHeight(), 1.f);
             g.drawLine (((float) grid * inc) * getWidth(), 0.f, ((float) grid * inc) * getWidth(), (float) getHeight(), 1.f);
         }
         else if (grid < 8192 && grid % pbstep2 == 0)
         {
-            g.setColour (Colours::lightgrey);
+            g.setColour (juce::Colours::lightgrey);
             g.drawLine (0.f, ((float) (16383 - grid) * inc) * getHeight(), (float) getWidth(), ((float) (16383 - grid) * inc) * getHeight(), 1.f);
             g.drawLine (((float) grid * inc) * getWidth(), 0.f, ((float) grid * inc) * getWidth(), (float) getHeight(), 1.f);
         }
         else if (grid % 4096 == 0)
         {
-            g.setColour (Colours::lightgoldenrodyellow);
+            g.setColour (juce::Colours::lightgoldenrodyellow);
             g.drawLine (0.f, ((float) (16383 - grid) * inc) * getHeight(), (float) getWidth(), ((float) (16383 - grid) * inc) * getHeight(), 1.f);
             g.drawLine (((float) grid * inc) * getWidth(), 0.f, ((float) grid * inc) * getWidth(), (float) getHeight(), 1.f);
         }
         if (grid == 8192)
         { //center line
-            g.setColour (Colours::blueviolet);
+            g.setColour (juce::Colours::blueviolet);
             g.drawLine (0.f, ((float) (16383 - grid) * inc) * getHeight(), (float) getWidth(), ((float) (16383 - grid) * inc) * getHeight(), 2.f);
             g.drawLine (((float) grid * inc) * getWidth(), 0.f, ((float) grid * inc) * getWidth(), (float) getHeight(), 2.f);
         }
@@ -105,12 +109,12 @@ void MidiEnvelope::paint (Graphics& g)
         //	g.setPixel(((float)grid*inc)*getWidth(),((float)(16383-grid)*inc)*getHeight());
         //}
     }
-    Path myPath = plugin->path;
-    myPath.applyTransform (AffineTransform::scale ((float) getWidth(), (float) getHeight()));
-    g.setColour (Colours::black);
-    g.strokePath (myPath, PathStrokeType (2.0f));
+    juce::Path myPath = plugin->path;
+    myPath.applyTransform (juce::AffineTransform::scale ((float) getWidth(), (float) getHeight()));
+    g.setColour (juce::Colours::black);
+    g.strokePath (myPath, juce::PathStrokeType (2.0f));
 
-    g.setColour (Colours::black);
+    g.setColour (juce::Colours::black);
     g.drawEllipse ((float) getWidth() * (float) roundToInt (16383.0 * (mouseDownPoint.getX() / (double) getWidth())) / 16383.f - 2,
                    (float) getHeight() * (float) roundToInt (16383.0 * (mouseDownPoint.getY() / (double) getHeight())) / 16383.f - 2,
                    4,
@@ -123,28 +127,28 @@ void MidiEnvelope::paint (Graphics& g)
 
         if (isPointActive (i))
         {
-            g.setColour (Colours::white);
+            g.setColour (juce::Colours::white);
             g.fillEllipse ((float) (x - halfDotSize), (float) (y - halfDotSize), (float) dotSize, (float) dotSize);
             if (draggingPoint == i)
             {
-                g.setColour (Colours::red);
+                g.setColour (juce::Colours::red);
                 g.drawHorizontalLine (y, 0, (float) getWidth());
                 g.drawVerticalLine (x, 0, (float) getHeight());
-                g.setColour (Colours::black);
+                g.setColour (juce::Colours::black);
                 g.fillEllipse ((float) (x - halfDotSize), (float) (y - halfDotSize), (float) dotSize, (float) dotSize);
-                g.setColour (Colours::red);
+                g.setColour (juce::Colours::red);
                 g.drawEllipse ((float) (x - halfDotSize), (float) (y - halfDotSize), (float) dotSize, (float) dotSize, 2.f);
             }
             else if (hoveringPoint == i)
             {
-                g.setColour (Colours::green);
+                g.setColour (juce::Colours::green);
                 g.drawHorizontalLine (y, 0, (float) getWidth());
                 g.drawVerticalLine (x, 0, (float) getHeight());
                 g.fillEllipse ((float) (x - halfDotSize), (float) (y - halfDotSize), (float) dotSize, (float) dotSize);
             }
             else
             {
-                g.setColour (Colours::black);
+                g.setColour (juce::Colours::black);
                 if (i == 0 || i == (MAX_ENVELOPE_POINTS - 1))
                     g.drawEllipse ((float) (x - halfDotSize), (float) (y - halfDotSize), (float) dotSize, (float) dotSize, 3);
                 else
@@ -152,7 +156,7 @@ void MidiEnvelope::paint (Graphics& g)
             }
             if (isPointControl (i))
             {
-                g.setColour (Colours::blue);
+                g.setColour (juce::Colours::blue);
                 g.drawEllipse ((float) (x - dotSize), (float) (y - dotSize), dotSize * 2.f, dotSize * 2.f, 1);
                 //g.setColour (Colours::lightblue);
                 //float dashes[2] = {2.f,2.f};
@@ -173,7 +177,7 @@ void MidiEnvelope::paint (Graphics& g)
         //	g.drawLine(x-dotSize,y+dotSize,x+dotSize,y-dotSize,1);
         //}
     }
-    g.setColour (Colours::darkgoldenrod);
+    g.setColour (juce::Colours::darkgoldenrod);
     g.drawVerticalLine (roundToInt ((float) plugin->lastCCIn * getWidth() / 16383.f),
                         (float) getHeight() - ((float) plugin->lastCCOut * (float) getHeight() / 16383.f),
                         (float) getHeight());
@@ -184,7 +188,7 @@ void MidiEnvelope::paint (Graphics& g)
 }
 
 //==============================================================================
-void MidiEnvelope::mouseDown (const MouseEvent& e)
+void MidiEnvelope::mouseDown (const juce::MouseEvent& e)
 {
     draggingPoint = findPointByMousePos (e.x, e.y);
     if (draggingPoint != -1)
@@ -218,9 +222,9 @@ void MidiEnvelope::mouseDown (const MouseEvent& e)
         }
         else
         {
-            labelX->setColour (Label::textColourId, Colours::red);
-            labelY->setColour (Label::textColourId, Colours::red);
-            Point<float> p (points[draggingPoint][0], 1.f - points[draggingPoint][1]);
+            labelX->setColour (juce::Label::textColourId, juce::Colours::red);
+            labelY->setColour (juce::Label::textColourId, juce::Colours::red);
+            juce::Point<float> p (points[draggingPoint][0], 1.f - points[draggingPoint][1]);
             float pbrange  = plugin->getParameter (kPBRange) * 48.f;
             float pbrange2 = plugin->getParameter (kPBRange2) * 48.f;
             if (pbrange2 == 0.f)
@@ -228,30 +232,30 @@ void MidiEnvelope::mouseDown (const MouseEvent& e)
             if (p.getX() > 0.5f)
             {
                 labelX->setText ("x: "
-                                     + String (roundToInt (16383.f * p.getX()))
-                                     + " (" + String (pbrange * (p.getX() - 0.5f), 2) + ")",
-                                 dontSendNotification);
+                                     + juce::String (roundToInt (16383.f * p.getX()))
+                                     + " (" + juce::String (pbrange * (p.getX() - 0.5f), 2) + ")",
+                                 juce::dontSendNotification);
             }
             else
             {
                 labelX->setText ("x: "
-                                     + String (roundToInt (16383.f * p.getX()))
-                                     + " (" + String (pbrange2 * (p.getX() - 0.5f), 2) + ")",
-                                 dontSendNotification);
+                                     + juce::String (roundToInt (16383.f * p.getX()))
+                                     + " (" + juce::String (pbrange2 * (p.getX() - 0.5f), 2) + ")",
+                                 juce::dontSendNotification);
             }
             if (p.getY() > 0.5f)
             {
                 labelY->setText ("y: "
-                                     + String (roundToInt (16383.f * p.getY()))
-                                     + " (" + String (pbrange * (p.getY() - 0.5f), 2) + ")",
-                                 dontSendNotification);
+                                     + juce::String (roundToInt (16383.f * p.getY()))
+                                     + " (" + juce::String (pbrange * (p.getY() - 0.5f), 2) + ")",
+                                 juce::dontSendNotification);
             }
             else
             {
                 labelY->setText ("y: "
-                                     + String (roundToInt (16383.f * p.getY()))
-                                     + " (" + String (pbrange2 * (p.getY() - 0.5f), 2) + ")",
-                                 dontSendNotification);
+                                     + juce::String (roundToInt (16383.f * p.getY()))
+                                     + " (" + juce::String (pbrange2 * (p.getY() - 0.5f), 2) + ")",
+                                 juce::dontSendNotification);
             }
         }
     }
@@ -292,7 +296,7 @@ int MidiEnvelope::findInactivePoint()
     return -1;
 }
 
-void MidiEnvelope::mouseDoubleClick (const MouseEvent& e)
+void MidiEnvelope::mouseDoubleClick (const juce::MouseEvent& e)
 {
     int p = findPointByMousePos (e.x, e.y);
     if (p != -1)
@@ -315,7 +319,7 @@ void MidiEnvelope::mouseDoubleClick (const MouseEvent& e)
     repaint();
 }
 
-void MidiEnvelope::mouseDrag (const MouseEvent& e)
+void MidiEnvelope::mouseDrag (const juce::MouseEvent& e)
 {
     int restrict = 0;
     if (e.mods.isCommandDown() && ! e.mods.isShiftDown())
@@ -363,9 +367,9 @@ void MidiEnvelope::mouseDrag (const MouseEvent& e)
             points[draggingPoint][1] = restrict == 1 ? oldpoints[draggingPoint][1] : (jmax (0.f, jmin (snapy, (float) getHeight()))) / (float) getHeight();
 
         plugin->setParameterNotifyingHost ((paramNumber + 1), (1.f - points[draggingPoint][1]));
-        labelX->setColour (Label::textColourId, Colours::red);
-        labelY->setColour (Label::textColourId, Colours::red);
-        Point<float> p (points[draggingPoint][0], 1.f - points[draggingPoint][1]);
+        labelX->setColour (juce::Label::textColourId, juce::Colours::red);
+        labelY->setColour (juce::Label::textColourId, juce::Colours::red);
+        juce::Point<float> p (points[draggingPoint][0], 1.f - points[draggingPoint][1]);
         float pbrange  = plugin->getParameter (kPBRange) * 48.f;
         float pbrange2 = plugin->getParameter (kPBRange2) * 48.f;
         if (pbrange2 == 0.f)
@@ -373,30 +377,30 @@ void MidiEnvelope::mouseDrag (const MouseEvent& e)
         if (p.getX() > 0.5f)
         {
             labelX->setText ("x: "
-                                 + String (roundToInt (16383.f * p.getX()))
-                                 + " (" + String (pbrange * (p.getX() - 0.5f), 2) + ")",
-                             dontSendNotification);
+                                 + juce::String (roundToInt (16383.f * p.getX()))
+                                 + " (" + juce::String (pbrange * (p.getX() - 0.5f), 2) + ")",
+                             juce::dontSendNotification);
         }
         else
         {
             labelX->setText ("x: "
-                                 + String (roundToInt (16383.f * p.getX()))
-                                 + " (" + String (pbrange2 * (p.getX() - 0.5f), 2) + ")",
-                             dontSendNotification);
+                                 + juce::String (roundToInt (16383.f * p.getX()))
+                                 + " (" + juce::String (pbrange2 * (p.getX() - 0.5f), 2) + ")",
+                             juce::dontSendNotification);
         }
         if (p.getY() > 0.5f)
         {
             labelY->setText ("y: "
-                                 + String (roundToInt (16383.f * p.getY()))
-                                 + " (" + String (pbrange * (p.getY() - 0.5f), 2) + ")",
-                             dontSendNotification);
+                                 + juce::String (roundToInt (16383.f * p.getY()))
+                                 + " (" + juce::String (pbrange * (p.getY() - 0.5f), 2) + ")",
+                             juce::dontSendNotification);
         }
         else
         {
             labelY->setText ("y: "
-                                 + String (roundToInt (16383.f * p.getY()))
-                                 + " (" + String (pbrange2 * (p.getY() - 0.5f), 2) + ")",
-                             dontSendNotification);
+                                 + juce::String (roundToInt (16383.f * p.getY()))
+                                 + " (" + juce::String (pbrange2 * (p.getY() - 0.5f), 2) + ")",
+                             juce::dontSendNotification);
         }
 
         repaint();
@@ -425,22 +429,22 @@ void MidiEnvelope::mouseDrag (const MouseEvent& e)
                 plugin->setParameterNotifyingHost ((i * 2 + 1), (1.f - points[i][1]));
             }
         }
-        labelX->setColour (Label::textColourId, Colours::black);
-        labelY->setColour (Label::textColourId, Colours::black);
+        labelX->setColour (juce::Label::textColourId, juce::Colours::black);
+        labelY->setColour (juce::Label::textColourId, juce::Colours::black);
         repaint();
     }
 }
 
-void MidiEnvelope::mouseUp (const MouseEvent& e)
+void MidiEnvelope::mouseUp (const juce::MouseEvent& e)
 {
-    labelX->setColour (Label::textColourId, Colours::black);
-    labelY->setColour (Label::textColourId, Colours::black);
+    labelX->setColour (juce::Label::textColourId, juce::Colours::black);
+    labelY->setColour (juce::Label::textColourId, juce::Colours::black);
     draggingPoint = -1;
 
     repaint();
 }
 
-void MidiEnvelope::mouseMove (const MouseEvent& e)
+void MidiEnvelope::mouseMove (const juce::MouseEvent& e)
 {
     hoveringPoint = findPointByMousePos (e.x, e.y);
     if (hoveringPoint != -1)
@@ -452,10 +456,10 @@ void MidiEnvelope::mouseMove (const MouseEvent& e)
 
         //labelX->setTopLeftPosition(x,y);
         //labelY->setTopLeftPosition(x,y+labelX->getHeight());
-        labelX->setColour (Label::textColourId, Colours::green);
-        labelY->setColour (Label::textColourId, Colours::green);
+        labelX->setColour (juce::Label::textColourId, juce::Colours::green);
+        labelY->setColour (juce::Label::textColourId, juce::Colours::green);
 
-        Point<float> p (points[hoveringPoint][0], 1.f - points[hoveringPoint][1]);
+        juce::Point<float> p (points[hoveringPoint][0], 1.f - points[hoveringPoint][1]);
         float pbrange  = plugin->getParameter (kPBRange) * 48.f;
         float pbrange2 = plugin->getParameter (kPBRange2) * 48.f;
         if (pbrange2 == 0.f)
@@ -463,40 +467,40 @@ void MidiEnvelope::mouseMove (const MouseEvent& e)
         if (p.getX() > 0.5f)
         {
             labelX->setText ("x: "
-                                 + String (roundToInt (16383.f * p.getX()))
-                                 + " (" + String (pbrange * (p.getX() - 0.5f), 2) + ")",
-                             dontSendNotification);
+                                 + juce::String (roundToInt (16383.f * p.getX()))
+                                 + " (" + juce::String (pbrange * (p.getX() - 0.5f), 2) + ")",
+                             juce::dontSendNotification);
         }
         else
         {
             labelX->setText ("x: "
-                                 + String (roundToInt (16383.f * p.getX()))
-                                 + " (" + String (pbrange2 * (p.getX() - 0.5f), 2) + ")",
-                             dontSendNotification);
+                                 + juce::String (roundToInt (16383.f * p.getX()))
+                                 + " (" + juce::String (pbrange2 * (p.getX() - 0.5f), 2) + ")",
+                             juce::dontSendNotification);
         }
         if (p.getY() > 0.5f)
         {
             labelY->setText ("y: "
-                                 + String (roundToInt (16383.f * p.getY()))
-                                 + " (" + String (pbrange * (p.getY() - 0.5f), 2) + ")",
-                             dontSendNotification);
+                                 + juce::String (roundToInt (16383.f * p.getY()))
+                                 + " (" + juce::String (pbrange * (p.getY() - 0.5f), 2) + ")",
+                             juce::dontSendNotification);
         }
         else
         {
             labelY->setText ("y: "
-                                 + String (roundToInt (16383.f * p.getY()))
-                                 + " (" + String (pbrange2 * (p.getY() - 0.5f), 2) + ")",
-                             dontSendNotification);
+                                 + juce::String (roundToInt (16383.f * p.getY()))
+                                 + " (" + juce::String (pbrange2 * (p.getY() - 0.5f), 2) + ")",
+                             juce::dontSendNotification);
         }
     }
     else
     {
         //labelX->setTopLeftPosition(e.x+16,e.y);
         //labelY->setTopLeftPosition(e.x+16,e.y+labelX->getHeight());
-        labelX->setColour (Label::textColourId, Colours::black);
-        labelY->setColour (Label::textColourId, Colours::black);
+        labelX->setColour (juce::Label::textColourId, juce::Colours::black);
+        labelY->setColour (juce::Label::textColourId, juce::Colours::black);
 
-        Point<float> p ((float) e.x / (float) getWidth(), 1.f - (float) e.y / (float) getHeight());
+        juce::Point<float> p ((float) e.x / (float) getWidth(), 1.f - (float) e.y / (float) getHeight());
         float pbrange  = plugin->getParameter (kPBRange) * 48.f;
         float pbrange2 = plugin->getParameter (kPBRange2) * 48.f;
         if (pbrange2 == 0.f)
@@ -504,30 +508,30 @@ void MidiEnvelope::mouseMove (const MouseEvent& e)
         if (p.getX() > 0.5f)
         {
             labelX->setText ("x: "
-                                 + String (roundToInt (16383.f * p.getX()))
-                                 + " (" + String (pbrange * (p.getX() - 0.5f), 2) + ")",
-                             dontSendNotification);
+                                 + juce::String (roundToInt (16383.f * p.getX()))
+                                 + " (" + juce::String (pbrange * (p.getX() - 0.5f), 2) + ")",
+                             juce::dontSendNotification);
         }
         else
         {
             labelX->setText ("x: "
-                                 + String (roundToInt (16383.f * p.getX()))
-                                 + " (" + String (pbrange2 * (p.getX() - 0.5f), 2) + ")",
-                             dontSendNotification);
+                                 + juce::String (roundToInt (16383.f * p.getX()))
+                                 + " (" + juce::String (pbrange2 * (p.getX() - 0.5f), 2) + ")",
+                             juce::dontSendNotification);
         }
         if (p.getY() > 0.5f)
         {
             labelY->setText ("y: "
-                                 + String (roundToInt (16383.f * p.getY()))
-                                 + " (" + String (pbrange * (p.getY() - 0.5f), 2) + ")",
-                             dontSendNotification);
+                                 + juce::String (roundToInt (16383.f * p.getY()))
+                                 + " (" + juce::String (pbrange * (p.getY() - 0.5f), 2) + ")",
+                             juce::dontSendNotification);
         }
         else
         {
             labelY->setText ("y: "
-                                 + String (roundToInt (16383.f * p.getY()))
-                                 + " (" + String (pbrange2 * (p.getY() - 0.5f), 2) + ")",
-                             dontSendNotification);
+                                 + juce::String (roundToInt (16383.f * p.getY()))
+                                 + " (" + juce::String (pbrange2 * (p.getY() - 0.5f), 2) + ")",
+                             juce::dontSendNotification);
         }
     }
 

--- a/pizjuce/midiPBCurve/MidiEnvelope.h
+++ b/pizjuce/midiPBCurve/MidiEnvelope.h
@@ -4,12 +4,12 @@
 #include "curve.h"
 
 //==============================================================================
-class MidiEnvelope : public Component
+class MidiEnvelope : public juce::Component
 {
 public:
     //==============================================================================
     MidiEnvelope (const int envelopeType,
-                  AudioProcessorEditor* owner,
+                  juce::AudioProcessorEditor* owner,
                   MidiCurve* plugin);
     ~MidiEnvelope() override;
 
@@ -17,33 +17,33 @@ public:
     void updateParameters (const bool repaintComponent = true);
 
     //==============================================================================
-    void mouseDown (const MouseEvent& e) override;
-    void mouseDrag (const MouseEvent& e) override;
-    void mouseUp (const MouseEvent& e) override;
-    void mouseMove (const MouseEvent& e) override;
-    void mouseDoubleClick (const MouseEvent& e) override;
+    void mouseDown (const juce::MouseEvent& e) override;
+    void mouseDrag (const juce::MouseEvent& e) override;
+    void mouseUp (const juce::MouseEvent& e) override;
+    void mouseMove (const juce::MouseEvent& e) override;
+    void mouseDoubleClick (const juce::MouseEvent& e) override;
 
-    void paint (Graphics& g) override;
+    void paint (juce::Graphics& g) override;
     void resized() override;
     float getValue (float input);
 
 protected:
     int findPointByMousePos (const int x, const int y);
 
-    AudioProcessorEditor* owner;
+    juce::AudioProcessorEditor* owner;
     MidiCurve* plugin;
 
     int draggingPoint;
     int hoveringPoint;
-    Point<float> mouseDownPoint;
+    juce::Point<float> mouseDownPoint;
     float points[MAX_ENVELOPE_POINTS][2];
     float oldpoints[MAX_ENVELOPE_POINTS][2];
     void setPointActive (int point, bool active);
     bool isPointActive (int point);
     void setPointControl (int point, bool control);
     bool isPointControl (int point);
-    Label* labelX;
-    Label* labelY;
+    juce::Label* labelX;
+    juce::Label* labelY;
     int findInactivePoint();
     int addPoint (float x, float y, bool control = false);
 };

--- a/pizjuce/midiPBCurve/curve.cpp
+++ b/pizjuce/midiPBCurve/curve.cpp
@@ -1,6 +1,8 @@
 #include "curve.h"
 #include "curvegui.h"
 
+using juce::roundToInt;
+
 //==============================================================================
 /*
     This function must be implemented to create the actual plugin object that
@@ -48,7 +50,7 @@ MidiCurve::MidiCurve()
     {
         for (int i = 0; i < getNumPrograms(); i++)
         {
-            programs[i].name = String ("Program ") + String (i + 1);
+            programs[i].name = juce::String ("Program ") + juce::String (i + 1);
         }
     }
     //start up with the first program
@@ -91,40 +93,40 @@ void MidiCurve::setParameter (int index, float newValue)
     }
 }
 
-const String MidiCurve::getParameterName (int index)
+const juce::String MidiCurve::getParameterName (int index)
 {
     if (index == kChannel)
         return "Channel";
-    return "param" + String (index);
+    return "param" + juce::String (index);
 }
 
-const String MidiCurve::getParameterText (int index)
+const juce::String MidiCurve::getParameterText (int index)
 {
     if (index == kChannel)
     {
         if (roundToInt (param[kChannel] * 16.0f) == 0)
-            return String ("Any");
+            return juce::String ("Any");
         else
-            return String (roundToInt (param[kChannel] * 16.0f));
+            return juce::String (roundToInt (param[kChannel] * 16.0f));
     }
     else if (index < getNumParameters())
-        return String (roundToInt (127.f * param[index]));
+        return juce::String (roundToInt (127.f * param[index]));
     else
-        return String();
+        return juce::String();
 }
 
-const String MidiCurve::getInputChannelName (const int channelIndex) const
+const juce::String MidiCurve::getInputChannelName (const int channelIndex) const
 {
     if (channelIndex < getNumInputChannels())
-        return String (JucePlugin_Name) + String (" ") + String (channelIndex + 1);
-    return String();
+        return juce::String (JucePlugin_Name) + juce::String (" ") + juce::String (channelIndex + 1);
+    return juce::String();
 }
 
-const String MidiCurve::getOutputChannelName (const int channelIndex) const
+const juce::String MidiCurve::getOutputChannelName (const int channelIndex) const
 {
     if (channelIndex < getNumOutputChannels())
-        return String (JucePlugin_Name) + String (" ") + String (channelIndex + 1);
-    return String();
+        return juce::String (JucePlugin_Name) + juce::String (" ") + juce::String (channelIndex + 1);
+    return juce::String();
 }
 
 bool MidiCurve::isInputChannelStereoPair (int index) const
@@ -162,17 +164,17 @@ void MidiCurve::setCurrentProgram (int index)
     sendChangeMessage();
 }
 
-void MidiCurve::changeProgramName (int index, const String& newName)
+void MidiCurve::changeProgramName (int index, const juce::String& newName)
 {
     if (index < getNumPrograms())
         programs[index].name = newName;
 }
 
-const String MidiCurve::getProgramName (int index)
+const juce::String MidiCurve::getProgramName (int index)
 {
     if (index < getNumPrograms())
         return programs[index].name;
-    return String();
+    return juce::String();
 }
 
 int MidiCurve::getCurrentProgram()
@@ -206,7 +208,7 @@ float MidiCurve::getPointValue (int n, int y)
 
 float MidiCurve::findValue (float input)
 {
-    PathFlatteningIterator it (path, {}, (float) midiScaler);
+    juce::PathFlatteningIterator it (path, {}, (float) midiScaler);
     while (it.next())
     {
         if (it.x1 == input)
@@ -227,15 +229,15 @@ double MidiCurve::linearInterpolate (double x, double y1, double y2, double x1, 
     return slope * x + y0;
 }
 
-void MidiCurve::processBlock (AudioSampleBuffer& buffer,
-                              MidiBuffer& midiMessages)
+void MidiCurve::processBlock (juce::AudioSampleBuffer& buffer,
+                              juce::MidiBuffer& midiMessages)
 {
     for (int i = getNumInputChannels(); i < getNumOutputChannels(); ++i)
     {
         buffer.clear (i, 0, buffer.getNumSamples());
     }
     const int channel = roundToInt (param[kChannel] * 16.0f);
-    MidiBuffer output;
+    juce::MidiBuffer output;
     for (auto&& msgMetadata : midiMessages)
     {
         auto midi_message  = msgMetadata.getMessage();
@@ -247,12 +249,12 @@ void MidiCurve::processBlock (AudioSampleBuffer& buffer,
             {
                 if (param[kPitchBend] >= 0.5f)
                 {
-                    int v             = midi_message.getPitchWheelValue();
-                    const uint8* data = midi_message.getRawData();
-                    lastCCIn          = v;
-                    v                 = roundToInt (16383.f * findValue (v * (float) 0.00006103888));
-                    lastCCOut         = v;
-                    MidiMessage out   = MidiMessage (data[0], v & 0x007f, (v & 0x3f80) >> 7);
+                    int v                   = midi_message.getPitchWheelValue();
+                    const juce::uint8* data = midi_message.getRawData();
+                    lastCCIn                = v;
+                    v                       = roundToInt (16383.f * findValue (v * (float) 0.00006103888));
+                    lastCCOut               = v;
+                    juce::MidiMessage out   = juce::MidiMessage (data[0], v & 0x007f, (v & 0x3f80) >> 7);
                     output.addEvent (out, sample_number);
                     sendChangeMessage();
                 }
@@ -279,7 +281,7 @@ void MidiCurve::updatePath()
         midiPoint p = midiPoint (param[i * 2], param[i * 2 + 1], isPointActive (i), isPointControl (i));
         points.addSorted (pointComparator, p);
     }
-    Path myPath;
+    juce::Path myPath;
     if (points[0].isActive)
     {
         myPath.startNewSubPath (0.f, getPointValue (0, 1));
@@ -370,13 +372,13 @@ bool MidiCurve::isPointControl (int point)
 }
 
 //==============================================================================
-AudioProcessorEditor* MidiCurve::createEditor()
+juce::AudioProcessorEditor* MidiCurve::createEditor()
 {
     return new CurveEditor (this);
 }
 
 //==============================================================================
-void MidiCurve::getCurrentProgramStateInformation (MemoryBlock& destData)
+void MidiCurve::getCurrentProgramStateInformation (juce::MemoryBlock& destData)
 {
     // make sure the non-parameter settings are copied to the current program
     programs[curProgram].lastUIHeight = lastUIHeight;
@@ -387,7 +389,7 @@ void MidiCurve::getCurrentProgramStateInformation (MemoryBlock& destData)
     // params as XML..
 
     // create an outer XML element..
-    XmlElement xmlState ("MYPLUGINSETTINGS");
+    juce::XmlElement xmlState ("MYPLUGINSETTINGS");
 
     // add some attributes to it..
     xmlState.setAttribute ("pluginVersion", 1);
@@ -397,7 +399,7 @@ void MidiCurve::getCurrentProgramStateInformation (MemoryBlock& destData)
 
     for (int i = 0; i < kNumParams; i++)
     {
-        xmlState.setAttribute (String (i), param[i]);
+        xmlState.setAttribute (juce::String (i), param[i]);
     }
 
     xmlState.setAttribute ("uiWidth", lastUIWidth);
@@ -406,22 +408,22 @@ void MidiCurve::getCurrentProgramStateInformation (MemoryBlock& destData)
     // then use this helper function to stuff it into the binary blob and return it..
     copyXmlToBinary (xmlState, destData);
 }
-void MidiCurve::getStateInformation (MemoryBlock& destData)
+void MidiCurve::getStateInformation (juce::MemoryBlock& destData)
 {
     // make sure the non-parameter settings are copied to the current program
     programs[curProgram].lastUIHeight = lastUIHeight;
     programs[curProgram].lastUIWidth  = lastUIWidth;
 
-    XmlElement xmlState ("MYPLUGINSETTINGS");
+    juce::XmlElement xmlState ("MYPLUGINSETTINGS");
     xmlState.setAttribute ("pluginVersion", 1);
     xmlState.setAttribute ("program", getCurrentProgram());
     for (int p = 0; p < getNumPrograms(); p++)
     {
-        String prefix = "P" + String (p) + ".";
+        juce::String prefix = "P" + juce::String (p) + ".";
         xmlState.setAttribute (prefix + "progname", programs[p].name);
         for (int i = 0; i < kNumParams; i++)
         {
-            xmlState.setAttribute (prefix + String (i), programs[p].param[i]);
+            xmlState.setAttribute (prefix + juce::String (i), programs[p].param[i]);
         }
         xmlState.setAttribute (prefix + "uiWidth", programs[p].lastUIWidth);
         xmlState.setAttribute (prefix + "uiHeight", programs[p].lastUIHeight);
@@ -443,7 +445,7 @@ void MidiCurve::setCurrentProgramStateInformation (const void* data, int sizeInB
             changeProgramName (getCurrentProgram(), xmlState->getStringAttribute ("progname", "Default"));
             for (int i = 0; i < kNumParams; i++)
             {
-                param[i] = (float) xmlState->getDoubleAttribute (String (i), param[i]);
+                param[i] = (float) xmlState->getDoubleAttribute (juce::String (i), param[i]);
             }
             lastUIWidth  = xmlState->getIntAttribute ("uiWidth", lastUIWidth);
             lastUIHeight = xmlState->getIntAttribute ("uiHeight", lastUIHeight);
@@ -463,10 +465,10 @@ void MidiCurve::setStateInformation (const void* data, int sizeInBytes)
         {
             for (int p = 0; p < getNumPrograms(); p++)
             {
-                String prefix = "P" + String (p) + ".";
+                juce::String prefix = "P" + juce::String (p) + ".";
                 for (int i = 0; i < kNumParams; i++)
                 {
-                    programs[p].param[i] = (float) xmlState->getDoubleAttribute (prefix + String (i), programs[p].param[i]);
+                    programs[p].param[i] = (float) xmlState->getDoubleAttribute (prefix + juce::String (i), programs[p].param[i]);
                 }
                 programs[p].lastUIWidth  = xmlState->getIntAttribute (prefix + "uiWidth", programs[p].lastUIWidth);
                 programs[p].lastUIHeight = xmlState->getIntAttribute (prefix + "uiHeight", programs[p].lastUIHeight);

--- a/pizjuce/midiPBCurve/curve.h
+++ b/pizjuce/midiPBCurve/curve.h
@@ -31,7 +31,7 @@ private:
     float param[kNumParams];
 
     int lastUIWidth, lastUIHeight;
-    String name;
+    juce::String name;
 };
 
 //==============================================================================
@@ -41,7 +41,7 @@ private:
 
 */
 class MidiCurve : public PizAudioProcessor,
-                  public ChangeBroadcaster
+                  public juce::ChangeBroadcaster
 {
 public:
     //==============================================================================
@@ -52,15 +52,15 @@ public:
     void prepareToPlay (double sampleRate, int samplesPerBlock) override;
     void releaseResources() override;
 
-    void processBlock (AudioSampleBuffer& buffer,
-                       MidiBuffer& midiMessages) override;
+    void processBlock (juce::AudioSampleBuffer& buffer,
+                       juce::MidiBuffer& midiMessages) override;
 
     //==============================================================================
-    AudioProcessorEditor* createEditor() override;
+    juce::AudioProcessorEditor* createEditor() override;
 
     //==============================================================================
     double getTailLengthSeconds() const override { return 0; }
-    const String getName() const override { return JucePlugin_Name; }
+    const juce::String getName() const override { return JucePlugin_Name; }
     bool hasEditor() const override { return true; }
     bool acceptsMidi() const override
     {
@@ -84,11 +84,11 @@ public:
     float getParameter (int index) override;
     void setParameter (int index, float newValue) override;
 
-    const String getParameterName (int index) override;
-    const String getParameterText (int index) override;
+    const juce::String getParameterName (int index) override;
+    const juce::String getParameterText (int index) override;
 
-    const String getInputChannelName (int channelIndex) const override;
-    const String getOutputChannelName (int channelIndex) const override;
+    const juce::String getInputChannelName (int channelIndex) const override;
+    const juce::String getOutputChannelName (int channelIndex) const override;
     bool isInputChannelStereoPair (int index) const override;
     bool isOutputChannelStereoPair (int index) const override;
 
@@ -97,13 +97,13 @@ public:
     int getNumPrograms() override { return 128; }
     int getCurrentProgram() override;
     void setCurrentProgram (int index) override;
-    const String getProgramName (int index) override;
-    void changeProgramName (int index, const String& newName) override;
+    const juce::String getProgramName (int index) override;
+    void changeProgramName (int index, const juce::String& newName) override;
 
     //==============================================================================
-    void getCurrentProgramStateInformation (MemoryBlock& destData) override;
+    void getCurrentProgramStateInformation (juce::MemoryBlock& destData) override;
     void setCurrentProgramStateInformation (const void* data, int sizeInBytes) override;
-    void getStateInformation (MemoryBlock& destData) override;
+    void getStateInformation (juce::MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
 
     //==============================================================================
@@ -121,12 +121,10 @@ public:
     int getPrevActivePoint (int currentPoint);
     int getNextActivePoint (int currentPoint);
     void resetPoints();
-    Path path;
+    juce::Path path;
 
-    //==============================================================================
-    juce_UseDebuggingNewOperator
-
-        private : float param[kNumParams];
+private:
+    float param[kNumParams];
 
     class midiPoint
     {
@@ -145,17 +143,17 @@ public:
         }
         ~midiPoint(){};
 
-        Point<float> p;
+        juce::Point<float> p;
         bool isControl;
         bool isActive;
     };
 
     struct PointComparator
     {
-        int compareElements (midiPoint a, midiPoint b) { return roundToInt (a.p.getX() * 127.f) - roundToInt (b.p.getX() * 127.f); }
+        int compareElements (midiPoint a, midiPoint b) { return juce::roundToInt (a.p.getX() * 127.f) - juce::roundToInt (b.p.getX() * 127.f); }
     } pointComparator;
 
-    Array<midiPoint> points;
+    juce::Array<midiPoint> points;
     void updatePath();
 
     JuceProgram* programs;
@@ -165,6 +163,8 @@ public:
 
     float findValue (float input);
     double linearInterpolate (double x, double y1, double y2, double x1, double x2);
+
+    JUCE_LEAK_DETECTOR (MidiCurve)
 };
 
 #endif

--- a/pizjuce/midiPBCurve/curvegui.cpp
+++ b/pizjuce/midiPBCurve/curvegui.cpp
@@ -54,7 +54,7 @@ CurveEditor::CurveEditor (MidiCurve* const ownerFilter)
     label2->setColour (juce::TextEditor::textColourId, juce::Colours::black);
     label2->setColour (juce::TextEditor::backgroundColourId, juce::Colour (0x00000000));
 
-    resizer.reset (new ResizableCornerComponent (this, &resizeLimits));
+    resizer.reset (new juce::ResizableCornerComponent (this, &resizeLimits));
     addAndMakeVisible (resizer.get());
 
     channelSlider.reset (new ChannelSlider ("new slider"));
@@ -304,7 +304,7 @@ void CurveEditor::buttonClicked (juce::Button* buttonThatWasClicked)
 }
 
 //[MiscUserCode] You can add your own definitions of your custom methods or any other code here...
-void CurveEditor::changeListenerCallback (ChangeBroadcaster* source)
+void CurveEditor::changeListenerCallback (juce::ChangeBroadcaster* source)
 {
     if (source == getFilter())
         updateParameters();
@@ -318,28 +318,28 @@ void CurveEditor::updateParameters()
     const float pbrange2 = getFilter()->getParameter (kPBRange2) * 48.f;
     if (lastin != -1)
     {
-        label->setText ("In: " + String (lastin), sendNotification);
+        label->setText ("In: " + juce::String (lastin), juce::sendNotification);
         if (lastin == 8192)
-            label6->setText ("(center)", sendNotification);
+            label6->setText ("(center)", juce::sendNotification);
         else if (lastin > 8192)
-            label6->setText ("(+" + String (pbrange * ((float) lastin / 16383.f - 0.5f), 2) + ")", sendNotification);
+            label6->setText ("(+" + juce::String (pbrange * ((float) lastin / 16383.f - 0.5f), 2) + ")", juce::sendNotification);
         else if (lastin < 8192)
-            label6->setText ("(" + String (pbrange2 * ((float) lastin / 16383.f - 0.5f), 2) + ")", sendNotification);
+            label6->setText ("(" + juce::String (pbrange2 * ((float) lastin / 16383.f - 0.5f), 2) + ")", juce::sendNotification);
     }
     if (lastout != -1)
     {
-        label2->setText ("Out: " + String (lastout), sendNotification);
+        label2->setText ("Out: " + juce::String (lastout), juce::sendNotification);
         if (lastout == 8192)
-            label7->setText ("(center)", sendNotification);
+            label7->setText ("(center)", juce::sendNotification);
         else if (lastout > 8192)
-            label7->setText ("(+" + String (pbrange * ((float) lastout / 16383.f - 0.5f), 2) + ")", sendNotification);
+            label7->setText ("(+" + juce::String (pbrange * ((float) lastout / 16383.f - 0.5f), 2) + ")", juce::sendNotification);
         else if (lastout < 8192)
-            label7->setText ("(" + String (pbrange2 * ((float) lastout / 16383.f - 0.5f), 2) + ")", sendNotification);
+            label7->setText ("(" + juce::String (pbrange2 * ((float) lastout / 16383.f - 0.5f), 2) + ")", juce::sendNotification);
     }
 
-    channelSlider->setValue (getFilter()->getParameter (kChannel) * channelSlider->getMaximum(), dontSendNotification);
-    rangeSlider->setValue (getFilter()->getParameter (kPBRange) * rangeSlider->getMaximum(), dontSendNotification);
-    rangeSlider2->setValue (getFilter()->getParameter (kPBRange2) * rangeSlider2->getMaximum(), dontSendNotification);
+    channelSlider->setValue (getFilter()->getParameter (kChannel) * channelSlider->getMaximum(), juce::dontSendNotification);
+    rangeSlider->setValue (getFilter()->getParameter (kPBRange) * rangeSlider->getMaximum(), juce::dontSendNotification);
+    rangeSlider2->setValue (getFilter()->getParameter (kPBRange2) * rangeSlider2->getMaximum(), juce::dontSendNotification);
 
     curve->updateParameters (true);
 

--- a/pizjuce/midiPBCurve/curvegui.h
+++ b/pizjuce/midiPBCurve/curvegui.h
@@ -20,9 +20,9 @@
 #pragma once
 
 //[Headers]     -- You can add your own extra header files here --
-#include "juce_audio_processors/juce_audio_processors.h"
-#include "juce_events/juce_events.h"
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_events/juce_events.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
 #include "../_common/ChannelSlider.h"
 #include "curve.h"
@@ -59,16 +59,16 @@ public:
 private:
     //[UserVariables]   -- You can add your own custom variables in this section.
     MidiCurve* getFilter() const throw() { return (MidiCurve*) getAudioProcessor(); }
-    void changeListenerCallback (ChangeBroadcaster* source) override;
+    void changeListenerCallback (juce::ChangeBroadcaster* source) override;
     void updateParameters();
-    ComponentBoundsConstrainer resizeLimits;
+    juce::ComponentBoundsConstrainer resizeLimits;
     //[/UserVariables]
 
     //==============================================================================
     std::unique_ptr<MidiEnvelope> curve;
     std::unique_ptr<juce::Label> label;
     std::unique_ptr<juce::Label> label2;
-    std::unique_ptr<ResizableCornerComponent> resizer;
+    std::unique_ptr<juce::ResizableCornerComponent> resizer;
     std::unique_ptr<ChannelSlider> channelSlider;
     std::unique_ptr<juce::Label> label3;
     std::unique_ptr<juce::TextButton> resetButton;

--- a/pizjuce/midiPCGUI/midiPCGUI.cpp
+++ b/pizjuce/midiPCGUI/midiPCGUI.cpp
@@ -33,7 +33,7 @@ midiPCGUI::midiPCGUI()
     {
         for (int i = 0; i < 128; i++)
         {
-            programs[i].setName ("Program " + String (i + 1));
+            programs[i].setName ("Program " + juce::String (i + 1));
         }
     }
 
@@ -176,7 +176,7 @@ void midiPCGUI::setParameter (int index, float newValue)
     sendChangeMessage();
 }
 
-const String midiPCGUI::getParameterName (int index)
+const juce::String midiPCGUI::getParameterName (int index)
 {
     switch (index)
     {
@@ -214,12 +214,12 @@ const String midiPCGUI::getParameterName (int index)
             return "Thru";
             break;
         default:
-            return String();
+            return juce::String();
             break;
     }
 }
 
-const String midiPCGUI::getParameterText (int index)
+const juce::String midiPCGUI::getParameterText (int index)
 {
     char* text;
     text = new char[24];
@@ -292,17 +292,17 @@ const String midiPCGUI::getParameterText (int index)
             sprintf (text, "%d", roundToInt (param[index] * 100.0f));
             break;
     }
-    return String (text);
+    return juce::String (text);
 }
 
-const String midiPCGUI::getInputChannelName (const int channelIndex) const
+const juce::String midiPCGUI::getInputChannelName (const int channelIndex) const
 {
-    return String (channelIndex + 1);
+    return juce::String (channelIndex + 1);
 }
 
-const String midiPCGUI::getOutputChannelName (const int channelIndex) const
+const juce::String midiPCGUI::getOutputChannelName (const int channelIndex) const
 {
-    return String (channelIndex + 1);
+    return juce::String (channelIndex + 1);
 }
 
 bool midiPCGUI::isInputChannelStereoPair (int index) const
@@ -334,12 +334,12 @@ void midiPCGUI::setCurrentProgram (int index)
         triggerbank = true;
 }
 
-void midiPCGUI::changeProgramName (int index, const String& newName)
+void midiPCGUI::changeProgramName (int index, const juce::String& newName)
 {
     programs[curProgram].name = newName;
 }
 
-const String midiPCGUI::getProgramName (int index)
+const juce::String midiPCGUI::getProgramName (int index)
 {
     return programs[index].name;
 }
@@ -349,7 +349,7 @@ int midiPCGUI::getCurrentProgram()
     return curProgram;
 }
 //==============================================================================
-AudioProcessorEditor* midiPCGUI::createEditor()
+juce::AudioProcessorEditor* midiPCGUI::createEditor()
 {
     return new midiPCGUIEditor (this);
 }
@@ -366,8 +366,8 @@ void midiPCGUI::releaseResources()
     // spare memory, etc.
 }
 
-void midiPCGUI::processBlock (AudioSampleBuffer& buffer,
-                              MidiBuffer& midiMessages)
+void midiPCGUI::processBlock (juce::AudioSampleBuffer& buffer,
+                              juce::MidiBuffer& midiMessages)
 {
     for (int i = 0; i < getNumOutputChannels(); ++i)
     {
@@ -375,18 +375,18 @@ void midiPCGUI::processBlock (AudioSampleBuffer& buffer,
     }
 
     int listenchannel = FLOAT_TO_CHANNEL015 (param[kChannel]);
-    MidiBuffer output;
+    juce::MidiBuffer output;
 
     for (auto&& msgMetadata : midiMessages)
     {
         auto midi_message = msgMetadata.getMessage();
 
-        bool discard          = ! thru;
-        const uint8* midiData = midi_message.getRawData();
-        unsigned char status  = midiData[0] & 0xf0; // scraping  channel
-        char channel          = midiData[0] & 0x0f; // isolating channel (0-15)
-        char data1            = midiData[1] & 0x7f;
-        char data2            = midiData[2] & 0x7f;
+        bool discard                = ! thru;
+        const juce::uint8* midiData = midi_message.getRawData();
+        unsigned char status        = midiData[0] & 0xf0; // scraping  channel
+        char channel                = midiData[0] & 0x0f; // isolating channel (0-15)
+        char data1                  = midiData[1] & 0x7f;
+        char data2                  = midiData[2] & 0x7f;
 
         //only look at the selected channel
         if (channel == listenchannel)
@@ -430,13 +430,13 @@ void midiPCGUI::processBlock (AudioSampleBuffer& buffer,
         //create GUI triggered message
         if (bankmsb != 0)
         {
-            MidiMessage msb (MIDI_CONTROLCHANGE | listenchannel, MIDI_BANK_CHANGE, bankmsb - 1, 0);
+            juce::MidiMessage msb (MIDI_CONTROLCHANGE | listenchannel, MIDI_BANK_CHANGE, bankmsb - 1, 0);
             output.addEvent (msb, 0);
             actualBankMSB[listenchannel] = bankmsb;
         }
         if (banklsb != 0)
         {
-            MidiMessage lsb (MIDI_CONTROLCHANGE | listenchannel, 0x20, banklsb - 1, 0);
+            juce::MidiMessage lsb (MIDI_CONTROLCHANGE | listenchannel, 0x20, banklsb - 1, 0);
             output.addEvent (lsb, 0);
             actualBankLSB[listenchannel] = banklsb;
         }
@@ -455,9 +455,9 @@ void midiPCGUI::processBlock (AudioSampleBuffer& buffer,
                 triggerbank = false;
                 if (buffer.getNumSamples() > delaytime)
                 {
-                    wait               = false;
-                    counter            = 0;
-                    MidiMessage progch = MidiMessage::programChange (listenchannel + 1, program - 1);
+                    wait                     = false;
+                    counter                  = 0;
+                    juce::MidiMessage progch = juce::MidiMessage::programChange (listenchannel + 1, program - 1);
                     output.addEvent (progch, delaytime);
                     setParameterNotifyingHost (kTrigger, 0.4f);
                 }
@@ -465,7 +465,7 @@ void midiPCGUI::processBlock (AudioSampleBuffer& buffer,
             else
             {
                 //create GUI triggered message
-                output.addEvent (MidiMessage::programChange (listenchannel + 1, program - 1), triggerdelta);
+                output.addEvent (juce::MidiMessage::programChange (listenchannel + 1, program - 1), triggerdelta);
                 setParameterNotifyingHost (kTrigger, 0.4f);
             }
         }
@@ -480,7 +480,7 @@ void midiPCGUI::processBlock (AudioSampleBuffer& buffer,
             program = 1;
         if (program != 0)
         {
-            output.addEvent (MidiMessage::programChange (listenchannel + 1, program - 1), 0);
+            output.addEvent (juce::MidiMessage::programChange (listenchannel + 1, program - 1), 0);
             actualProgram[listenchannel] = program;
         }
         setParameterNotifyingHost (kProgram, MIDI_TO_FLOAT2 (program));
@@ -496,7 +496,7 @@ void midiPCGUI::processBlock (AudioSampleBuffer& buffer,
             program = 128;
         if (program != 0)
         {
-            output.addEvent (MidiMessage::programChange (listenchannel + 1, program - 1), 0);
+            output.addEvent (juce::MidiMessage::programChange (listenchannel + 1, program - 1), 0);
             actualProgram[listenchannel] = program;
         }
         setParameterNotifyingHost (kProgram, MIDI_TO_FLOAT2 (program));
@@ -508,7 +508,7 @@ void midiPCGUI::processBlock (AudioSampleBuffer& buffer,
 }
 
 //==============================================================================
-void midiPCGUI::getCurrentProgramStateInformation (MemoryBlock& destData)
+void midiPCGUI::getCurrentProgramStateInformation (juce::MemoryBlock& destData)
 {
     // you can store your parameters as binary data if you want to or if you've got
     // a load of binary to put in there, but if you're not doing anything too heavy,
@@ -516,7 +516,7 @@ void midiPCGUI::getCurrentProgramStateInformation (MemoryBlock& destData)
     // params as XML..
 
     // create an outer XML element..
-    XmlElement xmlState ("MIDIPCGUISETTINGS");
+    juce::XmlElement xmlState ("MIDIPCGUISETTINGS");
 
     // add some attributes to it..
     xmlState.setAttribute ("pluginVersion", 2);
@@ -524,12 +524,12 @@ void midiPCGUI::getCurrentProgramStateInformation (MemoryBlock& destData)
     xmlState.setAttribute ("program", getCurrentProgram());
     xmlState.setAttribute ("progname", getProgramName (getCurrentProgram()));
     for (int i = 0; i < getNumParameters(); i++)
-        xmlState.setAttribute (String (i), param[i]);
+        xmlState.setAttribute (juce::String (i), param[i]);
 
-    XmlElement* names = new XmlElement ("names");
+    auto* names = new juce::XmlElement ("names");
     for (int i = 0; i < progNames.names.size(); i++)
     {
-        XmlElement* name = new XmlElement ("name");
+        auto* name = new juce::XmlElement ("name");
         name->setAttribute ("c", progNames.names[i].channel);
         name->setAttribute ("b", progNames.names[i].bank);
         name->setAttribute ("p", progNames.names[i].program);
@@ -542,27 +542,27 @@ void midiPCGUI::getCurrentProgramStateInformation (MemoryBlock& destData)
     copyXmlToBinary (xmlState, destData);
 }
 
-void midiPCGUI::getStateInformation (MemoryBlock& destData)
+void midiPCGUI::getStateInformation (juce::MemoryBlock& destData)
 {
     // make sure the non-parameter settings are copied to the current program
 
-    XmlElement xmlState ("MIDIPCGUISETTINGS");
+    juce::XmlElement xmlState ("MIDIPCGUISETTINGS");
     xmlState.setAttribute ("pluginVersion", 2);
     xmlState.setAttribute ("program", getCurrentProgram());
     for (int p = 0; p < getNumPrograms(); p++)
     {
-        String prefix = "P" + String (p) + "_";
+        juce::String prefix = "P" + juce::String (p) + "_";
         xmlState.setAttribute (prefix + "progname", programs[p].name);
         for (int i = 0; i < getNumParameters(); i++)
         {
-            xmlState.setAttribute (prefix + String (i), programs[p].param[i]);
+            xmlState.setAttribute (prefix + juce::String (i), programs[p].param[i]);
         }
     }
 
-    XmlElement* names = new XmlElement ("names");
+    auto* names = new juce::XmlElement ("names");
     for (int i = 0; i < progNames.names.size(); i++)
     {
-        XmlElement* name = new XmlElement ("name");
+        auto* name = new juce::XmlElement ("name");
         name->setAttribute ("c", progNames.names[i].channel);
         name->setAttribute ("b", progNames.names[i].bank);
         name->setAttribute ("p", progNames.names[i].program);
@@ -579,7 +579,7 @@ void midiPCGUI::setCurrentProgramStateInformation (const void* data, int sizeInB
     // use this helper function to get the XML from this binary blob..
     auto xmlState = getXmlFromBinary (data, sizeInBytes);
 
-    if (xmlState != 0)
+    if (xmlState != nullptr)
     {
         // check that it's the right type of xml..
         if (xmlState->hasTagName ("MIDIPCGUISETTINGS"))
@@ -588,9 +588,9 @@ void midiPCGUI::setCurrentProgramStateInformation (const void* data, int sizeInB
             changeProgramName (getCurrentProgram(), xmlState->getStringAttribute ("progname", "Default"));
             for (int i = 0; i < getNumParameters(); i++)
             {
-                param[i] = (float) xmlState->getDoubleAttribute (String (i), param[i]);
+                param[i] = (float) xmlState->getDoubleAttribute (juce::String (i), param[i]);
             }
-            XmlElement* n = xmlState->getChildByName ("names");
+            juce::XmlElement* n = xmlState->getChildByName ("names");
             if (n)
             {
                 for (auto* e : xmlState->getChildIterator())
@@ -610,24 +610,24 @@ void midiPCGUI::setStateInformation (const void* data, int sizeInBytes)
 {
     auto xmlState = getXmlFromBinary (data, sizeInBytes);
 
-    if (xmlState != 0)
+    if (xmlState != nullptr)
     {
         if (xmlState->hasTagName ("MIDIPCGUISETTINGS"))
         {
             for (int p = 0; p < getNumPrograms(); p++)
             {
-                String prefix;
+                juce::String prefix;
                 if (xmlState->getIntAttribute ("pluginVersion") < 2)
-                    prefix = "P" + String (p) + ".";
+                    prefix = "P" + juce::String (p) + ".";
                 else
-                    prefix = "P" + String (p) + "_";
+                    prefix = "P" + juce::String (p) + "_";
                 for (int i = 0; i < getNumParameters(); i++)
                 {
-                    programs[p].param[i] = (float) xmlState->getDoubleAttribute (prefix + String (i), programs[p].param[i]);
+                    programs[p].param[i] = (float) xmlState->getDoubleAttribute (prefix + juce::String (i), programs[p].param[i]);
                 }
                 programs[p].name = xmlState->getStringAttribute (prefix + "progname", programs[p].name);
             }
-            XmlElement* n = xmlState->getChildByName ("names");
+            juce::XmlElement* n = xmlState->getChildByName ("names");
             if (n)
             {
                 for (auto* e : xmlState->getChildIterator())

--- a/pizjuce/midiPCGUI/midiPCGUI.h
+++ b/pizjuce/midiPCGUI/midiPCGUI.h
@@ -1,8 +1,8 @@
 #ifndef MIDIOUTPLUGINFILTER_H
 #define MIDIOUTPLUGINFILTER_H
 
-#include "juce_core/juce_core.h"
-#include "juce_events/juce_events.h"
+#include <juce_core/juce_core.h>
+#include <juce_events/juce_events.h>
 
 #include "../_common/PizAudioProcessor.h"
 
@@ -30,16 +30,16 @@ class midiPCGUIProgram
 public:
     midiPCGUIProgram();
     ~midiPCGUIProgram(){};
-    void setName (String newName) { name = newName; }
+    void setName (juce::String newName) { name = newName; }
 
 private:
     float param[numParams];
-    String name;
+    juce::String name;
 };
 
 //==============================================================================
 class midiPCGUI : public PizAudioProcessor,
-                  public ChangeBroadcaster
+                  public juce::ChangeBroadcaster
 {
 public:
     //==============================================================================
@@ -50,15 +50,15 @@ public:
     void prepareToPlay (double sampleRate, int samplesPerBlock) override;
     void releaseResources() override;
 
-    void processBlock (AudioSampleBuffer& buffer,
-                       MidiBuffer& midiMessages) override;
+    void processBlock (juce::AudioSampleBuffer& buffer,
+                       juce::MidiBuffer& midiMessages) override;
 
     //==============================================================================
-    AudioProcessorEditor* createEditor() override;
+    juce::AudioProcessorEditor* createEditor() override;
 
     //==============================================================================
     double getTailLengthSeconds() const override { return 0; }
-    const String getName() const override { return JucePlugin_Name; }
+    const juce::String getName() const override { return JucePlugin_Name; }
     bool hasEditor() const override { return true; }
     bool acceptsMidi() const override { return true; }
     bool producesMidi() const override { return true; }
@@ -68,11 +68,11 @@ public:
     float getParameter (int index) override;
     void setParameter (int index, float newValue) override;
 
-    const String getParameterName (int index) override;
-    const String getParameterText (int index) override;
+    const juce::String getParameterName (int index) override;
+    const juce::String getParameterText (int index) override;
 
-    const String getInputChannelName (int channelIndex) const override;
-    const String getOutputChannelName (int channelIndex) const override;
+    const juce::String getInputChannelName (int channelIndex) const override;
+    const juce::String getOutputChannelName (int channelIndex) const override;
     bool isInputChannelStereoPair (int index) const override;
     bool isOutputChannelStereoPair (int index) const override;
 
@@ -80,21 +80,21 @@ public:
     int getNumPrograms() override { return 128; }
     int getCurrentProgram() override;
     void setCurrentProgram (int index) override;
-    const String getProgramName (int index) override;
-    void changeProgramName (int index, const String& newName) override;
-    void setMidiProgName (int channel, int bank, int prog, const String& newName)
+    const juce::String getProgramName (int index) override;
+    void changeProgramName (int index, const juce::String& newName) override;
+    void setMidiProgName (int channel, int bank, int prog, const juce::String& newName)
     {
         progNames.setNameFor (channel, bank, prog, newName);
     }
-    String getMidiProgName (int channel, int bank, int prog)
+    juce::String getMidiProgName (int channel, int bank, int prog)
     {
         return progNames.getNameFor (channel, bank, prog);
     }
 
     //==============================================================================
-    void getStateInformation (MemoryBlock& destData) override;
+    void getStateInformation (juce::MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
-    void getCurrentProgramStateInformation (MemoryBlock& destData) override;
+    void getCurrentProgramStateInformation (juce::MemoryBlock& destData) override;
     void setCurrentProgramStateInformation (const void* data, int sizeInBytes) override;
 
     //==============================================================================
@@ -104,13 +104,10 @@ public:
     int actualBankMSB[16];
     int actualBankLSB[16];
 
-    //==============================================================================
-    juce_UseDebuggingNewOperator
-
-        private :
-        // this is our gain - the UI and the host can access this by getting/setting
-        // parameter 0.
-        float param[numParams];
+private:
+    // this is our gain - the UI and the host can access this by getting/setting
+    // parameter 0.
+    float param[numParams];
     struct MidiProgName
     {
         MidiProgName()
@@ -118,9 +115,9 @@ public:
             channel = -1;
             bank    = -1;
             program = -1;
-            name    = String();
+            name    = juce::String();
         }
-        MidiProgName (int c, int b, int p, const String& n)
+        MidiProgName (int c, int b, int p, const juce::String& n)
         {
             channel = c;
             bank    = b;
@@ -131,7 +128,7 @@ public:
         int channel;
         int bank;
         int program;
-        String name;
+        juce::String name;
     };
 
     class ProgNames
@@ -141,7 +138,7 @@ public:
     public:
         ProgNames(){};
         ~ProgNames(){};
-        String getNameFor (int c, int b, int p)
+        juce::String getNameFor (int c, int b, int p)
         {
             for (int i = 0; i < names.size(); i++)
             {
@@ -150,10 +147,10 @@ public:
                     && names.getUnchecked (i).program == p)
                     return names.getUnchecked (i).name;
             }
-            return "Program " + String (p + 1);
+            return "Program " + juce::String (p + 1);
         }
 
-        bool getNameIfSet (int c, int b, int p, String& name)
+        bool getNameIfSet (int c, int b, int p, juce::String& name)
         {
             for (int i = 0; i < names.size(); i++)
             {
@@ -168,7 +165,7 @@ public:
             return false;
         }
 
-        void setNameFor (int c, int b, int p, String newName)
+        void setNameFor (int c, int b, int p, juce::String newName)
         {
             for (int i = 0; i < names.size(); i++)
             {
@@ -184,12 +181,12 @@ public:
         }
 
     private:
-        Array<MidiProgName> names;
+        juce::Array<MidiProgName> names;
     };
 
     ProgNames progNames;
 
-    String pluginPath;
+    juce::String pluginPath;
 
     midiPCGUIProgram* programs;
     int curProgram;
@@ -212,6 +209,8 @@ public:
     int delaytime;
     int counter;
     int triggerdelta;
+
+    JUCE_LEAK_DETECTOR (midiPCGUI)
 };
 
 #endif

--- a/pizjuce/midiPCGUI/midiPCGUIEditor.cpp
+++ b/pizjuce/midiPCGUI/midiPCGUIEditor.cpp
@@ -27,6 +27,7 @@ inline int combineBytes (int lsb, int msb)
 #include "midiPCGUIEditor.h"
 
 //[MiscUserDefs] You can add your own user definitions and misc code here...
+using juce::roundToInt;
 //[/MiscUserDefs]
 
 //==============================================================================
@@ -733,12 +734,12 @@ void midiPCGUIEditor::paint (juce::Graphics& g)
     //[UserPrePaint] Add your own custom painting code here..
     if (minimized)
     {
-        g.fillAll (Colour (0xff464646));
+        g.fillAll (juce::Colour (0xff464646));
 
-        g.setColour (Colour (0xffe6e6e6));
+        g.setColour (juce::Colour (0xffe6e6e6));
         g.fillRoundedRectangle (4.0f, 4.0f, 302.0f, 272.0f, 10.0000f);
 
-        g.setColour (Colour (0xffbababa));
+        g.setColour (juce::Colour (0xffbababa));
         g.fillRoundedRectangle (14.0f, 13.0f, 282.0f, 255.0f, 10.0000f);
     }
     else
@@ -832,8 +833,8 @@ void midiPCGUIEditor::resized()
     label6->setVisible (! minimized);
     if (minimized)
     {
-        ProgramName->setFont (Font (32.f, Font::bold));
-        PCDisplay->setFont (Font (128.f, Font::bold));
+        ProgramName->setFont (juce::Font (32.f, juce::Font::bold));
+        PCDisplay->setFont (juce::Font (128.f, juce::Font::bold));
 
         b_Inc->setBounds (159, 228, 40, 24);
         b_Dec->setBounds (119, 228, 40, 24);
@@ -844,8 +845,8 @@ void midiPCGUIEditor::resized()
     }
     else
     {
-        ProgramName->setFont (Font (18.f, Font::bold));
-        PCDisplay->setFont (Font (63.3f, Font::bold));
+        ProgramName->setFont (juce::Font (18.f, juce::Font::bold));
+        PCDisplay->setFont (juce::Font (63.3f, juce::Font::bold));
     }
     repaint();
     //[/UserResized]
@@ -1021,7 +1022,7 @@ void midiPCGUIEditor::labelTextChanged (juce::Label* labelThatHasChanged)
 
 //[MiscUserCode] You can add your own definitions of your custom methods or any other code here...
 //==============================================================================
-void midiPCGUIEditor::changeListenerCallback (ChangeBroadcaster* source)
+void midiPCGUIEditor::changeListenerCallback (juce::ChangeBroadcaster* source)
 {
     if (source == getFilter())
     {
@@ -1044,38 +1045,38 @@ void midiPCGUIEditor::updateParametersFromFilter()
     // take a local copy of the info we need while we've got the lock..
     for (int i = 0; i < numParams; i++)
         param[i] = filter->getParameter (i);
-    const int channel = roundToInt (param[kChannel] * 15.0f);
-    const int p       = filter->actualProgram[channel];
-    const int msb     = filter->actualBankMSB[channel];
-    const int lsb     = filter->actualBankLSB[channel];
-    const String name = filter->getMidiProgName (channel, combineBytes (lsb - 1, msb - 1), p - 1);
+    const int channel       = roundToInt (param[kChannel] * 15.0f);
+    const int p             = filter->actualProgram[channel];
+    const int msb           = filter->actualBankMSB[channel];
+    const int lsb           = filter->actualBankLSB[channel];
+    const juce::String name = filter->getMidiProgName (channel, combineBytes (lsb - 1, msb - 1), p - 1);
 
-    // ..release the lock ASAP
+    // release the lock ASAP
     filter->getCallbackLock().exit();
 
     // ..and after releasing the lock, we're free to do the time-consuming UI stuff..
 
     //prog name
-    ProgramName->setText (name, dontSendNotification);
+    ProgramName->setText (name, juce::dontSendNotification);
     //toggle buttons
-    b_PCListen->setToggleState (param[kPCListen] >= 0.5f, dontSendNotification);
-    b_Thru->setToggleState (param[kThru] >= 0.5f, dontSendNotification);
+    b_PCListen->setToggleState (param[kPCListen] >= 0.5f, juce::dontSendNotification);
+    b_Thru->setToggleState (param[kThru] >= 0.5f, juce::dontSendNotification);
 
     if (param[kMode] < 0.5f)
     {
         b_Mode->setButtonText ("Direct");
-        b_Mode->setToggleState (true, dontSendNotification);
-        s_Program->setColour (Slider::thumbColourId, Colours::coral);
-        s_BankMSB->setColour (Slider::thumbColourId, Colours::coral);
-        s_BankLSB->setColour (Slider::thumbColourId, Colours::coral);
+        b_Mode->setToggleState (true, juce::dontSendNotification);
+        s_Program->setColour (juce::Slider::thumbColourId, juce::Colours::coral);
+        s_BankMSB->setColour (juce::Slider::thumbColourId, juce::Colours::coral);
+        s_BankLSB->setColour (juce::Slider::thumbColourId, juce::Colours::coral);
     }
     else
     {
         b_Mode->setButtonText ("Triggered");
-        b_Mode->setToggleState (false, dontSendNotification);
-        s_Program->setColour (Slider::thumbColourId, Colour (getLookAndFeel().findColour (Slider::thumbColourId)));
-        s_BankMSB->setColour (Slider::thumbColourId, Colour (getLookAndFeel().findColour (Slider::thumbColourId)));
-        s_BankLSB->setColour (Slider::thumbColourId, Colour (getLookAndFeel().findColour (Slider::thumbColourId)));
+        b_Mode->setToggleState (false, juce::dontSendNotification);
+        s_Program->setColour (juce::Slider::thumbColourId, juce::Colour (getLookAndFeel().findColour (juce::Slider::thumbColourId)));
+        s_BankMSB->setColour (juce::Slider::thumbColourId, juce::Colour (getLookAndFeel().findColour (juce::Slider::thumbColourId)));
+        s_BankLSB->setColour (juce::Slider::thumbColourId, juce::Colour (getLookAndFeel().findColour (juce::Slider::thumbColourId)));
     }
 
     //sliders
@@ -1083,9 +1084,9 @@ void midiPCGUIEditor::updateParametersFromFilter()
     s_BankMSB->setVSTSlider (param[kBankMSB]);
     s_BankLSB->setVSTSlider (param[kBankLSB]);
     s_Channel->setVSTSlider (param[kChannel]);
-    PCDisplay->setText (String (p), dontSendNotification);
-    PCDisplay2->setText (String (msb), dontSendNotification);
-    PCDisplay3->setText (String (lsb), dontSendNotification);
+    PCDisplay->setText (juce::String (p), juce::dontSendNotification);
+    PCDisplay2->setText (juce::String (msb), juce::dontSendNotification);
+    PCDisplay3->setText (juce::String (lsb), juce::dontSendNotification);
     minimized = param[kMinimize] >= 0.5f;
 }
 //[/MiscUserCode]

--- a/pizjuce/midiPCGUI/midiPCGUIEditor.h
+++ b/pizjuce/midiPCGUI/midiPCGUIEditor.h
@@ -20,9 +20,9 @@
 #pragma once
 
 //[Headers]     -- You can add your own extra header files here --
-#include "juce_audio_processors/juce_audio_processors.h"
-#include "juce_events/juce_events.h"
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_events/juce_events.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
 #include "../_common/ClickableLabel.h"
 #include "../_common/VSTSlider.h"
@@ -51,9 +51,9 @@ public:
 
     //==============================================================================
     //[UserMethods]     -- You can add your own custom methods in this section.
-    void changeListenerCallback (ChangeBroadcaster* source) override;
-    void clickableLabelMouseDown (ClickableLabel* label, const MouseEvent& e) override {}
-    void clickableLabelMouseDoubleClick (ClickableLabel* label, const MouseEvent& e) override { label->edit(); }
+    void changeListenerCallback (juce::ChangeBroadcaster* source) override;
+    void clickableLabelMouseDown (ClickableLabel* label, const juce::MouseEvent& e) override {}
+    void clickableLabelMouseDoubleClick (ClickableLabel* label, const juce::MouseEvent& e) override { label->edit(); }
     //[/UserMethods]
 
     void paint (juce::Graphics& g) override;
@@ -66,7 +66,7 @@ private:
     //[UserVariables]   -- You can add your own custom variables in this section.
     //    ResizableCornerComponent* resizer;
     //    ComponentBoundsConstrainer resizeLimits;
-    TooltipWindow tooltipWindow;
+    juce::TooltipWindow tooltipWindow;
     void updateParametersFromFilter();
 
     bool minimized;

--- a/pizjuce/midiPads/MidiPad.cpp
+++ b/pizjuce/midiPads/MidiPad.cpp
@@ -1,5 +1,10 @@
 #include "MidiPad.h"
 
+using juce::jlimit;
+using juce::jmax;
+using juce::jmin;
+using juce::roundToInt;
+
 MidiPad::MidiPad (int _index)
     : Button ("MidiPad"),
       normalImage (nullptr),
@@ -7,8 +12,8 @@ MidiPad::MidiPad (int _index)
       text (nullptr)
 
 {
-    backgroundOff = Colour (0xffbbbbff);
-    backgroundOn  = Colour (0xff3333ff);
+    backgroundOff = juce::Colour (0xffbbbbff);
+    backgroundOn  = juce::Colour (0xff3333ff);
 
     Description  = "x:0 y:0";
     showdot      = false;
@@ -24,9 +29,9 @@ MidiPad::MidiPad (int _index)
     isPlaying    = false;
     setMouseClickGrabsKeyboardFocus (false);
 
-    addAndMakeVisible (text = new Label ("label", ""));
+    addAndMakeVisible (text = new juce::Label ("label", ""));
     text->setMouseClickGrabsKeyboardFocus (false);
-    text->setJustificationType (Justification::centredTop);
+    text->setJustificationType (juce::Justification::centredTop);
     text->setEditable (false, false, false);
     text->setInterceptsMouseClicks (false, false);
 
@@ -45,14 +50,14 @@ void MidiPad::deleteImages()
     normalImage.reset();
 }
 
-bool MidiPad::setImageFromFile (File file)
+bool MidiPad::setImageFromFile (juce::File file)
 {
     if (file.exists())
     {
         deleteImages();
 
-        normalImage = Drawable::createFromImageFile (file);
-        if (normalImage != 0)
+        normalImage = juce::Drawable::createFromImageFile (file);
+        if (normalImage != nullptr)
         {
             repaint();
         }
@@ -63,28 +68,28 @@ bool MidiPad::setImageFromFile (File file)
     return false;
 }
 
-void MidiPad::setImages (const Drawable* normal)
+void MidiPad::setImages (const juce::Drawable* normal)
 {
     deleteImages();
-    if (normal != 0)
+    if (normal != nullptr)
     {
         normalImage = normal->createCopy();
     }
     repaint();
 }
 
-void MidiPad::setIconPath (String name)
+void MidiPad::setIconPath (juce::String name)
 {
     iconPath = name;
 }
 
-String MidiPad::getIconPath()
+juce::String MidiPad::getIconPath()
 {
     return iconPath;
 }
 
-void MidiPad::setBackgroundColours (const Colour& toggledOffColour,
-                                    const Colour& toggledOnColour)
+void MidiPad::setBackgroundColours (const juce::Colour& toggledOffColour,
+                                    const juce::Colour& toggledOnColour)
 {
     if (backgroundOff != toggledOffColour) // || backgroundOn != toggledOnColour)
     {
@@ -95,15 +100,15 @@ void MidiPad::setBackgroundColours (const Colour& toggledOffColour,
     }
 }
 
-const Colour& MidiPad::getBackgroundColour() const throw()
+const juce::Colour& MidiPad::getBackgroundColour() const throw()
 {
     return getToggleState() ? backgroundOn
                             : backgroundOff;
 }
 
-void MidiPad::drawButtonBackground (Graphics& g,
+void MidiPad::drawButtonBackground (juce::Graphics& g,
                                     Button& button,
-                                    const Colour& backgroundColour,
+                                    const juce::Colour& backgroundColour,
                                     bool isMouseOverButton,
                                     bool isButtonDown)
 {
@@ -114,7 +119,7 @@ void MidiPad::drawButtonBackground (Graphics& g,
     roundness            = jlimit (0.f, 1.f, roundness);
     const int cornerSize = jmin (roundToInt (width * roundness),
                                  roundToInt (height * roundness));
-    Colour bc (backgroundColour);
+    juce::Colour bc (backgroundColour);
     if (isMouseOverButton)
     {
         if (isButtonDown)
@@ -130,31 +135,31 @@ void MidiPad::drawButtonBackground (Graphics& g,
         g.setColour (bc);
         g.fillPath (hexpath);
         g.setColour (bc.contrasting().withAlpha ((isMouseOverButton) ? 0.6f : 0.4f));
-        g.strokePath (hexpath, PathStrokeType ((isMouseOverButton) ? 2.0f : 1.4f));
+        g.strokePath (hexpath, juce::PathStrokeType ((isMouseOverButton) ? 2.0f : 1.4f));
     }
     else
     {
-        Path p;
+        juce::Path p;
         p.addRoundedRectangle (indent, indent, width - indent * 2.0f, height - indent * 2.0f, (float) cornerSize);
         g.setColour (bc);
         g.fillPath (p);
         g.setColour (bc.contrasting().withAlpha ((isMouseOverButton) ? 0.6f : 0.4f));
-        g.strokePath (p, PathStrokeType ((isMouseOverButton) ? 2.0f : 1.4f));
+        g.strokePath (p, juce::PathStrokeType ((isMouseOverButton) ? 2.0f : 1.4f));
     }
 }
 
-void MidiPad::paintButton (Graphics& g, bool isMouseOverButton, bool isButtonDown)
+void MidiPad::paintButton (juce::Graphics& g, bool isMouseOverButton, bool isButtonDown)
 {
-    Rectangle<float> imageSpace;
+    juce::Rectangle<float> imageSpace;
     const float insetX = getWidth() * (1.f - imageSize) * 0.5f;
     const float insetY = getHeight() * (1.f - imageSize) * 0.5f;
     imageSpace.setBounds (insetX, insetY, getWidth() - insetX * 2, getHeight() - insetY * 2);
     MidiPad::drawButtonBackground (g, *this, getBackgroundColour(), isMouseOverButton, isButtonDown);
 
-    g.setImageResamplingQuality (Graphics::highResamplingQuality);
+    g.setImageResamplingQuality (juce::Graphics::highResamplingQuality);
     g.setOpacity (1.0f);
 
-    const Drawable* imageToDraw = 0;
+    const juce::Drawable* imageToDraw = nullptr;
 
     if (isEnabled())
     {
@@ -172,32 +177,32 @@ void MidiPad::paintButton (Graphics& g, bool isMouseOverButton, bool isButtonDow
         //}
     }
 
-    if (imageToDraw != 0)
+    if (imageToDraw != nullptr)
     {
         imageToDraw->drawWithin (g,
                                  imageSpace,
-                                 RectanglePlacement::centred,
+                                 juce::RectanglePlacement::centred,
                                  1.f);
     }
 
     if (showvalues)
     {
         float fontsize = jmax (0.5f, jmin ((float) (proportionOfWidth (0.2f)), (float) (proportionOfHeight (0.15f))));
-        g.setFont (Font (fontsize * 0.9f, Font::plain));
+        g.setFont (juce::Font (fontsize * 0.9f, juce::Font::plain));
         g.setColour (getBackgroundColour().contrasting (0.8f));
-        String xy = String();
+        juce::String xy = juce::String();
         if (showx && showy)
-            xy = "x:" + String ((int) (x * 127.1)) + " y:" + String ((int) (y * 127.1));
+            xy = "x:" + juce::String ((int) (x * 127.1)) + " y:" + juce::String ((int) (y * 127.1));
         else if (showx)
-            xy = "x:" + String ((int) (x * 127.1));
+            xy = "x:" + juce::String ((int) (x * 127.1));
         else if (showy)
-            xy = "y:" + String ((int) (y * 127.1));
+            xy = "y:" + juce::String ((int) (y * 127.1));
         g.drawFittedText (xy,
                           proportionOfWidth (0.0447f),
                           proportionOfHeight (0.8057f),
                           proportionOfWidth (0.9137f),
                           proportionOfHeight (0.1355f),
-                          Justification::centred,
+                          juce::Justification::centred,
                           1);
     }
     if (showdot)
@@ -205,12 +210,12 @@ void MidiPad::paintButton (Graphics& g, bool isMouseOverButton, bool isButtonDow
         x              = jlimit (0.f, 1.f, x);
         y              = jlimit (0.f, 1.f, y);
         float diameter = jlimit (10.f, jmax (10.f, jmin (getHeight(), getWidth()) * 0.4f), jmax ((float) (proportionOfHeight (0.125f)), (float) (proportionOfWidth (0.125f))));
-        g.setColour (Colour (0x88faa52a));
+        g.setColour (juce::Colour (0x88faa52a));
         g.fillEllipse ((float) (proportionOfWidth (x)) - diameter * 0.5f,
                        (float) (proportionOfHeight (1.0f - y)) - diameter * 0.5f,
                        diameter,
                        diameter);
-        g.setColour (Colour (0x99a52a88));
+        g.setColour (juce::Colour (0x99a52a88));
         g.drawEllipse ((float) (proportionOfWidth (x)) - diameter * 0.5f,
                        (float) (proportionOfHeight (1.0f - y)) - diameter * 0.5f,
                        diameter,
@@ -222,12 +227,12 @@ void MidiPad::paintButton (Graphics& g, bool isMouseOverButton, bool isButtonDow
 void MidiPad::setColour (const juce::Colour& colour)
 {
     setBackgroundColours (colour, colour);
-    text->setColour (Label::textColourId, colour.contrasting (0.8f));
+    text->setColour (juce::Label::textColourId, colour.contrasting (0.8f));
 }
 
 void MidiPad::setCenteredText (bool centered)
 {
-    text->setJustificationType (centered ? Justification::centred : Justification::centredTop);
+    text->setJustificationType (centered ? juce::Justification::centred : juce::Justification::centredTop);
 }
 
 void MidiPad::resized()
@@ -245,7 +250,7 @@ void MidiPad::resized()
     }
     text->setBounds (4, 4, getWidth() - 8, getHeight() - 8);
     float fontsize = jmax (5.f, jmin ((float) (proportionOfWidth (0.2f)), (float) (proportionOfHeight (0.15f))));
-    text->setFont (Font (fontsize, Font::bold));
+    text->setFont (juce::Font (fontsize, juce::Font::bold));
 }
 
 void MidiPad::setHex (bool newhex)
@@ -254,7 +259,7 @@ void MidiPad::setHex (bool newhex)
     repaint();
 }
 
-const Drawable* MidiPad::getCurrentImage() const throw()
+const juce::Drawable* MidiPad::getCurrentImage() const throw()
 {
     //if (isDown())
     //    return getDownImage();
@@ -265,7 +270,7 @@ const Drawable* MidiPad::getCurrentImage() const throw()
     return getNormalImage();
 }
 
-const Drawable* MidiPad::getNormalImage() const throw()
+const juce::Drawable* MidiPad::getNormalImage() const throw()
 {
     return
         //(getToggleState() && normalImageOn != 0) ? normalImageOn :
@@ -308,12 +313,12 @@ bool MidiPad::hitTest (int x, int y)
         return true;
 }
 
-void MidiPad::setText (const String& name)
+void MidiPad::setText (const juce::String& name)
 {
-    text->setText (name, dontSendNotification);
+    text->setText (name, juce::dontSendNotification);
 }
 
-String MidiPad::getText()
+juce::String MidiPad::getText()
 {
     return text->getText();
 }

--- a/pizjuce/midiPads/MidiPad.h
+++ b/pizjuce/midiPads/MidiPad.h
@@ -3,13 +3,11 @@
 
 #include <memory>
 
-#include "juce_gui_basics/juce_gui_basics.h"
-
-using namespace juce;
+#include <juce_gui_basics/juce_gui_basics.h>
 
 #define midiScaler (0.007874016f)
 
-class MidiPad : public Button
+class MidiPad : public juce::Button
 {
 public:
     //==============================================================================
@@ -18,33 +16,33 @@ public:
 
     void resized() override;
     void buttonClicked (Button*);
-    void setColour (const Colour&);
+    void setColour (const juce::Colour&);
     bool isPlaying;
     void setXFloat (float v) { x = v; }
     void setYFloat (float v) { y = v; }
     void setXInt (int v) { x = v * midiScaler; }
     void setYInt (int v) { y = v * midiScaler; }
     int getIndex() { return index; }
-    String getIconPath();
-    void setIconPath (String name);
-    void setText (const String& name);
-    String getText();
+    juce::String getIconPath();
+    void setIconPath (juce::String name);
+    void setText (const juce::String& name);
+    juce::String getText();
 
     //==============================================================================
-    void setImages (const Drawable* normalImage);
-    bool setImageFromFile (File file);
+    void setImages (const juce::Drawable* normalImage);
+    bool setImageFromFile (juce::File file);
 
     //==============================================================================
-    void setBackgroundColours (const Colour& toggledOffColour,
-                               const Colour& toggledOnColour);
+    void setBackgroundColours (const juce::Colour& toggledOffColour,
+                               const juce::Colour& toggledOnColour);
 
-    const Colour& getBackgroundColour() const throw();
+    const juce::Colour& getBackgroundColour() const throw();
 
     //==============================================================================
-    const Drawable* getCurrentImage() const throw();
-    const Drawable* getNormalImage() const throw();
+    const juce::Drawable* getCurrentImage() const throw();
+    const juce::Drawable* getNormalImage() const throw();
 
-    String Description;
+    juce::String Description;
     bool showx, showy;
     float roundness;
     bool showdot;
@@ -54,17 +52,15 @@ public:
     void setHex (bool newhex);
     bool isHex();
 
-    //==============================================================================
-    juce_UseDebuggingNewOperator
+protected:
+    void
+        drawButtonBackground (juce::Graphics& g,
+                              Button& button,
+                              const juce::Colour& backgroundColour,
+                              bool isMouseOverButton,
+                              bool isButtonDown);
 
-        protected : void
-                    drawButtonBackground (Graphics& g,
-                                          Button& button,
-                                          const Colour& backgroundColour,
-                                          bool isMouseOverButton,
-                                          bool isButtonDown);
-
-    void paintButton (Graphics& g,
+    void paintButton (juce::Graphics& g,
                       bool isMouseOverButton,
                       bool isButtonDown) override;
 
@@ -74,16 +70,18 @@ private:
     float y;
     int index;
     bool hitTest (int x, int y) override;
-    std::unique_ptr<Drawable> normalImage;
-    Colour backgroundOff, backgroundOn;
-    Path hexpath;
+    std::unique_ptr<juce::Drawable> normalImage;
+    juce::Colour backgroundOff, backgroundOn;
+    juce::Path hexpath;
     bool hex;
     void deleteImages();
-    String iconPath;
-    Label* text;
+    juce::String iconPath;
+    juce::Label* text;
 
     MidiPad (const MidiPad&);
     const MidiPad& operator= (const MidiPad&);
+
+    JUCE_LEAK_DETECTOR (MidiPad)
 };
 
 #endif

--- a/pizjuce/midiPads/PadEditor.h
+++ b/pizjuce/midiPads/PadEditor.h
@@ -20,8 +20,8 @@
 #pragma once
 
 //[Headers]     -- You can add your own extra header files here --
-#include "juce_gui_basics/juce_gui_basics.h"
-#include "juce_gui_extra/juce_gui_extra.h"
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <juce_gui_extra/juce_gui_extra.h>
 //[/Headers]
 
 //==============================================================================

--- a/pizjuce/midiPads/midiPads.cpp
+++ b/pizjuce/midiPads/midiPads.cpp
@@ -1,6 +1,9 @@
 #include "midiPads.h"
 #include "midiPadsEditor.h"
 
+using juce::jlimit;
+using juce::roundToInt;
+
 //==============================================================================
 juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()
 {
@@ -14,112 +17,112 @@ MidiPadsPrograms::MidiPadsPrograms()
     //default values
     for (int p = 0; p < numPrograms; p++)
     {
-        ValueTree progv ("ProgValues");
-        progv.setProperty ("progIndex", p, 0);
+        juce::ValueTree progv ("ProgValues");
+        progv.setProperty ("progIndex", p, nullptr);
         for (int i = 0; i < numPads; i++)
         {
             x[p][i] = 0.5f;
             y[p][i] = 0.5f;
-            ValueTree pv ("PadValues");
-            pv.setProperty ("padIndex", i, 0);
-            pv.setProperty ("Ydata1", 60, 0);     //note
-            pv.setProperty ("Ycc", i, 0);         //y cc
-            pv.setProperty ("Ytype", 0, 0);       //0==note, 1==cc, 2==program change???
-            pv.setProperty ("Ydata2", 127, 0);    //data2
-            pv.setProperty ("Yoff", 0, 0);        //y off value
-            pv.setProperty ("trigger", 0, 0);     //trigger note
-            pv.setProperty ("Xcc", 1, 0);         //x cc
-            pv.setProperty ("Xoff", 64, 0);       //x off value
-            pv.setProperty ("UseX", false, 0);    // use x-position?
-            pv.setProperty ("UseY", false, 0);    // use y-position?
-            pv.setProperty ("UseYCC", false, 0);  // (don't) send y-cc with note
-            pv.setProperty ("UseXPB", false, 0);  // (don't) use x as pitch bend
-            pv.setProperty ("toggle", false, 0);  // toggle mode off
-            pv.setProperty ("SendOff", false, 0); // send off value
+            juce::ValueTree pv ("PadValues");
+            pv.setProperty ("padIndex", i, nullptr);
+            pv.setProperty ("Ydata1", 60, nullptr);     //note
+            pv.setProperty ("Ycc", i, nullptr);         //y cc
+            pv.setProperty ("Ytype", 0, nullptr);       //0==note, 1==cc, 2==program change???
+            pv.setProperty ("Ydata2", 127, nullptr);    //data2
+            pv.setProperty ("Yoff", 0, nullptr);        //y off value
+            pv.setProperty ("trigger", 0, nullptr);     //trigger note
+            pv.setProperty ("Xcc", 1, nullptr);         //x cc
+            pv.setProperty ("Xoff", 64, nullptr);       //x off value
+            pv.setProperty ("UseX", false, nullptr);    // use x-position?
+            pv.setProperty ("UseY", false, nullptr);    // use y-position?
+            pv.setProperty ("UseYCC", false, nullptr);  // (don't) send y-cc with note
+            pv.setProperty ("UseXPB", false, nullptr);  // (don't) use x as pitch bend
+            pv.setProperty ("toggle", false, nullptr);  // toggle mode off
+            pv.setProperty ("SendOff", false, nullptr); // send off value
 
-            pv.setProperty ("icon", String (i + 1) + ".svg", 0); //icon filename
-            pv.setProperty ("text", "Pad " + String (i + 1), 0); //pad name
-            pv.setProperty ("padcolor", Colour (0xFF000000).toString(), 0);
-            pv.setProperty ("roundness", 0.4f, 0);
-            pv.setProperty ("iconsize", 0.5f, 0);
-            pv.setProperty ("centeredText", false, 0);
+            pv.setProperty ("icon", juce::String (i + 1) + ".svg", nullptr); //icon filename
+            pv.setProperty ("text", "Pad " + juce::String (i + 1), nullptr); //pad name
+            pv.setProperty ("padcolor", juce::Colour (0xFF000000).toString(), nullptr);
+            pv.setProperty ("roundness", 0.4f, nullptr);
+            pv.setProperty ("iconsize", 0.5f, nullptr);
+            pv.setProperty ("centeredText", false, nullptr);
 
-            pv.setProperty ("lastx", 64, 0);
-            pv.setProperty ("lasty", 0.0f, 0);
-            pv.setProperty ("togglestate", false, 0);
-            pv.setProperty ("showdots", true, 0);
-            pv.setProperty ("showvalues", true, 0);
+            pv.setProperty ("lastx", 64, nullptr);
+            pv.setProperty ("lasty", 0.0f, nullptr);
+            pv.setProperty ("togglestate", false, nullptr);
+            pv.setProperty ("showdots", true, nullptr);
+            pv.setProperty ("showvalues", true, nullptr);
 
-            progv.addChild (pv, i, 0);
+            progv.addChild (pv, i, nullptr);
         }
 
-        ValueTree gv ("GlobalValues");
-        gv.setProperty ("VelOffset", 0.5f, 0);     // velocity offset
-        gv.setProperty ("CCOffset", 0.5f, 0);      // cc value offset
-        gv.setProperty ("ChIn", 0.0f / 15.0f, 0);  // in channel
-        gv.setProperty ("ChOut", 0.0f / 15.0f, 0); // out channel
-        gv.setProperty ("UseTrigger", 0.0f, 0);    // use triggering?
-        gv.setProperty ("NoteOnTrig", 0.0f, 0);    // "piezo trigger mode"
-        gv.setProperty ("UseVel", 1.0f, 0);        // use trigger velocity?
-        gv.setProperty ("Thru", 1.f, 0);           // midi thru?
-        gv.setProperty ("UseAft", 0.f, 0);         // send aftertouch?
-        gv.setProperty ("Mono", 0.f, 0);           // mono mode
+        juce::ValueTree gv ("GlobalValues");
+        gv.setProperty ("VelOffset", 0.5f, nullptr);     // velocity offset
+        gv.setProperty ("CCOffset", 0.5f, nullptr);      // cc value offset
+        gv.setProperty ("ChIn", 0.0f / 15.0f, nullptr);  // in channel
+        gv.setProperty ("ChOut", 0.0f / 15.0f, nullptr); // out channel
+        gv.setProperty ("UseTrigger", 0.0f, nullptr);    // use triggering?
+        gv.setProperty ("NoteOnTrig", 0.0f, nullptr);    // "piezo trigger mode"
+        gv.setProperty ("UseVel", 1.0f, nullptr);        // use trigger velocity?
+        gv.setProperty ("Thru", 1.f, nullptr);           // midi thru?
+        gv.setProperty ("UseAft", 0.f, nullptr);         // send aftertouch?
+        gv.setProperty ("Mono", 0.f, nullptr);           // mono mode
 
         //default GUI size
-        gv.setProperty ("lastUIWidth", 400, 0);
-        gv.setProperty ("lastUIHeight", 400, 0);
+        gv.setProperty ("lastUIWidth", 400, nullptr);
+        gv.setProperty ("lastUIHeight", 400, nullptr);
 
         //colors, etc
-        gv.setProperty ("bghue", 0.1f, 0);
-        gv.setProperty ("bgsat", 0.1f, 0);
-        gv.setProperty ("bgbri", 0.8f, 0);
-        gv.setProperty ("contrast", 0.3f, 0);
-        gv.setProperty ("squares", 16, 0);
-        gv.setProperty ("editmode", true, 0);
-        gv.setProperty ("usemouseup", true, 0);
-        gv.setProperty ("hex", false, 0);
+        gv.setProperty ("bghue", 0.1f, nullptr);
+        gv.setProperty ("bgsat", 0.1f, nullptr);
+        gv.setProperty ("bgbri", 0.8f, nullptr);
+        gv.setProperty ("contrast", 0.3f, nullptr);
+        gv.setProperty ("squares", 16, nullptr);
+        gv.setProperty ("editmode", true, nullptr);
+        gv.setProperty ("usemouseup", true, nullptr);
+        gv.setProperty ("hex", false, nullptr);
 
         //program name
-        gv.setProperty ("name", "Default", 0);
+        gv.setProperty ("name", "Default", nullptr);
 
-        progv.addChild (gv, numPads, 0);
+        progv.addChild (gv, numPads, nullptr);
 
-        ValueTree layout ("Layout");
+        juce::ValueTree layout ("Layout");
         for (int i = 0; i < numPads; i++)
         {
-            ValueTree padpos ("PadPosition");
-            padpos.setProperty ("visible", i < (int) gv.getProperty ("squares"), 0);
-            padpos.setProperty ("x", 0.f, 0);
-            padpos.setProperty ("y", 0.f, 0);
-            padpos.setProperty ("w", 0.1f, 0);
-            padpos.setProperty ("h", 0.1f, 0);
-            layout.addChild (padpos, i, 0);
+            juce::ValueTree padpos ("PadPosition");
+            padpos.setProperty ("visible", i < (int) gv.getProperty ("squares"), nullptr);
+            padpos.setProperty ("x", 0.f, nullptr);
+            padpos.setProperty ("y", 0.f, nullptr);
+            padpos.setProperty ("w", 0.1f, nullptr);
+            padpos.setProperty ("h", 0.1f, nullptr);
+            layout.addChild (padpos, i, nullptr);
         }
-        progv.addChild (layout, numPads + 1, 0);
+        progv.addChild (layout, numPads + 1, nullptr);
 
-        this->values_.addChild (progv, p, 0);
+        this->values_.addChild (progv, p, nullptr);
     }
 }
 
 //==============================================================================
 midiPads::midiPads()
-    : programs (0), layouts (0)
+    : programs (nullptr), layouts (nullptr)
 {
-    pluginPath = getCurrentPath() + File::getSeparatorString() + "midiPads";
-    layoutPath = pluginPath + File::getSeparatorString() + "midiPadLayouts";
-    presetPath = pluginPath + File::getSeparatorString() + "midiPadPresets";
-    bankPath   = pluginPath + File::getSeparatorString() + "midiPadBanks";
-    iconPath   = pluginPath + File::getSeparatorString() + "midiPadIcons";
+    pluginPath = getCurrentPath() + juce::File::getSeparatorString() + "midiPads";
+    layoutPath = pluginPath + juce::File::getSeparatorString() + "midiPadLayouts";
+    presetPath = pluginPath + juce::File::getSeparatorString() + "midiPadPresets";
+    bankPath   = pluginPath + juce::File::getSeparatorString() + "midiPadBanks";
+    iconPath   = pluginPath + juce::File::getSeparatorString() + "midiPadIcons";
 
     layouts = new PadLayouts();
     fillLayouts();
     programs = new MidiPadsPrograms();
 
-    if (! loadXmlBank (File (pluginPath + File::getSeparatorString()
-                             + File::getSpecialLocation (File::currentApplicationFile).getFileNameWithoutExtension() + ".mpadb")))
+    if (! loadXmlBank (juce::File (pluginPath + juce::File::getSeparatorString()
+                                   + juce::File::getSpecialLocation (juce::File::currentApplicationFile).getFileNameWithoutExtension() + ".mpadb")))
     {
-        if (! loadFxb (File (pluginPath + File::getSeparatorString()
-                             + File::getSpecialLocation (File::currentApplicationFile).getFileNameWithoutExtension() + ".fxb")))
+        if (! loadFxb (juce::File (pluginPath + juce::File::getSeparatorString()
+                                   + juce::File::getSpecialLocation (juce::File::currentApplicationFile).getFileNameWithoutExtension() + ".fxb")))
         {
             loadDefaultPrograms();
         }
@@ -150,9 +153,9 @@ midiPads::midiPads()
 midiPads::~midiPads()
 {
     if (programs)
-        deleteAndZero (programs);
+        juce::deleteAndZero (programs);
     if (layouts)
-        deleteAndZero (layouts);
+        juce::deleteAndZero (layouts);
 }
 
 //==============================================================================
@@ -180,14 +183,14 @@ void midiPads::setParameter (int index, float newValue)
     //}
 }
 
-const String midiPads::getParameterName (int index)
+const juce::String midiPads::getParameterName (int index)
 {
     for (int i = 0; i < numPads; i++)
     {
         if (index == i + xpos)
-            return "x pos " + String (i + 1);
+            return "x pos " + juce::String (i + 1);
         else if (index == i + ypos)
-            return "y pos " + String (i + 1);
+            return "y pos " + juce::String (i + 1);
     }
     if (index == kVelOffset)
         return "velocity";
@@ -210,28 +213,28 @@ const String midiPads::getParameterName (int index)
     else if (index == kSendAft)
         return "send aftertouch";
     else
-        return String();
+        return juce::String();
 }
 
-const String midiPads::getParameterText (int index)
+const juce::String midiPads::getParameterText (int index)
 {
     if (index < getNumParameters())
-        return String (param[index], 3);
-    return String();
+        return juce::String (param[index], 3);
+    return juce::String();
 }
 
-const String midiPads::getInputChannelName (const int channelIndex) const
+const juce::String midiPads::getInputChannelName (const int channelIndex) const
 {
     if (channelIndex < getNumInputChannels())
-        return String (JucePlugin_Name) + String (channelIndex + 1);
-    return String();
+        return juce::String (JucePlugin_Name) + juce::String (channelIndex + 1);
+    return juce::String();
 }
 
-const String midiPads::getOutputChannelName (const int channelIndex) const
+const juce::String midiPads::getOutputChannelName (const int channelIndex) const
 {
     if (channelIndex < getNumOutputChannels())
-        return String (JucePlugin_Name) + String (channelIndex + 1);
-    return String();
+        return juce::String (JucePlugin_Name) + juce::String (channelIndex + 1);
+    return juce::String();
 }
 
 bool midiPads::isInputChannelStereoPair (int index) const
@@ -255,7 +258,7 @@ void midiPads::setCurrentProgram (int index)
 
     //then set the new program
     curProgram = index;
-    programs->values_.setProperty ("lastProgram", index, 0);
+    programs->values_.setProperty ("lastProgram", index, nullptr);
     for (int i = 0; i < kNumGlobalParams; i++)
     {
         param[i] = programs->get (index, getGlobalParamValueName (i));
@@ -270,7 +273,7 @@ void midiPads::setCurrentProgram (int index)
         param[ypos + i] = programs->y[index][i];
         icon[i]         = programs->getForPad (index, i, "icon");
         text[i]         = programs->getForPad (index, i, "text");
-        padcolor[i]     = Colour::fromString (programs->getForPad (index, i, "padcolor").toString());
+        padcolor[i]     = juce::Colour::fromString (programs->getForPad (index, i, "padcolor").toString());
         Ydata1[i]       = programs->getForPad (index, i, "Ydata1");
         Ycc[i]          = programs->getForPad (index, i, "Ycc");
         Ytype[i]        = programs->getForPad (index, i, "Ytype");
@@ -305,12 +308,12 @@ void midiPads::setCurrentProgram (int index)
     sendChangeMessage();
 }
 
-void midiPads::changeProgramName (int index, const String& newName)
+void midiPads::changeProgramName (int index, const juce::String& newName)
 {
     programs->set (index, "name", newName);
 }
 
-const String midiPads::getProgramName (int index)
+const juce::String midiPads::getProgramName (int index)
 {
     return programs->get (index, "name");
 }
@@ -334,14 +337,14 @@ void midiPads::releaseResources()
     // spare memory, etc.
 }
 
-void midiPads::processBlock (AudioSampleBuffer& buffer, MidiBuffer& midiMessages)
+void midiPads::processBlock (juce::AudioSampleBuffer& buffer, juce::MidiBuffer& midiMessages)
 {
     for (int i = getNumInputChannels(); i < getNumOutputChannels(); ++i)
     {
         buffer.clear (i, 0, buffer.getNumSamples());
     }
 
-    MidiBuffer midiout;
+    juce::MidiBuffer midiout;
     bool discard = param[kThru] < 0.5f; // if midi thru is off, discard original message
     int outch    = (int) (param[kChOut] * 15.1f);
     for (auto&& msgMetadata : midiMessages)
@@ -465,7 +468,7 @@ void midiPads::processBlock (AudioSampleBuffer& buffer, MidiBuffer& midiMessages
                                     {
                                         if (isplaying[note])
                                         {
-                                            midiout.addEvent (MidiMessage (0x80 | outch, note, Yoff[i], 0), 0); //noteoff
+                                            midiout.addEvent (juce::MidiMessage (0x80 | outch, note, Yoff[i], 0), 0); //noteoff
                                             isplaying[note] = false;
                                         }
                                         togglestate[i] = false;
@@ -474,7 +477,7 @@ void midiPads::processBlock (AudioSampleBuffer& buffer, MidiBuffer& midiMessages
                                     {
                                         if (! isplaying[note])
                                         {
-                                            midiout.addEvent (MidiMessage (0x90 | outch, note, vel, 0), sample_number);
+                                            midiout.addEvent (juce::MidiMessage (0x90 | outch, note, vel, 0), sample_number);
                                             isplaying[note] = true;
                                         }
                                         togglestate[i] = true;
@@ -484,9 +487,9 @@ void midiPads::processBlock (AudioSampleBuffer& buffer, MidiBuffer& midiMessages
                                 {
                                     if (isplaying[note])
                                     {
-                                        midiout.addEvent (MidiMessage (0x80 | outch, note, Yoff[i], 0), 0); //noteoff
+                                        midiout.addEvent (juce::MidiMessage (0x80 | outch, note, Yoff[i], 0), 0); //noteoff
                                     }
-                                    midiout.addEvent (MidiMessage (0x90 | outch, note, vel, 0), sample_number);
+                                    midiout.addEvent (juce::MidiMessage (0x90 | outch, note, vel, 0), sample_number);
                                     isplaying[note] = true;
                                     triggered[i]    = true;
                                     trig            = true;
@@ -501,18 +504,18 @@ void midiPads::processBlock (AudioSampleBuffer& buffer, MidiBuffer& midiMessages
                                 {
                                     if (togglestate[i])
                                     {
-                                        midiout.addEvent (MidiMessage (0xB0 | outch, Ycc[i], Yoff[i], 0), 0);
+                                        midiout.addEvent (juce::MidiMessage (0xB0 | outch, Ycc[i], Yoff[i], 0), 0);
                                         togglestate[i] = false;
                                     }
                                     else
                                     {
-                                        midiout.addEvent (MidiMessage (0xB0 | outch, Ycc[i], value, 0), sample_number);
+                                        midiout.addEvent (juce::MidiMessage (0xB0 | outch, Ycc[i], value, 0), sample_number);
                                         togglestate[i] = true;
                                     }
                                 }
                                 else
                                 {
-                                    midiout.addEvent (MidiMessage (0xB0 | outch, Ycc[i], value, 0), sample_number);
+                                    midiout.addEvent (juce::MidiMessage (0xB0 | outch, Ycc[i], value, 0), sample_number);
                                     triggered[i] = true;
                                     trig         = true;
                                 }
@@ -533,14 +536,14 @@ void midiPads::processBlock (AudioSampleBuffer& buffer, MidiBuffer& midiMessages
                                     if (Ytype[i] == 0)
                                     {
                                         // note off
-                                        midiout.addEvent (MidiMessage (0x80 | outch, Ydata1[i], Yoff[i], 0), sample_number);
+                                        midiout.addEvent (juce::MidiMessage (0x80 | outch, Ydata1[i], Yoff[i], 0), sample_number);
                                         isplaying[Ydata1[i]] = false;
                                     }
                                     else
                                     {
                                         if (SendOff[i])
                                         { // if sending cc off value
-                                            midiout.addEvent (MidiMessage (0xB0 | outch, Ycc[i], Yoff[i], 0), sample_number);
+                                            midiout.addEvent (juce::MidiMessage (0xB0 | outch, Ycc[i], Yoff[i], 0), sample_number);
                                         }
                                     }
                                     triggered[i] = false;
@@ -568,7 +571,7 @@ void midiPads::processBlock (AudioSampleBuffer& buffer, MidiBuffer& midiMessages
                 if (UseXPB[i])
                 {
                     int value = jlimit (0, 16383, roundToInt ((param[i + xpos] * 16383.0f) * (getParameter (kCCOffset) * 2)));
-                    midiout.addEvent (MidiMessage (0xE0 | outch, value & 0x007f, (value & 0x3f80) >> 7, 0), 0);
+                    midiout.addEvent (juce::MidiMessage (0xE0 | outch, value & 0x007f, (value & 0x3f80) >> 7, 0), 0);
                 }
                 else
                 {
@@ -576,13 +579,13 @@ void midiPads::processBlock (AudioSampleBuffer& buffer, MidiBuffer& midiMessages
                     if (value != lastxccvalue[i])
                     {
                         lastxccvalue[i] = value;
-                        midiout.addEvent (MidiMessage (0xB0 | outch, Xcc[i], value, 0), 0);
+                        midiout.addEvent (juce::MidiMessage (0xB0 | outch, Xcc[i], value, 0), 0);
                     }
                 }
             }
             if (param[kSendAft] >= 0.5f && Ytype[i] == 0)
             {
-                midiout.addEvent (MidiMessage (0xA0 | outch, Ydata1[i], jlimit (0, 127, (int) (param[i + ypos] * 127.1f)), 0), 0);
+                midiout.addEvent (juce::MidiMessage (0xA0 | outch, Ydata1[i], jlimit (0, 127, (int) (param[i + ypos] * 127.1f)), 0), 0);
             }
             if (UseYCC[i] && Ytype[i] == 0)
             {
@@ -590,7 +593,7 @@ void midiPads::processBlock (AudioSampleBuffer& buffer, MidiBuffer& midiMessages
                 if (value != lastyccvalue[i])
                 {
                     lastyccvalue[i] = value;
-                    midiout.addEvent (MidiMessage (0xB0 | outch, Ycc[i], value, 0), 0);
+                    midiout.addEvent (juce::MidiMessage (0xB0 | outch, Ycc[i], value, 0), 0);
                 }
             }
         }
@@ -607,7 +610,7 @@ void midiPads::processBlock (AudioSampleBuffer& buffer, MidiBuffer& midiMessages
                     //    midiout.addEvent(aft_message,0);
                     //}
                     //noteoff
-                    midiout.addEvent (MidiMessage (0x80 | outch, note, Yoff[i], 0), 0);
+                    midiout.addEvent (juce::MidiMessage (0x80 | outch, note, Yoff[i], 0), 0);
                 }
                 if (param[kMono] >= 0.5f)
                 {
@@ -617,7 +620,7 @@ void midiPads::processBlock (AudioSampleBuffer& buffer, MidiBuffer& midiMessages
                         if (isplaying[n])
                         {
                             //noteoff
-                            midiout.addEvent (MidiMessage (0x80 | outch, n, 0, 0), 0);
+                            midiout.addEvent (juce::MidiMessage (0x80 | outch, n, 0, 0), 0);
                             isplaying[n] = false;
                         }
                     }
@@ -629,11 +632,11 @@ void midiPads::processBlock (AudioSampleBuffer& buffer, MidiBuffer& midiMessages
                     vel = jlimit (0, 127, (int) ((param[i + ypos] * 127.1) * (getParameter (kVelOffset) * 2)));
                 else
                     vel = jlimit (0, 127, (int) (Ydata2[i] * (getParameter (kVelOffset) * 2)));
-                midiout.addEvent (MidiMessage (0x90 | outch, note, vel, 0), 1); //noteon
+                midiout.addEvent (juce::MidiMessage (0x90 | outch, note, vel, 0), 1); //noteon
                 isplaying[note] = true;
                 if (param[kSendAft] >= 0.5f)
                 {
-                    midiout.addEvent (MidiMessage (0xA0 | outch, note, jlimit (0, 127, (int) (param[i + ypos] * 127.1f)), 0), 2);
+                    midiout.addEvent (juce::MidiMessage (0xA0 | outch, note, jlimit (0, 127, (int) (param[i + ypos] * 127.1f)), 0), 2);
                 }
                 if (UseYCC[i])
                 {
@@ -645,7 +648,7 @@ void midiPads::processBlock (AudioSampleBuffer& buffer, MidiBuffer& midiMessages
                     if (val != lastyccvalue[i])
                     {
                         lastyccvalue[i] = val;
-                        midiout.addEvent (MidiMessage (0xB0 | outch, Ycc[i], val, 0), 2);
+                        midiout.addEvent (juce::MidiMessage (0xB0 | outch, Ycc[i], val, 0), 2);
                     }
                 }
             }
@@ -657,13 +660,13 @@ void midiPads::processBlock (AudioSampleBuffer& buffer, MidiBuffer& midiMessages
                     if (value != lastyccvalue[i])
                     {
                         lastyccvalue[i] = value;
-                        midiout.addEvent (MidiMessage (0xB0 | outch, Ycc[i], value, 0), 0);
+                        midiout.addEvent (juce::MidiMessage (0xB0 | outch, Ycc[i], value, 0), 0);
                     }
                 }
                 else if (! UseX[i])
                 {
                     int value = jlimit (0, 127, (int) (Ydata2[i] * (getParameter (kCCOffset) * 2)));
-                    midiout.addEvent (MidiMessage (0xB0 | outch, Ycc[i], value, 0), 0); //on value
+                    midiout.addEvent (juce::MidiMessage (0xB0 | outch, Ycc[i], value, 0), 0); //on value
                 }
             }
         }
@@ -674,24 +677,24 @@ void midiPads::processBlock (AudioSampleBuffer& buffer, MidiBuffer& midiMessages
             {
                 //x-off value
                 if (UseXPB[i])
-                    midiout.addEvent (MidiMessage (0xE0 | outch, 0, Xoff[i], 0), 0);
+                    midiout.addEvent (juce::MidiMessage (0xE0 | outch, 0, Xoff[i], 0), 0);
                 else
-                    midiout.addEvent (MidiMessage (0xB0 | outch, Xcc[i], Xoff[i], 0), 0);
+                    midiout.addEvent (juce::MidiMessage (0xB0 | outch, Xcc[i], Xoff[i], 0), 0);
             }
             if (Ytype[i] == 0)
             {
                 int note = Ydata1[i];
                 if (param[kSendAft] >= 0.5f)
-                    midiout.addEvent (MidiMessage (0xA0 | outch, note, 0, 0), 0);
+                    midiout.addEvent (juce::MidiMessage (0xA0 | outch, note, 0, 0), 0);
                 if (UseYCC[i] && SendOff[i])
-                    midiout.addEvent (MidiMessage (0xB0 | outch, Ycc[i], Yoff[i], 0), 0); //y-off value
-                midiout.addEvent (MidiMessage (0x80 | outch, note, Yoff[i], 0), 0);       //noteoff
+                    midiout.addEvent (juce::MidiMessage (0xB0 | outch, Ycc[i], Yoff[i], 0), 0); //y-off value
+                midiout.addEvent (juce::MidiMessage (0x80 | outch, note, Yoff[i], 0), 0);       //noteoff
                 isplaying[note] = false;
             }
             else
             {
                 if ((SendOff[i] || toggle[i]) && ((! UseX[i]) || UseY[i]))
-                    midiout.addEvent (MidiMessage (0xB0 | outch, Ycc[i], Yoff[i], 0), 0); //y-off value
+                    midiout.addEvent (juce::MidiMessage (0xB0 | outch, Ycc[i], Yoff[i], 0), 0); //y-off value
             }
         }
     }
@@ -699,7 +702,7 @@ void midiPads::processBlock (AudioSampleBuffer& buffer, MidiBuffer& midiMessages
     midiMessages = midiout;
 }
 //==============================================================================
-AudioProcessorEditor* midiPads::createEditor()
+juce::AudioProcessorEditor* midiPads::createEditor()
 {
     return new midiPadsEditor (this);
 }
@@ -747,10 +750,10 @@ void midiPads::copySettingsToProgram (int index)
 }
 
 //==============================================================================
-void midiPads::getCurrentProgramStateInformation (MemoryBlock& destData)
+void midiPads::getCurrentProgramStateInformation (juce::MemoryBlock& destData)
 {
     copySettingsToProgram (curProgram);
-    MemoryOutputStream stream (destData, false);
+    juce::MemoryOutputStream stream (destData, false);
     programs->values_.getChild (curProgram).writeToStream (stream);
     //programs->values_.getChild(curProgram).writeToStream(MemoryOutputStream(262144,256,&destData));
 }
@@ -758,7 +761,7 @@ void midiPads::getCurrentProgramStateInformation (MemoryBlock& destData)
 void midiPads::getStateInformation (juce::MemoryBlock& destData)
 {
     copySettingsToProgram (curProgram);
-    MemoryOutputStream stream (destData, false);
+    juce::MemoryOutputStream stream (destData, false);
     programs->values_.writeToStream (stream);
     //programs->values_.writeToStream(MemoryOutputStream(262144,256,&destData));
 }
@@ -767,7 +770,7 @@ void midiPads::setCurrentProgramStateInformation (const void* data, int sizeInBy
 {
     //check for old format
     auto xmlState (getXmlFromBinary (data, sizeInBytes));
-    if (xmlState != 0)
+    if (xmlState != nullptr)
     {
         // check that it's the right type of xml..
         if (xmlState->hasTagName ("MYPLUGINSETTINGS"))
@@ -776,7 +779,7 @@ void midiPads::setCurrentProgramStateInformation (const void* data, int sizeInBy
             changeProgramName (getCurrentProgram(), xmlState->getStringAttribute ("progname", "Default"));
             for (int i = 0; i < kNumGlobalParams; i++)
             {
-                param[i] = (float) xmlState->getDoubleAttribute (String (i), param[i]);
+                param[i] = (float) xmlState->getDoubleAttribute (juce::String (i), param[i]);
             }
             lastUIWidth  = xmlState->getIntAttribute ("uiWidth", lastUIWidth);
             lastUIHeight = xmlState->getIntAttribute ("uiHeight", lastUIHeight);
@@ -848,38 +851,38 @@ void midiPads::setCurrentProgramStateInformation (const void* data, int sizeInBy
                 iconsize[i]     = 0.5f;
                 roundness[i]    = (float) xmlState->getDoubleAttribute ("roundness", roundness[i]);
                 showdots[i]     = xmlState->getBoolAttribute ("showdots", showdots[i]);
-                showdots[i]     = xmlState->getBoolAttribute ("showdots" + String (i), showdots[i]);
-                showvalues[i]   = xmlState->getBoolAttribute ("showvalues" + String (i), showvalues[i]);
-                icon[i]         = xmlState->getStringAttribute ("icon" + String (i), icon[i]);
-                text[i]         = xmlState->getStringAttribute ("text" + String (i), text[i]);
-                padcolor[i]     = Colour (xmlState->getIntAttribute ("padcolor" + String (i), padcolor[i].getARGB()));
-                Ydata1[i]       = (int) (127.1 * xmlState->getDoubleAttribute ("Ydata1" + String (i), Ydata1[i] * midiScaler));
-                Ycc[i]          = (int) (127.1 * xmlState->getDoubleAttribute ("Ycc" + String (i), Ycc[i] * midiScaler));
-                Ytype[i]        = roundToInt (xmlState->getDoubleAttribute ("Ytype" + String (i), Ytype[i]));
-                Ydata2[i]       = (int) (127.1 * xmlState->getDoubleAttribute ("Ydata2" + String (i), Ydata2[i] * midiScaler));
-                Yoff[i]         = (int) (127.1 * xmlState->getDoubleAttribute ("Yoff" + String (i), Yoff[i] * midiScaler));
-                trigger[i]      = (int) (127.1 * xmlState->getDoubleAttribute ("trigger" + String (i), trigger[i] * midiScaler));
-                Xcc[i]          = (int) (127.1 * xmlState->getDoubleAttribute ("Xcc" + String (i), Xcc[i] * midiScaler));
-                Xoff[i]         = (int) (127.1 * xmlState->getDoubleAttribute ("Xoff" + String (i), Xoff[i] * midiScaler));
-                SendOff[i]      = xmlState->getBoolAttribute ("SendOff" + String (i), SendOff[i]);
-                UseX[i]         = xmlState->getDoubleAttribute ("UseX" + String (i), UseX[i]) >= 0.5f;
-                UseY[i]         = xmlState->getDoubleAttribute ("UseY" + String (i), UseY[i]) >= 0.5f;
-                UseYCC[i]       = xmlState->getBoolAttribute ("UseYCC" + String (i), UseYCC[i]);
-                UseXPB[i]       = xmlState->getBoolAttribute ("UseXPB" + String (i), UseXPB[i]);
-                lastx[i]        = xmlState->getIntAttribute ("lastx" + String (i), lastx[i]);
-                lasty[i]        = xmlState->getIntAttribute ("lasty" + String (i), lasty[i]);
-                toggle[i]       = xmlState->getBoolAttribute ("toggle" + String (i), toggle[i]);
-                togglestate[i]  = xmlState->getBoolAttribute ("togglestate" + String (i), togglestate[i]);
+                showdots[i]     = xmlState->getBoolAttribute ("showdots" + juce::String (i), showdots[i]);
+                showvalues[i]   = xmlState->getBoolAttribute ("showvalues" + juce::String (i), showvalues[i]);
+                icon[i]         = xmlState->getStringAttribute ("icon" + juce::String (i), icon[i]);
+                text[i]         = xmlState->getStringAttribute ("text" + juce::String (i), text[i]);
+                padcolor[i]     = juce::Colour (xmlState->getIntAttribute ("padcolor" + juce::String (i), padcolor[i].getARGB()));
+                Ydata1[i]       = (int) (127.1 * xmlState->getDoubleAttribute ("Ydata1" + juce::String (i), Ydata1[i] * midiScaler));
+                Ycc[i]          = (int) (127.1 * xmlState->getDoubleAttribute ("Ycc" + juce::String (i), Ycc[i] * midiScaler));
+                Ytype[i]        = roundToInt (xmlState->getDoubleAttribute ("Ytype" + juce::String (i), Ytype[i]));
+                Ydata2[i]       = (int) (127.1 * xmlState->getDoubleAttribute ("Ydata2" + juce::String (i), Ydata2[i] * midiScaler));
+                Yoff[i]         = (int) (127.1 * xmlState->getDoubleAttribute ("Yoff" + juce::String (i), Yoff[i] * midiScaler));
+                trigger[i]      = (int) (127.1 * xmlState->getDoubleAttribute ("trigger" + juce::String (i), trigger[i] * midiScaler));
+                Xcc[i]          = (int) (127.1 * xmlState->getDoubleAttribute ("Xcc" + juce::String (i), Xcc[i] * midiScaler));
+                Xoff[i]         = (int) (127.1 * xmlState->getDoubleAttribute ("Xoff" + juce::String (i), Xoff[i] * midiScaler));
+                SendOff[i]      = xmlState->getBoolAttribute ("SendOff" + juce::String (i), SendOff[i]);
+                UseX[i]         = xmlState->getDoubleAttribute ("UseX" + juce::String (i), UseX[i]) >= 0.5f;
+                UseY[i]         = xmlState->getDoubleAttribute ("UseY" + juce::String (i), UseY[i]) >= 0.5f;
+                UseYCC[i]       = xmlState->getBoolAttribute ("UseYCC" + juce::String (i), UseYCC[i]);
+                UseXPB[i]       = xmlState->getBoolAttribute ("UseXPB" + juce::String (i), UseXPB[i]);
+                lastx[i]        = xmlState->getIntAttribute ("lastx" + juce::String (i), lastx[i]);
+                lasty[i]        = xmlState->getIntAttribute ("lasty" + juce::String (i), lasty[i]);
+                toggle[i]       = xmlState->getBoolAttribute ("toggle" + juce::String (i), toggle[i]);
+                togglestate[i]  = xmlState->getBoolAttribute ("togglestate" + juce::String (i), togglestate[i]);
             }
             sendChangeMessage();
         }
     }
     else
     {
-        programs->values_.removeChild (programs->values_.getChild (curProgram), 0);
-        MemoryInputStream stream (data, sizeInBytes, false);
-        programs->values_.addChild (ValueTree::readFromStream (stream), curProgram, 0);
-        programs->values_.getChild (curProgram).setProperty ("progIndex", curProgram, 0);
+        programs->values_.removeChild (programs->values_.getChild (curProgram), nullptr);
+        juce::MemoryInputStream stream (data, sizeInBytes, false);
+        programs->values_.addChild (juce::ValueTree::readFromStream (stream), curProgram, nullptr);
+        programs->values_.getChild (curProgram).setProperty ("progIndex", curProgram, nullptr);
         init = true;
         setCurrentProgram (curProgram);
     }
@@ -889,16 +892,16 @@ void midiPads::setStateInformation (const void* data, int sizeInBytes)
 {
     //check for old format
     auto const xmlState (getXmlFromBinary (data, sizeInBytes));
-    if (xmlState != 0)
+    if (xmlState != nullptr)
     {
         if (xmlState->hasTagName ("MYPLUGINSETTINGS"))
         {
             for (int p = 0; p < getNumPrograms(); p++)
             {
-                String prefix = "P" + String (p) + ".";
+                juce::String prefix = "P" + juce::String (p) + ".";
                 for (int i = 0; i < kNumGlobalParams; i++)
                 {
-                    programs->set (p, getGlobalParamValueName (i), (float) xmlState->getDoubleAttribute (prefix + String (i), programs->get (p, getGlobalParamValueName (i))));
+                    programs->set (p, getGlobalParamValueName (i), (float) xmlState->getDoubleAttribute (prefix + juce::String (i), programs->get (p, getGlobalParamValueName (i))));
                 }
                 programs->set (p, "lastUIWidth", xmlState->getIntAttribute (prefix + "uiWidth", programs->get (p, "lastUIWidth")));
                 programs->set (p, "lastUIHeight", xmlState->getIntAttribute (prefix + "uiHeight", programs->get (p, "lastUIHeight")));
@@ -966,31 +969,31 @@ void midiPads::setStateInformation (const void* data, int sizeInBytes)
                 for (int i = 0; i < (int) (programs->get (p, "squares")); i++)
                 {
                     programs->setForPad (p, i, "showdots", xmlState->getBoolAttribute (prefix + "showdots", programs->getForPad (p, i, "showdots")));
-                    programs->setForPad (p, i, "showdots", xmlState->getBoolAttribute (prefix + "showdots" + String (i), programs->getForPad (p, i, "showdots")));
-                    programs->setForPad (p, i, "showvalues", xmlState->getBoolAttribute (prefix + "showvalues" + String (i), programs->getForPad (p, i, "showvalues")));
+                    programs->setForPad (p, i, "showdots", xmlState->getBoolAttribute (prefix + "showdots" + juce::String (i), programs->getForPad (p, i, "showdots")));
+                    programs->setForPad (p, i, "showvalues", xmlState->getBoolAttribute (prefix + "showvalues" + juce::String (i), programs->getForPad (p, i, "showvalues")));
                     programs->setForPad (p, i, "iconsize", 0.5f);
                     programs->setForPad (p, i, "centeredText", false);
                     programs->setForPad (p, i, "roundness", (float) xmlState->getDoubleAttribute (prefix + "roundness", programs->getForPad (p, i, "roundness")));
-                    programs->setForPad (p, i, "icon", xmlState->getStringAttribute (prefix + "icon" + String (i), programs->getForPad (p, i, "icon")));
-                    programs->setForPad (p, i, "text", xmlState->getStringAttribute (prefix + "text" + String (i), programs->getForPad (p, i, "text")));
-                    programs->setForPad (p, i, "padcolor", Colour (xmlState->getIntAttribute (prefix + "padcolor" + String (i), Colour::fromString (programs->getForPad (p, i, "padcolor").toString()).getARGB())).toString());
-                    programs->setForPad (p, i, "Ydata1", (int) (127.1 * xmlState->getDoubleAttribute (prefix + "Ydata1" + String (i), programs->getForPad (p, i, "Ydata1"))));
-                    programs->setForPad (p, i, "Ycc", (int) (127.1 * xmlState->getDoubleAttribute (prefix + "Ycc" + String (i), programs->getForPad (p, i, "Ycc"))));
-                    programs->setForPad (p, i, "Ytype", roundToInt (xmlState->getDoubleAttribute (prefix + "Ytype" + String (i), programs->getForPad (p, i, "Ytype"))));
-                    programs->setForPad (p, i, "Ydata2", (int) (127.1 * xmlState->getDoubleAttribute (prefix + "Ydata2" + String (i), programs->getForPad (p, i, "Ydata2"))));
-                    programs->setForPad (p, i, "Yoff", (int) (127.1 * xmlState->getDoubleAttribute (prefix + "Yoff" + String (i), programs->getForPad (p, i, "Yoff"))));
-                    programs->setForPad (p, i, "trigger", (int) (127.1 * xmlState->getDoubleAttribute (prefix + "trigger" + String (i), programs->getForPad (p, i, "trigger"))));
-                    programs->setForPad (p, i, "Xcc", (int) (127.1 * xmlState->getDoubleAttribute (prefix + "Xcc" + String (i), programs->getForPad (p, i, "Xcc"))));
-                    programs->setForPad (p, i, "Xoff", (int) (127.1 * xmlState->getDoubleAttribute (prefix + "Xoff" + String (i), programs->getForPad (p, i, "Xoff"))));
-                    programs->setForPad (p, i, "SendOff", xmlState->getBoolAttribute (prefix + "SendOff" + String (i), programs->getForPad (p, i, "SendOff")));
-                    programs->setForPad (p, i, "UseX", xmlState->getDoubleAttribute (prefix + "UseX" + String (i), programs->getForPad (p, i, "UseX")) >= 0.5f);
-                    programs->setForPad (p, i, "UseY", xmlState->getDoubleAttribute (prefix + "UseY" + String (i), programs->getForPad (p, i, "UseY")) >= 0.5f);
-                    programs->setForPad (p, i, "UseYCC", xmlState->getBoolAttribute (prefix + "UseYCC" + String (i), programs->getForPad (p, i, "UseYCC")));
-                    programs->setForPad (p, i, "UseXPB", xmlState->getBoolAttribute (prefix + "UseXPB" + String (i), programs->getForPad (p, i, "UseXPB")));
-                    programs->setForPad (p, i, "lastx", xmlState->getIntAttribute (prefix + "lastx" + String (i), programs->getForPad (p, i, "lastx")));
-                    programs->setForPad (p, i, "lasty", xmlState->getIntAttribute (prefix + "lasty" + String (i), programs->getForPad (p, i, "lasty")));
-                    programs->setForPad (p, i, "toggle", xmlState->getBoolAttribute (prefix + "toggle" + String (i), programs->getForPad (p, i, "toggle")));
-                    programs->setForPad (p, i, "togglestate", xmlState->getBoolAttribute (prefix + "togglestate" + String (i), programs->getForPad (p, i, "togglestate")));
+                    programs->setForPad (p, i, "icon", xmlState->getStringAttribute (prefix + "icon" + juce::String (i), programs->getForPad (p, i, "icon")));
+                    programs->setForPad (p, i, "text", xmlState->getStringAttribute (prefix + "text" + juce::String (i), programs->getForPad (p, i, "text")));
+                    programs->setForPad (p, i, "padcolor", juce::Colour (xmlState->getIntAttribute (prefix + "padcolor" + juce::String (i), juce::Colour::fromString (programs->getForPad (p, i, "padcolor").toString()).getARGB())).toString());
+                    programs->setForPad (p, i, "Ydata1", (int) (127.1 * xmlState->getDoubleAttribute (prefix + "Ydata1" + juce::String (i), programs->getForPad (p, i, "Ydata1"))));
+                    programs->setForPad (p, i, "Ycc", (int) (127.1 * xmlState->getDoubleAttribute (prefix + "Ycc" + juce::String (i), programs->getForPad (p, i, "Ycc"))));
+                    programs->setForPad (p, i, "Ytype", roundToInt (xmlState->getDoubleAttribute (prefix + "Ytype" + juce::String (i), programs->getForPad (p, i, "Ytype"))));
+                    programs->setForPad (p, i, "Ydata2", (int) (127.1 * xmlState->getDoubleAttribute (prefix + "Ydata2" + juce::String (i), programs->getForPad (p, i, "Ydata2"))));
+                    programs->setForPad (p, i, "Yoff", (int) (127.1 * xmlState->getDoubleAttribute (prefix + "Yoff" + juce::String (i), programs->getForPad (p, i, "Yoff"))));
+                    programs->setForPad (p, i, "trigger", (int) (127.1 * xmlState->getDoubleAttribute (prefix + "trigger" + juce::String (i), programs->getForPad (p, i, "trigger"))));
+                    programs->setForPad (p, i, "Xcc", (int) (127.1 * xmlState->getDoubleAttribute (prefix + "Xcc" + juce::String (i), programs->getForPad (p, i, "Xcc"))));
+                    programs->setForPad (p, i, "Xoff", (int) (127.1 * xmlState->getDoubleAttribute (prefix + "Xoff" + juce::String (i), programs->getForPad (p, i, "Xoff"))));
+                    programs->setForPad (p, i, "SendOff", xmlState->getBoolAttribute (prefix + "SendOff" + juce::String (i), programs->getForPad (p, i, "SendOff")));
+                    programs->setForPad (p, i, "UseX", xmlState->getDoubleAttribute (prefix + "UseX" + juce::String (i), programs->getForPad (p, i, "UseX")) >= 0.5f);
+                    programs->setForPad (p, i, "UseY", xmlState->getDoubleAttribute (prefix + "UseY" + juce::String (i), programs->getForPad (p, i, "UseY")) >= 0.5f);
+                    programs->setForPad (p, i, "UseYCC", xmlState->getBoolAttribute (prefix + "UseYCC" + juce::String (i), programs->getForPad (p, i, "UseYCC")));
+                    programs->setForPad (p, i, "UseXPB", xmlState->getBoolAttribute (prefix + "UseXPB" + juce::String (i), programs->getForPad (p, i, "UseXPB")));
+                    programs->setForPad (p, i, "lastx", xmlState->getIntAttribute (prefix + "lastx" + juce::String (i), programs->getForPad (p, i, "lastx")));
+                    programs->setForPad (p, i, "lasty", xmlState->getIntAttribute (prefix + "lasty" + juce::String (i), programs->getForPad (p, i, "lasty")));
+                    programs->setForPad (p, i, "toggle", xmlState->getBoolAttribute (prefix + "toggle" + juce::String (i), programs->getForPad (p, i, "toggle")));
+                    programs->setForPad (p, i, "togglestate", xmlState->getBoolAttribute (prefix + "togglestate" + juce::String (i), programs->getForPad (p, i, "togglestate")));
                 }
                 programs->set (p, "name", xmlState->getStringAttribute (prefix + "progname", programs->get (p, "name")));
             }
@@ -1000,14 +1003,14 @@ void midiPads::setStateInformation (const void* data, int sizeInBytes)
     }
     else
     {
-        MemoryInputStream stream (data, sizeInBytes, false);
-        ValueTree vt = ValueTree::readFromStream (stream);
+        juce::MemoryInputStream stream (data, sizeInBytes, false);
+        juce::ValueTree vt = juce::ValueTree::readFromStream (stream);
         if (vt.isValid())
         {
-            programs->values_.removeAllChildren (0);
+            programs->values_.removeAllChildren (nullptr);
             for (int i = 0; i < vt.getNumChildren(); i++)
             {
-                programs->values_.addChild (vt.getChild (i).createCopy(), i, 0);
+                programs->values_.addChild (vt.getChild (i).createCopy(), i, nullptr);
             }
         }
         init = true;
@@ -1015,29 +1018,29 @@ void midiPads::setStateInformation (const void* data, int sizeInBytes)
     }
 }
 
-void midiPads::saveXmlPatch (int index, File file)
+void midiPads::saveXmlPatch (int index, juce::File file)
 {
     copySettingsToProgram (curProgram);
     auto xml (programs->values_.getChild (index).createXml());
     xml->writeTo (file);
 }
 
-void midiPads::saveXmlBank (File file)
+void midiPads::saveXmlBank (juce::File file)
 {
     copySettingsToProgram (curProgram);
     auto xml (programs->values_.createXml());
     xml->writeTo (file);
 }
 
-bool midiPads::loadXmlPatch (int index, File file)
+bool midiPads::loadXmlPatch (int index, juce::File file)
 {
     if (! file.exists())
         return false;
-    XmlDocument xmldoc (file.loadFileAsString());
+    juce::XmlDocument xmldoc (file.loadFileAsString());
     auto xmlState (xmldoc.getDocumentElement());
-    programs->values_.removeChild (programs->values_.getChild (index), 0);
-    programs->values_.addChild (ValueTree::fromXml (*xmlState), index, 0);
-    programs->values_.getChild (index).setProperty ("progIndex", index, 0);
+    programs->values_.removeChild (programs->values_.getChild (index), nullptr);
+    programs->values_.addChild (juce::ValueTree::fromXml (*xmlState), index, nullptr);
+    programs->values_.getChild (index).setProperty ("progIndex", index, nullptr);
     if (curProgram == index)
     {
         init = true;
@@ -1046,20 +1049,20 @@ bool midiPads::loadXmlPatch (int index, File file)
     return true;
 }
 
-bool midiPads::loadXmlBank (File file)
+bool midiPads::loadXmlBank (juce::File file)
 {
     if (! file.exists())
         return false;
-    String xml = file.loadFileAsString();
-    XmlDocument xmldoc (xml);
+    juce::String xml = file.loadFileAsString();
+    juce::XmlDocument xmldoc (xml);
     auto xmlState (xmldoc.getDocumentElement());
-    ValueTree vt = ValueTree::fromXml (*xmlState);
+    juce::ValueTree vt = juce::ValueTree::fromXml (*xmlState);
     if (vt.isValid())
     {
-        programs->values_.removeAllChildren (0);
+        programs->values_.removeAllChildren (nullptr);
         for (int i = 0; i < vt.getNumChildren(); i++)
         {
-            programs->values_.addChild (vt.getChild (i).createCopy(), i, 0);
+            programs->values_.addChild (vt.getChild (i).createCopy(), i, nullptr);
         }
     }
     init = true;
@@ -1067,11 +1070,11 @@ bool midiPads::loadXmlBank (File file)
     return true;
 }
 
-bool midiPads::loadFxb (File file)
+bool midiPads::loadFxb (juce::File file)
 {
     if (! file.exists())
         return false;
-    MemoryBlock bank = MemoryBlock (0, true);
+    juce::MemoryBlock bank = juce::MemoryBlock (0, true);
     file.loadFileAsData (bank);
     bank.removeSection (0, 16);
     if (! strncmp ((char*) bank.getData(), "m16p", 4))
@@ -1084,11 +1087,11 @@ bool midiPads::loadFxb (File file)
     return false;
 }
 
-bool midiPads::loadFxp (File file)
+bool midiPads::loadFxp (juce::File file)
 {
     if (! file.exists())
         return false;
-    MemoryBlock data = MemoryBlock (0, true);
+    juce::MemoryBlock data = juce::MemoryBlock (0, true);
     file.loadFileAsData (data);
     data.removeSection (0, 16);
     if (! strncmp ((char*) data.getData(), "m16p", 4))
@@ -1100,22 +1103,22 @@ bool midiPads::loadFxp (File file)
     return false;
 }
 
-void midiPads::saveXmlLayout (File file)
+void midiPads::saveXmlLayout (juce::File file)
 {
     auto xml (programs->values_.getChild (curProgram).getChildWithName ("Layout").createXml());
     xml->writeTo (file);
 }
 
-void midiPads::loadXmlLayout (File file)
+void midiPads::loadXmlLayout (juce::File file)
 {
     if (file.exists())
     {
-        XmlDocument xmldoc (file.loadFileAsString());
+        juce::XmlDocument xmldoc (file.loadFileAsString());
         auto xmlState (xmldoc.getDocumentElement());
-        ValueTree program = programs->values_.getChild (curProgram);
-        int index         = program.indexOf (program.getChildWithName ("Layout"));
-        program.removeChild (index, 0);
-        program.addChild (ValueTree::fromXml (*xmlState), index, 0);
+        juce::ValueTree program = programs->values_.getChild (curProgram);
+        int index               = program.indexOf (program.getChildWithName ("Layout"));
+        program.removeChild (index, nullptr);
+        program.addChild (juce::ValueTree::fromXml (*xmlState), index, nullptr);
     }
 }
 
@@ -1154,58 +1157,58 @@ void midiPads::fillLayouts()
     {
         if (onepad == i)
         {
-            ValueTree layout ("Layout");
-            layout.setProperty ("name", "1 Pad", 0);
+            juce::ValueTree layout ("Layout");
+            layout.setProperty ("name", "1 Pad", nullptr);
             for (int p = 0; p < numPads; p++)
             {
-                ValueTree padpos ("PadPosition");
-                padpos.setProperty ("visible", p == 0, 0);
-                layout.addChild (padpos, p, 0);
+                juce::ValueTree padpos ("PadPosition");
+                padpos.setProperty ("visible", p == 0, nullptr);
+                layout.addChild (padpos, p, nullptr);
             }
             PadLayouts::setPadLayout (layout.getChild (0), 0.0151f, 0.0649f, 0.9698f, 0.9243f);
-            layouts->values_.addChild (layout, i, 0);
+            layouts->values_.addChild (layout, i, nullptr);
         }
         else if (fourpads == i)
         {
-            ValueTree layout ("Layout");
-            layout.setProperty ("name", "4 Pads", 0);
+            juce::ValueTree layout ("Layout");
+            layout.setProperty ("name", "4 Pads", nullptr);
             for (int p = 0; p < numPads; p++)
             {
-                ValueTree padpos ("PadPosition");
-                padpos.setProperty ("visible", p < 4, 0);
-                layout.addChild (padpos, p, 0);
+                juce::ValueTree padpos ("PadPosition");
+                padpos.setProperty ("visible", p < 4, nullptr);
+                layout.addChild (padpos, p, nullptr);
             }
             PadLayouts::setPadLayout (layout.getChild (0), 0.01f, 0.0603f, 0.4799f, 0.4606f);
             PadLayouts::setPadLayout (layout.getChild (1), 0.51f, 0.0603f, 0.4799f, 0.4606f);
             PadLayouts::setPadLayout (layout.getChild (2), 0.01f, 0.5301f, 0.4799f, 0.4606f);
             PadLayouts::setPadLayout (layout.getChild (3), 0.51f, 0.5301f, 0.4799f, 0.4606f);
-            layouts->values_.addChild (layout, i, 0);
+            layouts->values_.addChild (layout, i, nullptr);
         }
         else if (foursliders == i)
         {
-            ValueTree layout ("Layout");
-            layout.setProperty ("name", "4 Sliders", 0);
+            juce::ValueTree layout ("Layout");
+            layout.setProperty ("name", "4 Sliders", nullptr);
             for (int p = 0; p < numPads; p++)
             {
-                ValueTree padpos ("PadPosition");
-                padpos.setProperty ("visible", p < 4, 0);
-                layout.addChild (padpos, p, 0);
+                juce::ValueTree padpos ("PadPosition");
+                padpos.setProperty ("visible", p < 4, nullptr);
+                layout.addChild (padpos, p, nullptr);
             }
             PadLayouts::setPadLayout (layout.getChild (0), 0.0192f, 0.0649f, 0.23f, 0.921f);
             PadLayouts::setPadLayout (layout.getChild (1), 0.2636f, 0.0649f, 0.23f, 0.921f);
             PadLayouts::setPadLayout (layout.getChild (2), 0.5064f, 0.0649f, 0.23f, 0.921f);
             PadLayouts::setPadLayout (layout.getChild (3), 0.7508f, 0.0649f, 0.23f, 0.921f);
-            layouts->values_.addChild (layout, i, 0);
+            layouts->values_.addChild (layout, i, nullptr);
         }
         else if (tenpads == i)
         {
-            ValueTree layout ("Layout");
-            layout.setProperty ("name", "10 Pads", 0);
+            juce::ValueTree layout ("Layout");
+            layout.setProperty ("name", "10 Pads", nullptr);
             for (int p = 0; p < numPads; p++)
             {
-                ValueTree padpos ("PadPosition");
-                padpos.setProperty ("visible", p < 10, 0);
-                layout.addChild (padpos, p, 0);
+                juce::ValueTree padpos ("PadPosition");
+                padpos.setProperty ("visible", p < 10, nullptr);
+                layout.addChild (padpos, p, nullptr);
             }
             PadLayouts::setPadLayout (layout.getChild (0), 0.0187f, 0.0649f, 0.2303f, 0.2319f);
             PadLayouts::setPadLayout (layout.getChild (1), 0.2627f, 0.0649f, 0.2303f, 0.2319f);
@@ -1217,17 +1220,17 @@ void midiPads::fillLayouts()
             PadLayouts::setPadLayout (layout.getChild (7), 0.7512f, 0.2983f, 0.2303f, 0.2319f);
             PadLayouts::setPadLayout (layout.getChild (8), 0.0187f, 0.5317f, 0.4793f, 0.4637f);
             PadLayouts::setPadLayout (layout.getChild (9), 0.5073f, 0.5317f, 0.4793f, 0.4637f);
-            layouts->values_.addChild (layout, i, 0);
+            layouts->values_.addChild (layout, i, nullptr);
         }
         else if (twelvepads == i)
         {
-            ValueTree layout ("Layout");
-            layout.setProperty ("name", "2 Pads, 12 Sliders", 0);
+            juce::ValueTree layout ("Layout");
+            layout.setProperty ("name", "2 Pads, 12 Sliders", nullptr);
             for (int p = 0; p < numPads; p++)
             {
-                ValueTree padpos ("PadPosition");
-                padpos.setProperty ("visible", p < 14, 0);
-                layout.addChild (padpos, p, 0);
+                juce::ValueTree padpos ("PadPosition");
+                padpos.setProperty ("visible", p < 14, nullptr);
+                layout.addChild (padpos, p, nullptr);
             }
             PadLayouts::setPadLayout (layout.getChild (0), 0.0086f, 0.0618f, 0.4786f, 0.4588f);
             PadLayouts::setPadLayout (layout.getChild (1), 0.4940f, 0.0618f, 0.0755f, 0.4588f);
@@ -1243,17 +1246,17 @@ void midiPads::fillLayouts()
             PadLayouts::setPadLayout (layout.getChild (11), 0.7479f, 0.5318f, 0.0755f, 0.4588f);
             PadLayouts::setPadLayout (layout.getChild (12), 0.8319f, 0.5318f, 0.0755f, 0.4588f);
             PadLayouts::setPadLayout (layout.getChild (13), 0.9160f, 0.5318f, 0.0755f, 0.4588f);
-            layouts->values_.addChild (layout, i, 0);
+            layouts->values_.addChild (layout, i, nullptr);
         }
         else if (sixteenpads == i)
         {
-            ValueTree layout ("Layout");
-            layout.setProperty ("name", "16 Pads", 0);
+            juce::ValueTree layout ("Layout");
+            layout.setProperty ("name", "16 Pads", nullptr);
             for (int p = 0; p < numPads; p++)
             {
-                ValueTree padpos ("PadPosition");
-                padpos.setProperty ("visible", p < 16, 0);
-                layout.addChild (padpos, p, 0);
+                juce::ValueTree padpos ("PadPosition");
+                padpos.setProperty ("visible", p < 16, nullptr);
+                layout.addChild (padpos, p, nullptr);
             }
             PadLayouts::setPadLayout (layout.getChild (0), 0.0187f, 0.0649f, 0.2303f, 0.2319f);
             PadLayouts::setPadLayout (layout.getChild (1), 0.2627f, 0.0649f, 0.2303f, 0.2319f);
@@ -1271,17 +1274,17 @@ void midiPads::fillLayouts()
             PadLayouts::setPadLayout (layout.getChild (13), 0.2627f, 0.7650f, 0.2303f, 0.2319f);
             PadLayouts::setPadLayout (layout.getChild (14), 0.5070f, 0.7650f, 0.2303f, 0.2319f);
             PadLayouts::setPadLayout (layout.getChild (15), 0.7512f, 0.7650f, 0.2303f, 0.2319f);
-            layouts->values_.addChild (layout, i, 0);
+            layouts->values_.addChild (layout, i, nullptr);
         }
         else if (sixteensliders == i)
         {
-            ValueTree layout ("Layout");
-            layout.setProperty ("name", "16 Sliders", 0);
+            juce::ValueTree layout ("Layout");
+            layout.setProperty ("name", "16 Sliders", nullptr);
             for (int p = 0; p < numPads; p++)
             {
-                ValueTree padpos ("PadPosition");
-                padpos.setProperty ("visible", p < 16, 0);
-                layout.addChild (padpos, p, 0);
+                juce::ValueTree padpos ("PadPosition");
+                padpos.setProperty ("visible", p < 16, nullptr);
+                layout.addChild (padpos, p, nullptr);
             }
             PadLayouts::setPadLayout (layout.getChild (0), 0.0058f, 0.0619f, 0.0603f, 0.9305f);
             PadLayouts::setPadLayout (layout.getChild (1), 0.0675f, 0.0619f, 0.0603f, 0.9305f);
@@ -1299,17 +1302,17 @@ void midiPads::fillLayouts()
             PadLayouts::setPadLayout (layout.getChild (13), 0.8089f, 0.0619f, 0.0603f, 0.9305f);
             PadLayouts::setPadLayout (layout.getChild (14), 0.8707f, 0.0619f, 0.0603f, 0.9305f);
             PadLayouts::setPadLayout (layout.getChild (15), 0.9325f, 0.0619f, 0.0603f, 0.9305f);
-            layouts->values_.addChild (layout, i, 0);
+            layouts->values_.addChild (layout, i, nullptr);
         }
         else if (sixtyfourpads == i)
         {
-            ValueTree layout ("Layout");
-            layout.setProperty ("name", "64 Pads", 0);
+            juce::ValueTree layout ("Layout");
+            layout.setProperty ("name", "64 Pads", nullptr);
             for (int p = 0; p < numPads; p++)
             {
-                ValueTree padpos ("PadPosition");
-                padpos.setProperty ("visible", p < 64, 0);
-                layout.addChild (padpos, p, 0);
+                juce::ValueTree padpos ("PadPosition");
+                padpos.setProperty ("visible", p < 64, nullptr);
+                layout.addChild (padpos, p, nullptr);
             }
             PadLayouts::setPadLayout (layout.getChild (0), 0.0031f, 0.0538f, 0.1203f, 0.1211f);
             PadLayouts::setPadLayout (layout.getChild (1), 0.1280f, 0.0538f, 0.1203f, 0.1211f);
@@ -1375,17 +1378,17 @@ void midiPads::fillLayouts()
             PadLayouts::setPadLayout (layout.getChild (61), 0.6266f, 0.8803f, 0.1203f, 0.1211f);
             PadLayouts::setPadLayout (layout.getChild (62), 0.7516f, 0.8803f, 0.1203f, 0.1211f);
             PadLayouts::setPadLayout (layout.getChild (63), 0.8766f, 0.8803f, 0.1203f, 0.1211f);
-            layouts->values_.addChild (layout, i, 0);
+            layouts->values_.addChild (layout, i, nullptr);
         }
         else if (hexagonpads == i)
         {
-            ValueTree layout ("Layout");
-            layout.setProperty ("name", "Hexagons", 0);
+            juce::ValueTree layout ("Layout");
+            layout.setProperty ("name", "Hexagons", nullptr);
             for (int p = 0; p < numPads; p++)
             {
-                ValueTree padpos ("PadPosition");
-                padpos.setProperty ("visible", p < 40, 0);
-                layout.addChild (padpos, p, 0);
+                juce::ValueTree padpos ("PadPosition");
+                padpos.setProperty ("visible", p < 40, nullptr);
+                layout.addChild (padpos, p, nullptr);
             }
             PadLayouts::setPadLayout (layout.getChild (0), 0.0370f, 0.1504f, 0.1317f, 0.1869f);
             PadLayouts::setPadLayout (layout.getChild (1), 0.0370f, 0.3372f, 0.1317f, 0.1869f);
@@ -1427,17 +1430,17 @@ void midiPads::fillLayouts()
             PadLayouts::setPadLayout (layout.getChild (37), 0.3333f, 0.0584f, 0.1317f, 0.1869f);
             PadLayouts::setPadLayout (layout.getChild (38), 0.5309f, 0.0584f, 0.1317f, 0.1869f);
             PadLayouts::setPadLayout (layout.getChild (39), 0.7284f, 0.0584f, 0.1317f, 0.1869f);
-            layouts->values_.addChild (layout, i, 0);
+            layouts->values_.addChild (layout, i, nullptr);
         }
         else if (mixerpads == i)
         {
-            ValueTree layout ("Layout");
-            layout.setProperty ("name", "8 Ch Mixer", 0);
+            juce::ValueTree layout ("Layout");
+            layout.setProperty ("name", "8 Ch Mixer", nullptr);
             for (int p = 0; p < numPads; p++)
             {
-                ValueTree padpos ("PadPosition");
-                padpos.setProperty ("visible", p < 32, 0);
-                layout.addChild (padpos, p, 0);
+                juce::ValueTree padpos ("PadPosition");
+                padpos.setProperty ("visible", p < 32, nullptr);
+                layout.addChild (padpos, p, nullptr);
             }
             PadLayouts::setPadLayout (layout.getChild (0), 0.0029f, 0.0541f, 0.1207f, 0.1206f);
             PadLayouts::setPadLayout (layout.getChild (1), 0.1273f, 0.0541f, 0.1207f, 0.1206f);
@@ -1471,17 +1474,17 @@ void midiPads::fillLayouts()
             PadLayouts::setPadLayout (layout.getChild (29), 0.6265f, 0.4100f, 0.1207f, 0.5792f);
             PadLayouts::setPadLayout (layout.getChild (30), 0.7517f, 0.4100f, 0.1207f, 0.5792f);
             PadLayouts::setPadLayout (layout.getChild (31), 0.8765f, 0.4100f, 0.1207f, 0.5792f);
-            layouts->values_.addChild (layout, i, 0);
+            layouts->values_.addChild (layout, i, nullptr);
         }
         else if (arrangeit28 == i)
         {
-            ValueTree layout ("Layout");
-            layout.setProperty ("name", "2 XY, 5 Sliders, 21 Buttons", 0);
+            juce::ValueTree layout ("Layout");
+            layout.setProperty ("name", "2 XY, 5 Sliders, 21 Buttons", nullptr);
             for (int p = 0; p < numPads; p++)
             {
-                ValueTree padpos ("PadPosition");
-                padpos.setProperty ("visible", p < 28, 0);
-                layout.addChild (padpos, p, 0);
+                juce::ValueTree padpos ("PadPosition");
+                padpos.setProperty ("visible", p < 28, nullptr);
+                layout.addChild (padpos, p, nullptr);
             }
             PadLayouts::setPadLayout (layout.getChild (0), 0.0134f, 0.4030f, 0.5854f, 0.5822f);
             PadLayouts::setPadLayout (layout.getChild (1), 0.6276f, 0.0696f, 0.3611f, 0.3126f);
@@ -1511,17 +1514,17 @@ void midiPads::fillLayouts()
             PadLayouts::setPadLayout (layout.getChild (25), 0.7047f, 0.4030f, 0.0576f, 0.5822f);
             PadLayouts::setPadLayout (layout.getChild (26), 0.7788f, 0.4030f, 0.0576f, 0.5822f);
             PadLayouts::setPadLayout (layout.getChild (27), 0.8529f, 0.4030f, 0.0576f, 0.5822f);
-            layouts->values_.addChild (layout, i, 0);
+            layouts->values_.addChild (layout, i, nullptr);
         }
         else if (arrangeit39 == i)
         {
-            ValueTree layout ("Layout");
-            layout.setProperty ("name", "2 XY, 12 Sliders, 25 Buttons", 0);
+            juce::ValueTree layout ("Layout");
+            layout.setProperty ("name", "2 XY, 12 Sliders, 25 Buttons", nullptr);
             for (int p = 0; p < numPads; p++)
             {
-                ValueTree padpos ("PadPosition");
-                padpos.setProperty ("visible", p < 39, 0);
-                layout.addChild (padpos, p, 0);
+                juce::ValueTree padpos ("PadPosition");
+                padpos.setProperty ("visible", p < 39, nullptr);
+                layout.addChild (padpos, p, nullptr);
             }
             PadLayouts::setPadLayout (layout.getChild (0), 0.5000f, 0.0696f, 0.0494f, 0.2993f);
             PadLayouts::setPadLayout (layout.getChild (1), 0.4383f, 0.0696f, 0.0494f, 0.2993f);
@@ -1564,17 +1567,17 @@ void midiPads::fillLayouts()
             PadLayouts::setPadLayout (layout.getChild (36), 0.9125f, 0.6370f, 0.0576f, 0.0948f);
             PadLayouts::setPadLayout (layout.getChild (37), 0.9125f, 0.7511f, 0.0576f, 0.0948f);
             PadLayouts::setPadLayout (layout.getChild (38), 0.9125f, 0.8637f, 0.0576f, 0.0948f);
-            layouts->values_.addChild (layout, i, 0);
+            layouts->values_.addChild (layout, i, nullptr);
         }
         else if (arrangeit51 == i)
         {
-            ValueTree layout ("Layout");
-            layout.setProperty ("name", "2 XY, 49 Buttons", 0);
+            juce::ValueTree layout ("Layout");
+            layout.setProperty ("name", "2 XY, 49 Buttons", nullptr);
             for (int p = 0; p < numPads; p++)
             {
-                ValueTree padpos ("PadPosition");
-                padpos.setProperty ("visible", p < 51, 0);
-                layout.addChild (padpos, p, 0);
+                juce::ValueTree padpos ("PadPosition");
+                padpos.setProperty ("visible", p < 51, nullptr);
+                layout.addChild (padpos, p, nullptr);
             }
             PadLayouts::setPadLayout (layout.getChild (22), 0.0216f, 0.0681f, 0.0576f, 0.0948f);
             PadLayouts::setPadLayout (layout.getChild (25), 0.1121f, 0.0681f, 0.0576f, 0.0948f);
@@ -1637,17 +1640,17 @@ void midiPads::fillLayouts()
             PadLayouts::setPadLayout (layout.getChild (21), 0.8189f, 0.8548f, 0.0576f, 0.0948f);
             PadLayouts::setPadLayout (layout.getChild (50), 0.9054f, 0.8548f, 0.0576f, 0.0948f);
 
-            layouts->values_.addChild (layout, i, 0);
+            layouts->values_.addChild (layout, i, nullptr);
         }
         else if (arrangeit48 == i)
         {
-            ValueTree layout ("Layout");
-            layout.setProperty ("name", "6 Mixer Blocks", 0);
+            juce::ValueTree layout ("Layout");
+            layout.setProperty ("name", "6 Mixer Blocks", nullptr);
             for (int p = 0; p < numPads; p++)
             {
-                ValueTree padpos ("PadPosition");
-                padpos.setProperty ("visible", p < 48, 0);
-                layout.addChild (padpos, p, 0);
+                juce::ValueTree padpos ("PadPosition");
+                padpos.setProperty ("visible", p < 48, nullptr);
+                layout.addChild (padpos, p, nullptr);
             }
             PadLayouts::setPadLayout (layout.getChild (0), 0.2541f, 0.1778f, 0.0576f, 0.0948f);
             PadLayouts::setPadLayout (layout.getChild (1), 0.0124f, 0.0800f, 0.0411f, 0.4178f);
@@ -1697,17 +1700,17 @@ void midiPads::fillLayouts()
             PadLayouts::setPadLayout (layout.getChild (45), 0.5257f, 0.6578f, 0.0411f, 0.3200f);
             PadLayouts::setPadLayout (layout.getChild (46), 0.5905f, 0.7704f, 0.0576f, 0.0948f);
             PadLayouts::setPadLayout (layout.getChild (47), 0.5926f, 0.8830f, 0.0576f, 0.0948f);
-            layouts->values_.addChild (layout, i, 0);
+            layouts->values_.addChild (layout, i, nullptr);
         }
         else if (arrangeit64 == i)
         {
-            ValueTree layout ("Layout");
-            layout.setProperty ("name", "8 Mixer Blocks w/Sends", 0);
+            juce::ValueTree layout ("Layout");
+            layout.setProperty ("name", "8 Mixer Blocks w/Sends", nullptr);
             for (int p = 0; p < numPads; p++)
             {
-                ValueTree padpos ("PadPosition");
-                padpos.setProperty ("visible", p < 64, 0);
-                layout.addChild (padpos, p, 0);
+                juce::ValueTree padpos ("PadPosition");
+                padpos.setProperty ("visible", p < 64, nullptr);
+                layout.addChild (padpos, p, nullptr);
             }
             PadLayouts::setPadLayout (layout.getChild (0), 0.0155f, 0.1809f, 0.0495f, 0.3118f);
             PadLayouts::setPadLayout (layout.getChild (1), 0.0113f, 0.0985f, 0.2186f, 0.0706f);
@@ -1773,17 +1776,17 @@ void midiPads::fillLayouts()
             PadLayouts::setPadLayout (layout.getChild (61), 0.8433f, 0.7750f, 0.1351f, 0.0588f);
             PadLayouts::setPadLayout (layout.getChild (62), 0.8433f, 0.8456f, 0.1351f, 0.0588f);
             PadLayouts::setPadLayout (layout.getChild (63), 0.8433f, 0.9162f, 0.1351f, 0.0588f);
-            layouts->values_.addChild (layout, i, 0);
+            layouts->values_.addChild (layout, i, nullptr);
         }
         else if (arrangeit55 == i)
         {
-            ValueTree layout ("Layout");
-            layout.setProperty ("name", "1 XY, 6 Sliders, 48 Buttons", 0);
+            juce::ValueTree layout ("Layout");
+            layout.setProperty ("name", "1 XY, 6 Sliders, 48 Buttons", nullptr);
             for (int p = 0; p < numPads; p++)
             {
-                ValueTree padpos ("PadPosition");
-                padpos.setProperty ("visible", p < 55, 0);
-                layout.addChild (padpos, p, 0);
+                juce::ValueTree padpos ("PadPosition");
+                padpos.setProperty ("visible", p < 55, nullptr);
+                layout.addChild (padpos, p, nullptr);
             }
             PadLayouts::setPadLayout (layout.getChild (0), 0.0082f, 0.5215f, 0.4562f, 0.4622f);
             PadLayouts::setPadLayout (layout.getChild (1), 0.0082f, 0.0785f, 0.0577f, 0.0948f);
@@ -1840,11 +1843,11 @@ void midiPads::fillLayouts()
             PadLayouts::setPadLayout (layout.getChild (52), 0.7706f, 0.0756f, 0.0577f, 0.4059f);
             PadLayouts::setPadLayout (layout.getChild (53), 0.8496f, 0.0756f, 0.0577f, 0.4059f);
             PadLayouts::setPadLayout (layout.getChild (54), 0.9310f, 0.0756f, 0.0577f, 0.4059f);
-            layouts->values_.addChild (layout, i, 0);
+            layouts->values_.addChild (layout, i, nullptr);
         }
 #ifdef _DEBUG
         auto xml (layouts->values_.getChild (i).createXml());
-        File file (layoutPath + File::getSeparatorString() + "default" + File::getSeparatorString() + layouts->values_.getChild (i).getProperty ("name").toString() + ".mpadl");
+        juce::File file (layoutPath + juce::File::getSeparatorString() + "default" + juce::File::getSeparatorString() + layouts->values_.getChild (i).getProperty ("name").toString() + ".mpadl");
         xml->writeTo (file);
 #endif
     }
@@ -1884,7 +1887,7 @@ void midiPads::loadDefaultPrograms()
                     programs->setForPad (i, pad, "UseY", true);
                     programs->setForPad (i, pad, "Ycc", i);   //data1
                     programs->setForPad (i, pad, "Ytype", 1); //type,CC
-                    programs->setForPad (i, pad, "icon", String());
+                    programs->setForPad (i, pad, "icon", juce::String());
                     programs->setForPad (i, pad, "SendOff", false);
                 }
                 setLayout (i, sixteensliders);
@@ -1915,8 +1918,8 @@ void midiPads::loadDefaultPrograms()
                 programs->setForPad (i, 0, "Ycc", 74);  //data1
                 programs->setForPad (i, 0, "Ytype", 1); //type,CC
                 programs->setForPad (i, 0, "Xcc", 1);   //x cc
-                programs->setForPad (i, 0, "icon", String());
-                programs->setForPad (i, 0, "text", String());
+                programs->setForPad (i, 0, "icon", juce::String());
+                programs->setForPad (i, 0, "text", juce::String());
                 programs->setForPad (i, 0, "roundness", 0.05f);
                 programs->setForPad (i, 0, "SendOff", false);
                 setLayout (i, onepad);
@@ -1931,10 +1934,10 @@ void midiPads::loadDefaultPrograms()
                 for (int pad = 0; pad < 16; pad++)
                 {
                     programs->setForPad (i, pad, "roundness", 0.3f);
-                    String padicon = String();
-                    padicon << "Mighty Pea" << File::getSeparatorString() << String (pad + 1) << ".svg";
+                    juce::String padicon = juce::String();
+                    padicon << "Mighty Pea" << juce::File::getSeparatorString() << juce::String (pad + 1) << ".svg";
                     programs->setForPad (i, pad, "icon", padicon);
-                    programs->setForPad (i, pad, "padcolor", Colour (0xFFFFFFFF).toString());
+                    programs->setForPad (i, pad, "padcolor", juce::Colour (0xFFFFFFFF).toString());
                 }
                 programs->setForPad (i, 0, "text", "Kick");
                 programs->setForPad (i, 1, "text", "Snare");
@@ -1948,10 +1951,10 @@ void midiPads::loadDefaultPrograms()
                 programs->setForPad (i, 9, "text", "Tom 2");
                 programs->setForPad (i, 10, "text", "Tom 1");
                 programs->setForPad (i, 11, "text", "Clap");
-                programs->setForPad (i, 12, "text", String());
-                programs->setForPad (i, 13, "text", String());
-                programs->setForPad (i, 14, "text", String());
-                programs->setForPad (i, 15, "text", String());
+                programs->setForPad (i, 12, "text", juce::String());
+                programs->setForPad (i, 13, "text", juce::String());
+                programs->setForPad (i, 14, "text", juce::String());
+                programs->setForPad (i, 15, "text", juce::String());
                 setLayout (i, sixteenpads);
                 break;
             case 5:
@@ -1961,8 +1964,8 @@ void midiPads::loadDefaultPrograms()
                 {
                     programs->setForPad (i, pad, "roundness", 0.05f);
                     programs->setForPad (i, pad, "showdots", false);
-                    programs->setForPad (i, pad, "icon", String());
-                    programs->setForPad (i, pad, "text", String());
+                    programs->setForPad (i, pad, "icon", juce::String());
+                    programs->setForPad (i, pad, "text", juce::String());
                 }
                 setLayout (i, sixtyfourpads);
                 break;
@@ -1973,8 +1976,8 @@ void midiPads::loadDefaultPrograms()
                 for (int pad = 0; pad < 40; pad++)
                 {
                     programs->setForPad (i, pad, "showdots", false);
-                    programs->setForPad (i, pad, "icon", String());
-                    programs->setForPad (i, pad, "text", String());
+                    programs->setForPad (i, pad, "icon", juce::String());
+                    programs->setForPad (i, pad, "text", juce::String());
                 }
                 setLayout (i, hexagonpads);
                 break;
@@ -1986,20 +1989,20 @@ void midiPads::loadDefaultPrograms()
                 programs->set (i, "bgbri", 0.3f);
                 for (int pad = 0; pad < 32; pad++)
                 {
-                    programs->setForPad (i, pad, "icon", String());
+                    programs->setForPad (i, pad, "icon", juce::String());
                     programs->setForPad (i, pad, "Ytype", 1);
                     if (pad < 8)
                     {
                         programs->setForPad (i, pad, "toggle", true);
                         programs->setForPad (i, pad, "SendOff", true);
-                        programs->setForPad (i, pad, "padcolor", Colour (0xFFFF0000).toString());
+                        programs->setForPad (i, pad, "padcolor", juce::Colour (0xFFFF0000).toString());
                         programs->setForPad (i, pad, "text", "Mute");
                     }
                     else if (pad < 16)
                     {
                         programs->setForPad (i, pad, "toggle", true);
                         programs->setForPad (i, pad, "SendOff", true);
-                        programs->setForPad (i, pad, "padcolor", Colour (0xFF00FF00).toString());
+                        programs->setForPad (i, pad, "padcolor", juce::Colour (0xFF00FF00).toString());
                         programs->setForPad (i, pad, "text", "Solo");
                     }
                     else if (pad < 24)
@@ -2010,20 +2013,20 @@ void midiPads::loadDefaultPrograms()
                         programs->setForPad (i, pad, "Xcc", programs->getForPad (i, pad, "Ycc"));
                         programs->setForPad (i, pad, "Ycc", 1);
                         programs->setForPad (i, pad, "text", "Pan");
-                        programs->setForPad (i, pad, "icon", String ("pancenter.svg"));
+                        programs->setForPad (i, pad, "icon", juce::String ("pancenter.svg"));
                     }
                     else
                     {
                         programs->setForPad (i, pad, "UseX", false);
                         programs->setForPad (i, pad, "UseY", true);
                         programs->setForPad (i, pad, "SendOff", false);
-                        programs->setForPad (i, pad, "text", String (pad - 23));
+                        programs->setForPad (i, pad, "text", juce::String (pad - 23));
                     }
                 }
                 setLayout (i, mixerpads);
                 break;
             case 8:
-                programs->set (i, "name", String ("KVR"));
+                programs->set (i, "name", juce::String ("KVR"));
                 programs->set (i, "squares", 16);
                 programs->set (i, "bgsat", 0.0f);
                 programs->set (i, "bgbri", 0.198275864f);
@@ -2032,28 +2035,28 @@ void midiPads::loadDefaultPrograms()
                 {
                     programs->setForPad (i, pad, "roundness", 0.1f);
                     programs->setForPad (i, pad, "showdots", false);
-                    programs->setForPad (i, pad, "icon", String ("hihi.svg"));
-                    programs->setForPad (i, pad, "text", String());
+                    programs->setForPad (i, pad, "icon", juce::String ("hihi.svg"));
+                    programs->setForPad (i, pad, "text", juce::String());
                     if (pad < 4)
-                        programs->setForPad (i, pad, "padcolor", Colour (0xFF304050).toString());
+                        programs->setForPad (i, pad, "padcolor", juce::Colour (0xFF304050).toString());
                     else if (pad < 8)
-                        programs->setForPad (i, pad, "padcolor", Colour (0xFF304060).toString());
+                        programs->setForPad (i, pad, "padcolor", juce::Colour (0xFF304060).toString());
                     else if (pad < 12)
-                        programs->setForPad (i, pad, "padcolor", Colour (0xFF304050).toString());
+                        programs->setForPad (i, pad, "padcolor", juce::Colour (0xFF304050).toString());
                     else
-                        programs->setForPad (i, pad, "padcolor", Colour (0xFF304060).toString());
+                        programs->setForPad (i, pad, "padcolor", juce::Colour (0xFF304060).toString());
                 }
                 setLayout (i, sixteenpads);
                 break;
             case 9:
-                programs->set (i, "name", String ("2 Pads, 12 Sliders"));
+                programs->set (i, "name", juce::String ("2 Pads, 12 Sliders"));
                 programs->set (i, "squares", 14);
                 for (int pad = 0; pad < 14; pad++)
                 {
                     programs->setForPad (i, pad, "roundness", 0.1f);
                     programs->setForPad (i, pad, "showdots", true);
-                    programs->setForPad (i, pad, "icon", String());
-                    programs->setForPad (i, pad, "text", String());
+                    programs->setForPad (i, pad, "icon", juce::String());
+                    programs->setForPad (i, pad, "text", juce::String());
                     programs->setForPad (i, pad, "UseY", true);
                     programs->setForPad (i, pad, "Ytype", 1); //type,CC
                     programs->setForPad (i, pad, "SendOff", false);
@@ -2065,13 +2068,13 @@ void midiPads::loadDefaultPrograms()
                 setLayout (i, twelvepads);
                 break;
             case 10:
-                programs->set (i, "name", String ("2/5/21"));
+                programs->set (i, "name", juce::String ("2/5/21"));
                 programs->set (i, "squares", 28);
                 for (int pad = 0; pad < 28; pad++)
                 {
                     programs->setForPad (i, pad, "roundness", 0.1f);
-                    programs->setForPad (i, pad, "icon", String());
-                    programs->setForPad (i, pad, "text", String());
+                    programs->setForPad (i, pad, "icon", juce::String());
+                    programs->setForPad (i, pad, "text", juce::String());
                     programs->setForPad (i, pad, "UseY", pad < 2 || pad > 22);
                     programs->setForPad (i, pad, "showdots", pad < 2 || pad > 22);
                     programs->setForPad (i, pad, "Ytype", 1); //type,CC
@@ -2084,13 +2087,13 @@ void midiPads::loadDefaultPrograms()
                 setLayout (i, arrangeit28);
                 break;
             case 11:
-                programs->set (i, "name", String ("2/12/25"));
+                programs->set (i, "name", juce::String ("2/12/25"));
                 programs->set (i, "squares", 46);
                 for (int pad = 0; pad < 39; pad++)
                 {
                     programs->setForPad (i, pad, "roundness", 0.1f);
-                    programs->setForPad (i, pad, "icon", String());
-                    programs->setForPad (i, pad, "text", String());
+                    programs->setForPad (i, pad, "icon", juce::String());
+                    programs->setForPad (i, pad, "text", juce::String());
                     programs->setForPad (i, pad, "UseY", pad < 14);
                     programs->setForPad (i, pad, "showdots", pad < 14);
                     programs->setForPad (i, pad, "Ytype", 1); //type,CC
@@ -2103,13 +2106,13 @@ void midiPads::loadDefaultPrograms()
                 setLayout (i, arrangeit39);
                 break;
             case 12:
-                programs->set (i, "name", String ("2/49"));
+                programs->set (i, "name", juce::String ("2/49"));
                 programs->set (i, "squares", 52);
                 for (int pad = 0; pad < 51; pad++)
                 {
                     programs->setForPad (i, pad, "roundness", 0.1f);
-                    programs->setForPad (i, pad, "icon", String());
-                    programs->setForPad (i, pad, "text", String());
+                    programs->setForPad (i, pad, "icon", juce::String());
+                    programs->setForPad (i, pad, "text", juce::String());
                     programs->setForPad (i, pad, "UseY", pad < 2);
                     programs->setForPad (i, pad, "showdots", pad < 2);
                     programs->setForPad (i, pad, "Ytype", 1); //type,CC
@@ -2122,13 +2125,13 @@ void midiPads::loadDefaultPrograms()
                 setLayout (i, arrangeit51);
                 break;
             case 13:
-                programs->set (i, "name", String ("6 Mixer Blocks"));
+                programs->set (i, "name", juce::String ("6 Mixer Blocks"));
                 programs->set (i, "squares", 48);
                 for (int pad = 0; pad < 48; pad++)
                 {
                     programs->setForPad (i, pad, "roundness", 0.1f);
-                    programs->setForPad (i, pad, "icon", String());
-                    programs->setForPad (i, pad, "text", String());
+                    programs->setForPad (i, pad, "icon", juce::String());
+                    programs->setForPad (i, pad, "text", juce::String());
                     programs->setForPad (i, pad, "Ytype", 1); //type,CC
                     programs->setForPad (i, pad, "SendOff", false);
                     switch (pad)

--- a/pizjuce/midiPads/midiPads.h
+++ b/pizjuce/midiPads/midiPads.h
@@ -1,12 +1,10 @@
 #ifndef MIDIPADSPLUGINFILTER_H
 #define MIDIPADSPLUGINFILTER_H
 
-#include "juce_core/juce_core.h"
-#include "juce_data_structures/juce_data_structures.h"
+#include <juce_core/juce_core.h>
+#include <juce_data_structures/juce_data_structures.h>
 
 #include "../_common/PizAudioProcessor.h"
-
-using namespace juce;
 
 #define midiScaler (0.007874016f)
 
@@ -58,21 +56,21 @@ class PadLayouts
 public:
     PadLayouts() : values_ ("PadLayouts"){};
     ~PadLayouts(){};
-    static void setPadLayout (ValueTree tree, float x, float y, float w, float h)
+    static void setPadLayout (juce::ValueTree tree, float x, float y, float w, float h)
     {
-        tree.setProperty ("x", x, 0);
-        tree.setProperty ("y", y, 0);
-        tree.setProperty ("w", w, 0);
-        tree.setProperty ("h", h, 0);
+        tree.setProperty ("x", x, nullptr);
+        tree.setProperty ("y", y, nullptr);
+        tree.setProperty ("w", w, nullptr);
+        tree.setProperty ("h", h, nullptr);
     }
 
     void setPadVisible (int prog, int pad, bool visibility)
     {
-        values_.getChild (prog).getChildWithName ("Layout").getChild (pad).setProperty ("visible", visibility, 0);
+        values_.getChild (prog).getChildWithName ("Layout").getChild (pad).setProperty ("visible", visibility, nullptr);
     }
 
 private:
-    ValueTree values_;
+    juce::ValueTree values_;
 };
 
 class MidiPadsPrograms
@@ -81,38 +79,38 @@ class MidiPadsPrograms
 
 public:
     MidiPadsPrograms();
-    void set (int prog, const Identifier& name, const var& newValue)
+    void set (int prog, const juce::Identifier& name, const juce::var& newValue)
     {
-        values_.getChild (prog).getChildWithName ("GlobalValues").setProperty (name, newValue, 0);
+        values_.getChild (prog).getChildWithName ("GlobalValues").setProperty (name, newValue, nullptr);
     }
-    const var get (int prog, const Identifier& name)
+    const juce::var get (int prog, const juce::Identifier& name)
     {
         return values_.getChild (prog).getChildWithName ("GlobalValues").getProperty (name);
     }
-    void setForPad (int prog, int pad, const Identifier& name, const var& newValue)
+    void setForPad (int prog, int pad, const juce::Identifier& name, const juce::var& newValue)
     {
-        values_.getChild (prog).getChild (pad).setProperty (name, newValue, 0);
+        values_.getChild (prog).getChild (pad).setProperty (name, newValue, nullptr);
     }
     void setPadLayout (int prog, int pad, float x, float y, float w, float h)
     {
-        values_.getChild (prog).getChildWithName ("Layout").getChild (pad).setProperty ("x", x, 0);
-        values_.getChild (prog).getChildWithName ("Layout").getChild (pad).setProperty ("y", y, 0);
-        values_.getChild (prog).getChildWithName ("Layout").getChild (pad).setProperty ("w", w, 0);
-        values_.getChild (prog).getChildWithName ("Layout").getChild (pad).setProperty ("h", h, 0);
+        values_.getChild (prog).getChildWithName ("Layout").getChild (pad).setProperty ("x", x, nullptr);
+        values_.getChild (prog).getChildWithName ("Layout").getChild (pad).setProperty ("y", y, nullptr);
+        values_.getChild (prog).getChildWithName ("Layout").getChild (pad).setProperty ("w", w, nullptr);
+        values_.getChild (prog).getChildWithName ("Layout").getChild (pad).setProperty ("h", h, nullptr);
     }
     void setPadPosition (int prog, int pad, float x, float y)
     {
-        values_.getChild (prog).getChildWithName ("Layout").getChild (pad).setProperty ("x", x, 0);
-        values_.getChild (prog).getChildWithName ("Layout").getChild (pad).setProperty ("y", y, 0);
+        values_.getChild (prog).getChildWithName ("Layout").getChild (pad).setProperty ("x", x, nullptr);
+        values_.getChild (prog).getChildWithName ("Layout").getChild (pad).setProperty ("y", y, nullptr);
     }
     void setPadSize (int prog, int pad, float w, float h)
     {
-        values_.getChild (prog).getChildWithName ("Layout").getChild (pad).setProperty ("w", w, 0);
-        values_.getChild (prog).getChildWithName ("Layout").getChild (pad).setProperty ("h", h, 0);
+        values_.getChild (prog).getChildWithName ("Layout").getChild (pad).setProperty ("w", w, nullptr);
+        values_.getChild (prog).getChildWithName ("Layout").getChild (pad).setProperty ("h", h, nullptr);
     }
     void setPadVisible (int prog, int pad, bool visibility)
     {
-        values_.getChild (prog).getChildWithName ("Layout").getChild (pad).setProperty ("visible", visibility, 0);
+        values_.getChild (prog).getChildWithName ("Layout").getChild (pad).setProperty ("visible", visibility, nullptr);
     }
     bool getPadVisible (int prog, int pad)
     {
@@ -120,28 +118,28 @@ public:
     }
     juce::Rectangle<float> getPadBounds (int prog, int pad)
     {
-        return juce::Rectangle<float> (values_.getChild (prog).getChildWithName ("Layout").getChild (pad).getProperty ("x"),
-                                       values_.getChild (prog).getChildWithName ("Layout").getChild (pad).getProperty ("y"),
-                                       values_.getChild (prog).getChildWithName ("Layout").getChild (pad).getProperty ("w"),
-                                       values_.getChild (prog).getChildWithName ("Layout").getChild (pad).getProperty ("h"));
+        return { values_.getChild (prog).getChildWithName ("Layout").getChild (pad).getProperty ("x"),
+                 values_.getChild (prog).getChildWithName ("Layout").getChild (pad).getProperty ("y"),
+                 values_.getChild (prog).getChildWithName ("Layout").getChild (pad).getProperty ("w"),
+                 values_.getChild (prog).getChildWithName ("Layout").getChild (pad).getProperty ("h") };
     }
-    const var getForPad (int prog, int pad, const Identifier& name)
+    const juce::var getForPad (int prog, int pad, const juce::Identifier& name)
     {
         return values_.getChild (prog).getChild (pad).getProperty (name);
     }
 
-    const var getForPad (int prog, int pad, const Identifier& name, const var& defaultValue)
+    const juce::var getForPad (int prog, int pad, const juce::Identifier& name, const juce::var& defaultValue)
     {
         return values_.getChild (prog).getChild (pad).getProperty (name, defaultValue);
     }
 
-    MidiPadsPrograms (ValueTree& tree)
+    MidiPadsPrograms (juce::ValueTree& tree)
     {
         values_.getChild (0).getParent() = tree.createCopy();
     }
 
 private:
-    ValueTree values_;
+    juce::ValueTree values_;
 
     float x[numPrograms][numPads];
     float y[numPrograms][numPads];
@@ -149,7 +147,7 @@ private:
 
 //==============================================================================
 class midiPads : public PizAudioProcessor,
-                 public ChangeBroadcaster
+                 public juce::ChangeBroadcaster
 {
 public:
     //==============================================================================
@@ -160,15 +158,15 @@ public:
     void prepareToPlay (double sampleRate, int samplesPerBlock) override;
     void releaseResources() override;
 
-    void processBlock (AudioSampleBuffer& buffer,
-                       MidiBuffer& midiMessages) override;
+    void processBlock (juce::AudioSampleBuffer& buffer,
+                       juce::MidiBuffer& midiMessages) override;
 
     //==============================================================================
-    AudioProcessorEditor* createEditor() override;
+    juce::AudioProcessorEditor* createEditor() override;
 
     //==============================================================================
     double getTailLengthSeconds() const override { return 0; }
-    const String getName() const override { return JucePlugin_Name; }
+    const juce::String getName() const override { return JucePlugin_Name; }
     bool acceptsMidi() const override
     {
 #if JucePlugin_WantsMidiInput
@@ -193,11 +191,11 @@ public:
     float getParameter (int index) override;
     void setParameter (int index, float newValue) override;
 
-    const String getParameterName (int index) override;
-    const String getParameterText (int index) override;
+    const juce::String getParameterName (int index) override;
+    const juce::String getParameterText (int index) override;
 
-    const String getInputChannelName (int channelIndex) const override;
-    const String getOutputChannelName (int channelIndex) const override;
+    const juce::String getInputChannelName (int channelIndex) const override;
+    const juce::String getOutputChannelName (int channelIndex) const override;
     bool isInputChannelStereoPair (int index) const override;
     bool isOutputChannelStereoPair (int index) const override;
 
@@ -215,28 +213,28 @@ public:
 #endif
     int getCurrentProgram() override;
     void setCurrentProgram (int index) override;
-    const String getProgramName (int index) override;
-    void changeProgramName (int index, const String& newName) override;
+    const juce::String getProgramName (int index) override;
+    void changeProgramName (int index, const juce::String& newName) override;
     void copySettingsToProgram (int index);
 
     //==============================================================================
-    void getCurrentProgramStateInformation (MemoryBlock& destData) override;
+    void getCurrentProgramStateInformation (juce::MemoryBlock& destData) override;
     void setCurrentProgramStateInformation (const void* data, int sizeInBytes) override;
-    void getStateInformation (MemoryBlock& destData) override;
+    void getStateInformation (juce::MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
-    void saveXmlPatch (int index, File file);
-    void saveXmlBank (File file);
-    bool loadXmlPatch (int index, File file);
-    bool loadXmlBank (File file);
-    bool loadFxp (File file);
-    bool loadFxb (File file);
+    void saveXmlPatch (int index, juce::File file);
+    void saveXmlBank (juce::File file);
+    bool loadXmlPatch (int index, juce::File file);
+    bool loadXmlBank (juce::File file);
+    bool loadFxp (juce::File file);
+    bool loadFxb (juce::File file);
     void loadDefaultPrograms();
 
     juce::Rectangle<int> getPadBounds (int index);
     void setPadPosition (int index, float x, float y);
     void setPadSize (int index, float w, float h);
 
-    String getGlobalParamValueName (int index)
+    juce::String getGlobalParamValueName (int index)
     {
         switch (index)
         {
@@ -261,7 +259,7 @@ public:
             case kNoteOnTrig:
                 return "NoteOnTrig";
             default:
-                return String();
+                return {};
         }
     }
 
@@ -270,17 +268,17 @@ public:
     void setLayout (int prog, int layoutIndex)
     {
         int index = programs->values_.getChild (prog).indexOf (programs->values_.getChild (prog).getChildWithName ("Layout"));
-        programs->values_.getChild (prog).removeChild (index, 0);
-        programs->values_.getChild (prog).addChild (layouts->values_.getChild (layoutIndex).createCopy(), index, 0);
+        programs->values_.getChild (prog).removeChild (index, nullptr);
+        programs->values_.getChild (prog).addChild (layouts->values_.getChild (layoutIndex).createCopy(), index, nullptr);
     }
-    void loadXmlLayout (File file);
-    void saveXmlLayout (File file);
+    void loadXmlLayout (juce::File file);
+    void saveXmlLayout (juce::File file);
     void copyPadSettings (int source, int dest);
-    void setProperty (int pad, const Identifier& name, const var& newValue)
+    void setProperty (int pad, const juce::Identifier& name, const juce::var& newValue)
     {
         programs->setForPad (curProgram, pad, name, newValue);
     }
-    const var getProperty (int pad, const Identifier& name, const var defaultReturnValue = 0)
+    const juce::var getProperty (int pad, const juce::Identifier& name, const juce::var defaultReturnValue = 0)
     {
         return programs->getForPad (curProgram, pad, name, defaultReturnValue);
     }
@@ -310,9 +308,9 @@ public:
     float bgsat;
     float bgbri;
     float contrast;
-    String icon[numPads];
-    String text[numPads];
-    Colour padcolor[numPads];
+    juce::String icon[numPads];
+    juce::String text[numPads];
+    juce::Colour padcolor[numPads];
     bool buttondown[numPads];
     bool isplaying[128];
     int squares;
@@ -332,12 +330,10 @@ public:
     int lastxccvalue[numPads];
     int lastyccvalue[numPads];
     bool centeredText[numPads];
-    String pluginPath, layoutPath, presetPath, bankPath, iconPath;
+    juce::String pluginPath, layoutPath, presetPath, bankPath, iconPath;
 
-    //==============================================================================
-    juce_UseDebuggingNewOperator
-
-        private : float param[kNumParams];
+private:
+    float param[kNumParams];
     int triggervel;
 
     MidiPadsPrograms* programs;
@@ -346,6 +342,8 @@ public:
     int curProgram;
 
     bool init;
+
+    JUCE_LEAK_DETECTOR (midiPads)
 };
 
 #endif

--- a/pizjuce/midiPads/midiPadsEditor.cpp
+++ b/pizjuce/midiPads/midiPadsEditor.cpp
@@ -3,6 +3,10 @@ midiPads
 ==============================================================================*/
 #include "midiPadsEditor.h"
 
+using juce::jmax;
+using juce::jmin;
+using juce::roundToInt;
+
 //==============================================================================
 midiPadsEditor::midiPadsEditor (midiPads* const ownerFilter)
     : AudioProcessorEditor (ownerFilter),
@@ -30,11 +34,11 @@ midiPadsEditor::midiPadsEditor (midiPads* const ownerFilter)
         usex[i]       = getFilter()->UseX[i];
         usey[i]       = getFilter()->UseY[i];
         container->addAndMakeVisible (midiPad[i] = new MidiPad (i));
-        midiPad[i]->setButtonText (String());
+        midiPad[i]->setButtonText (juce::String());
         midiPad[i]->setTriggeredOnMouseDown (false);
         midiPad[i]->addListener (this);
         midiPad[i]->addMouseListener (this, true);
-        midiPad[i]->setToggleState (getFilter()->togglestate[i], dontSendNotification);
+        midiPad[i]->setToggleState (getFilter()->togglestate[i], juce::dontSendNotification);
         sending[i] = false;
 
         midiPad[i]->showdot = getFilter()->toggle[i];
@@ -59,57 +63,57 @@ midiPadsEditor::midiPadsEditor (midiPads* const ownerFilter)
         lastx[i] = 0;
         lasty[i] = 0;
     }
-    padEditor->addAndMakeVisible (vSlider = new Slider ("new slider"));
+    padEditor->addAndMakeVisible (vSlider = new juce::Slider ("new slider"));
     vSlider->setRange (0, 127, 1);
-    vSlider->setSliderStyle (Slider::LinearBar);
-    vSlider->setTextBoxStyle (Slider::TextBoxLeft, false, 80, 20);
+    vSlider->setSliderStyle (juce::Slider::LinearBar);
+    vSlider->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 80, 20);
     vSlider->addListener (this);
 
-    padEditor->addAndMakeVisible (nSlider = new Slider ("note slider"));
+    padEditor->addAndMakeVisible (nSlider = new juce::Slider ("note slider"));
     nSlider->setRange (0, 127, 1);
-    nSlider->setSliderStyle (Slider::LinearBar);
-    nSlider->setTextBoxStyle (Slider::TextBoxLeft, false, 80, 20);
+    nSlider->setSliderStyle (juce::Slider::LinearBar);
+    nSlider->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 80, 20);
     nSlider->addListener (this);
 
-    padEditor->addAndMakeVisible (ySlider = new Slider ("y-cc slider"));
+    padEditor->addAndMakeVisible (ySlider = new juce::Slider ("y-cc slider"));
     ySlider->setRange (0, 127, 1);
-    ySlider->setSliderStyle (Slider::LinearBar);
-    ySlider->setTextBoxStyle (Slider::TextBoxLeft, false, 80, 20);
+    ySlider->setSliderStyle (juce::Slider::LinearBar);
+    ySlider->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 80, 20);
     ySlider->addListener (this);
 
-    padEditor->addAndMakeVisible (oSlider = new Slider ("new slider"));
+    padEditor->addAndMakeVisible (oSlider = new juce::Slider ("new slider"));
     oSlider->setRange (0, 127, 1);
-    oSlider->setSliderStyle (Slider::LinearBar);
-    oSlider->setTextBoxStyle (Slider::TextBoxLeft, false, 80, 20);
+    oSlider->setSliderStyle (juce::Slider::LinearBar);
+    oSlider->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 80, 20);
     oSlider->addListener (this);
 
-    padEditor->addAndMakeVisible (triggerSlider = new Slider ("new slider"));
+    padEditor->addAndMakeVisible (triggerSlider = new juce::Slider ("new slider"));
     triggerSlider->setRange (0, 127, 1);
-    triggerSlider->setSliderStyle (Slider::LinearBar);
-    triggerSlider->setTextBoxStyle (Slider::TextBoxLeft, false, 80, 20);
+    triggerSlider->setSliderStyle (juce::Slider::LinearBar);
+    triggerSlider->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 80, 20);
     triggerSlider->addListener (this);
 
-    padEditor->addAndMakeVisible (xSlider = new Slider ("new slider"));
+    padEditor->addAndMakeVisible (xSlider = new juce::Slider ("new slider"));
     xSlider->setRange (0, 127, 1);
-    xSlider->setSliderStyle (Slider::LinearBar);
-    xSlider->setTextBoxStyle (Slider::TextBoxLeft, false, 80, 20);
+    xSlider->setSliderStyle (juce::Slider::LinearBar);
+    xSlider->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 80, 20);
     xSlider->addListener (this);
 
-    padEditor->addAndMakeVisible (xoSlider = new Slider ("new slider"));
+    padEditor->addAndMakeVisible (xoSlider = new juce::Slider ("new slider"));
     xoSlider->setRange (0, 127, 1);
-    xoSlider->setSliderStyle (Slider::LinearBar);
-    xoSlider->setTextBoxStyle (Slider::TextBoxLeft, false, 80, 20);
+    xoSlider->setSliderStyle (juce::Slider::LinearBar);
+    xoSlider->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 80, 20);
     xoSlider->addListener (this);
 
-    padEditor->addAndMakeVisible (roundnessSlider = new Slider ("Pad Roundness"));
+    padEditor->addAndMakeVisible (roundnessSlider = new juce::Slider ("Pad Roundness"));
     roundnessSlider->setRange (0, 0.5, 0);
-    roundnessSlider->setSliderStyle (Slider::LinearBar);
-    roundnessSlider->setTextBoxStyle (Slider::NoTextBox, false, 80, 20);
+    roundnessSlider->setSliderStyle (juce::Slider::LinearBar);
+    roundnessSlider->setTextBoxStyle (juce::Slider::NoTextBox, false, 80, 20);
     roundnessSlider->setTooltip ("Pad Roundness");
     roundnessSlider->setMouseClickGrabsKeyboardFocus (false);
     roundnessSlider->addListener (this);
 
-    padEditor->addAndMakeVisible (textEditor = new TextEditor ("text editor"));
+    padEditor->addAndMakeVisible (textEditor = new juce::TextEditor ("text editor"));
     textEditor->setMultiLine (true);
     textEditor->setReturnKeyStartsNewLine (true);
     textEditor->setReadOnly (false);
@@ -118,108 +122,108 @@ midiPadsEditor::midiPadsEditor (midiPads* const ownerFilter)
     textEditor->setPopupMenuEnabled (false);
     textEditor->setSelectAllWhenFocused (true);
     textEditor->addListener (this);
-    textEditor->setColour (TextEditor::outlineColourId, Colours::black);
+    textEditor->setColour (juce::TextEditor::outlineColourId, juce::Colours::black);
 
-    padEditor->addAndMakeVisible (colourSelector1 = new ColourSelector (ColourSelector::showColourAtTop | ColourSelector::showSliders | ColourSelector::showColourspace));
+    padEditor->addAndMakeVisible (colourSelector1 = new juce::ColourSelector (juce::ColourSelector::showColourAtTop | juce::ColourSelector::showSliders | juce::ColourSelector::showColourspace));
     colourSelector1->setName ("Pad Color");
     colourSelector1->addChangeListener (this);
 
-    padEditor->addAndMakeVisible (iconSizeSlider = new Slider ("Icon Size"));
+    padEditor->addAndMakeVisible (iconSizeSlider = new juce::Slider ("Icon Size"));
     iconSizeSlider->setRange (0.1, 1.0, 0);
-    iconSizeSlider->setSliderStyle (Slider::LinearBar);
-    iconSizeSlider->setTextBoxStyle (Slider::NoTextBox, false, 80, 20);
+    iconSizeSlider->setSliderStyle (juce::Slider::LinearBar);
+    iconSizeSlider->setTextBoxStyle (juce::Slider::NoTextBox, false, 80, 20);
     iconSizeSlider->setTooltip ("Icon Size");
     iconSizeSlider->setMouseClickGrabsKeyboardFocus (false);
     iconSizeSlider->addListener (this);
 
-    container->addAndMakeVisible (hueSlider = new Slider ("Hue"));
+    container->addAndMakeVisible (hueSlider = new juce::Slider ("Hue"));
     hueSlider->setTooltip ("Hue");
     hueSlider->setRange (0, 1, 0);
-    hueSlider->setSliderStyle (Slider::LinearBar);
-    hueSlider->setTextBoxStyle (Slider::NoTextBox, false, 80, 20);
+    hueSlider->setSliderStyle (juce::Slider::LinearBar);
+    hueSlider->setTextBoxStyle (juce::Slider::NoTextBox, false, 80, 20);
     hueSlider->addListener (this);
     hueSlider->setMouseClickGrabsKeyboardFocus (false);
 
-    container->addAndMakeVisible (saturationSlider = new Slider ("Saturation"));
+    container->addAndMakeVisible (saturationSlider = new juce::Slider ("Saturation"));
     saturationSlider->setTooltip ("Saturation");
     saturationSlider->setRange (0, 1, 0);
-    saturationSlider->setSliderStyle (Slider::LinearBar);
-    saturationSlider->setTextBoxStyle (Slider::NoTextBox, false, 80, 20);
+    saturationSlider->setSliderStyle (juce::Slider::LinearBar);
+    saturationSlider->setTextBoxStyle (juce::Slider::NoTextBox, false, 80, 20);
     saturationSlider->addListener (this);
     saturationSlider->setMouseClickGrabsKeyboardFocus (false);
 
-    container->addAndMakeVisible (brigtnessSlider = new Slider ("Brightness"));
+    container->addAndMakeVisible (brigtnessSlider = new juce::Slider ("Brightness"));
     brigtnessSlider->setTooltip ("Brightness");
     brigtnessSlider->setRange (0, 1, 0);
-    brigtnessSlider->setSliderStyle (Slider::LinearBar);
-    brigtnessSlider->setTextBoxStyle (Slider::NoTextBox, false, 80, 20);
+    brigtnessSlider->setSliderStyle (juce::Slider::LinearBar);
+    brigtnessSlider->setTextBoxStyle (juce::Slider::NoTextBox, false, 80, 20);
     brigtnessSlider->addListener (this);
     brigtnessSlider->setMouseClickGrabsKeyboardFocus (false);
 
-    container->addAndMakeVisible (padOpacitySlider = new Slider ("Pad Opacity"));
+    container->addAndMakeVisible (padOpacitySlider = new juce::Slider ("Pad Opacity"));
     padOpacitySlider->setTooltip ("Pad Opacity");
     padOpacitySlider->setRange (0, 1, 0);
-    padOpacitySlider->setSliderStyle (Slider::LinearBar);
-    padOpacitySlider->setTextBoxStyle (Slider::NoTextBox, false, 80, 20);
+    padOpacitySlider->setSliderStyle (juce::Slider::LinearBar);
+    padOpacitySlider->setTextBoxStyle (juce::Slider::NoTextBox, false, 80, 20);
     padOpacitySlider->addListener (this);
     padOpacitySlider->setMouseClickGrabsKeyboardFocus (false);
 
-    container->addAndMakeVisible (globalRoundnessSlider = new Slider ("Pad Roundness"));
+    container->addAndMakeVisible (globalRoundnessSlider = new juce::Slider ("Pad Roundness"));
     globalRoundnessSlider->setTooltip ("Pad Roundness");
     globalRoundnessSlider->setRange (0, 0.5, 0);
-    globalRoundnessSlider->setSliderStyle (Slider::LinearBar);
-    globalRoundnessSlider->setTextBoxStyle (Slider::NoTextBox, false, 80, 20);
+    globalRoundnessSlider->setSliderStyle (juce::Slider::LinearBar);
+    globalRoundnessSlider->setTextBoxStyle (juce::Slider::NoTextBox, false, 80, 20);
     globalRoundnessSlider->setMouseClickGrabsKeyboardFocus (false);
     globalRoundnessSlider->addListener (this);
 
-    container->addAndMakeVisible (globalIconSizeSlider = new Slider ("Icon Size"));
+    container->addAndMakeVisible (globalIconSizeSlider = new juce::Slider ("Icon Size"));
     globalIconSizeSlider->setTooltip ("Icon Size");
     globalIconSizeSlider->setRange (0.1, 1.0, 0);
-    globalIconSizeSlider->setSliderStyle (Slider::LinearBar);
-    globalIconSizeSlider->setTextBoxStyle (Slider::NoTextBox, false, 80, 20);
+    globalIconSizeSlider->setSliderStyle (juce::Slider::LinearBar);
+    globalIconSizeSlider->setTextBoxStyle (juce::Slider::NoTextBox, false, 80, 20);
     globalIconSizeSlider->setMouseClickGrabsKeyboardFocus (false);
     globalIconSizeSlider->addListener (this);
 
-    container->addAndMakeVisible (velocitySlider = new Slider ("Velocity Scale"));
+    container->addAndMakeVisible (velocitySlider = new juce::Slider ("Velocity Scale"));
     velocitySlider->setTooltip ("Velocity Scale Factor");
     velocitySlider->setRange (0, 2, 0.01);
-    velocitySlider->setSliderStyle (Slider::LinearBar);
-    velocitySlider->setTextBoxStyle (Slider::TextBoxLeft, false, 80, 20);
+    velocitySlider->setSliderStyle (juce::Slider::LinearBar);
+    velocitySlider->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 80, 20);
     velocitySlider->setMouseClickGrabsKeyboardFocus (false);
     velocitySlider->addListener (this);
 
-    container->addAndMakeVisible (valueSlider = new Slider ("CC Value Scale"));
+    container->addAndMakeVisible (valueSlider = new juce::Slider ("CC Value Scale"));
     valueSlider->setTooltip ("CC Value Scale Factor");
     valueSlider->setRange (0, 2, 0.01);
-    valueSlider->setSliderStyle (Slider::LinearBar);
-    valueSlider->setTextBoxStyle (Slider::TextBoxLeft, false, 80, 20);
+    valueSlider->setSliderStyle (juce::Slider::LinearBar);
+    valueSlider->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 80, 20);
     valueSlider->setMouseClickGrabsKeyboardFocus (false);
     valueSlider->addListener (this);
 
-    container->addAndMakeVisible (menuButton = new TextButton ("Menu Button"));
+    container->addAndMakeVisible (menuButton = new juce::TextButton ("Menu Button"));
     menuButton->setButtonText ("menu");
     menuButton->addListener (this);
     menuButton->setTriggeredOnMouseDown (true);
     menuButton->setMouseClickGrabsKeyboardFocus (false);
 
-    container->addAndMakeVisible (icSlider = new Slider ("new slider"));
+    container->addAndMakeVisible (icSlider = new juce::Slider ("new slider"));
     icSlider->setRange (1, 16, 1);
-    icSlider->setSliderStyle (Slider::LinearBar);
-    icSlider->setTextBoxStyle (Slider::TextBoxLeft, false, 80, 20);
+    icSlider->setSliderStyle (juce::Slider::LinearBar);
+    icSlider->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 80, 20);
     icSlider->setMouseClickGrabsKeyboardFocus (false);
     icSlider->addListener (this);
 
-    container->addAndMakeVisible (cSlider = new Slider ("new slider"));
+    container->addAndMakeVisible (cSlider = new juce::Slider ("new slider"));
     cSlider->setRange (1, 16, 1);
-    cSlider->setSliderStyle (Slider::LinearBar);
-    cSlider->setTextBoxStyle (Slider::TextBoxLeft, false, 80, 20);
+    cSlider->setSliderStyle (juce::Slider::LinearBar);
+    cSlider->setTextBoxStyle (juce::Slider::TextBoxLeft, false, 80, 20);
     cSlider->setMouseClickGrabsKeyboardFocus (false);
     cSlider->addListener (this);
 
     squares = 16;
 
     // add the triangular resizer component for the bottom-right of the UI
-    container->addAndMakeVisible (resizer = new ResizableCornerComponent (this, &resizeLimits));
+    container->addAndMakeVisible (resizer = new juce::ResizableCornerComponent (this, &resizeLimits));
     resizer->setMouseClickGrabsKeyboardFocus (false);
     resizeLimits.setSizeLimits (50, 50, 1600, 1600);
 
@@ -272,7 +276,7 @@ midiPadsEditor::~midiPadsEditor()
 }
 
 //==============================================================================
-void midiPadsEditor::paint (Graphics& g)
+void midiPadsEditor::paint (juce::Graphics& g)
 {
     g.fillAll (color);
     for (int i = 0; i < numPads; i++)
@@ -304,7 +308,7 @@ void midiPadsEditor::resized()
     {
         float xscale  = (float) container->getWidth() / (float) getWidth();
         float yscale  = (float) container->getHeight() / (float) getHeight();
-        auto* display = Desktop::getInstance().getDisplays().getDisplayForPoint (container->getScreenPosition(), false);
+        auto* display = juce::Desktop::getInstance().getDisplays().getDisplayForPoint (container->getScreenPosition(), false);
         if (display != nullptr)
         {
             container->setBounds (display->userArea);
@@ -328,7 +332,7 @@ void midiPadsEditor::resized()
 }
 
 //-------------------------------------------------------------------------------
-void midiPadsEditor::mouseDrag (const MouseEvent& e)
+void midiPadsEditor::mouseDrag (const juce::MouseEvent& e)
 {
     if (e.eventComponent->getName().compare ("MidiPad"))
         return;
@@ -379,10 +383,10 @@ void midiPadsEditor::mouseDrag (const MouseEvent& e)
         {
             if (midiPad[i]->isMouseButtonDown())
             {
-                bool usex                = getFilter()->UseX[i];
-                bool usey                = getFilter()->UseY[i];
-                bool useaft              = getFilter()->getParameter (kSendAft) >= 0.5;
-                ModifierKeys mousebutton = ModifierKeys::getCurrentModifiers();
+                bool usex                      = getFilter()->UseX[i];
+                bool usey                      = getFilter()->UseY[i];
+                bool useaft                    = getFilter()->getParameter (kSendAft) >= 0.5;
+                juce::ModifierKeys mousebutton = juce::ModifierKeys::getCurrentModifiers();
                 //this->setWantsKeyboardFocus(false);
                 if (mousebutton.isMiddleButtonDown() || mousebutton.isCommandDown())
                 {
@@ -396,7 +400,7 @@ void midiPadsEditor::mouseDrag (const MouseEvent& e)
                 {
                     if (usex || usey || useaft)
                     {
-                        Point<int> xy = midiPad[i]->getMouseXYRelative();
+                        juce::Point<int> xy = midiPad[i]->getMouseXYRelative();
                         //measure y from the bottom, make into range 0..1
                         float fy = 1.0f - (((float) (xy.getY())) / ((float) (midiPad[i]->getHeight())));
                         float fx = (((float) (xy.getX())) / ((float) (midiPad[i]->getWidth())));
@@ -506,13 +510,13 @@ void midiPadsEditor::mouseDrag (const MouseEvent& e)
     }
 }
 
-void midiPadsEditor::mouseDown (const MouseEvent& e)
+void midiPadsEditor::mouseDown (const juce::MouseEvent& e)
 {
     dragging = false;
     resizing = false;
 }
 
-void midiPadsEditor::mouseDoubleClick (const MouseEvent& e)
+void midiPadsEditor::mouseDoubleClick (const juce::MouseEvent& e)
 {
     if (e.eventComponent == container && ! fullscreen && getFilter()->editmode)
     {
@@ -550,7 +554,7 @@ void midiPadsEditor::mouseDoubleClick (const MouseEvent& e)
     }
 }
 
-void midiPadsEditor::mouseUp (const MouseEvent& e)
+void midiPadsEditor::mouseUp (const juce::MouseEvent& e)
 {
     if (e.eventComponent->getName().compare ("MidiPad"))
         return;
@@ -597,7 +601,7 @@ void midiPadsEditor::mouseUp (const MouseEvent& e)
     }
 }
 
-void midiPadsEditor::buttonStateChanged (Button* buttonThatWasClicked) //mousedown
+void midiPadsEditor::buttonStateChanged (juce::Button* buttonThatWasClicked) //mousedown
 {
     if (buttonThatWasClicked->getName().compare ("MidiPad"))
         return;
@@ -612,7 +616,7 @@ void midiPadsEditor::buttonStateChanged (Button* buttonThatWasClicked) //mousedo
         bool usexpb = getFilter()->UseXPB[i];
         bool toggle = getFilter()->toggle[i];
         //middle/ctrl click midi learn
-        ModifierKeys mousebutton = ModifierKeys::getCurrentModifiers();
+        juce::ModifierKeys mousebutton = juce::ModifierKeys::getCurrentModifiers();
         if (mousebutton.isMiddleButtonDown() || mousebutton.isCommandDown())
         {
             if (mousebutton.isAltDown() && mousebutton.isShiftDown())
@@ -635,15 +639,15 @@ void midiPadsEditor::buttonStateChanged (Button* buttonThatWasClicked) //mousedo
                 bool iscc   = getFilter()->Ytype[i] == 1;
                 colourSelector1->setCurrentColour (getFilter()->padcolor[i]);
                 textEditor->setText (getFilter()->text[i], false);
-                vSlider->setValue (getFilter()->Ydata2[i], dontSendNotification);
-                oSlider->setValue (getFilter()->Yoff[i], dontSendNotification);
-                nSlider->setValue (getFilter()->Ydata1[i], dontSendNotification);
-                ySlider->setValue (getFilter()->Ycc[i], dontSendNotification);
-                xSlider->setValue (getFilter()->Xcc[i], dontSendNotification);
-                xoSlider->setValue (getFilter()->Xoff[i], dontSendNotification);
-                triggerSlider->setValue (getFilter()->trigger[i], dontSendNotification);
-                roundnessSlider->setValue (getFilter()->roundness[i], dontSendNotification);
-                iconSizeSlider->setValue (getFilter()->iconsize[i], dontSendNotification);
+                vSlider->setValue (getFilter()->Ydata2[i], juce::dontSendNotification);
+                oSlider->setValue (getFilter()->Yoff[i], juce::dontSendNotification);
+                nSlider->setValue (getFilter()->Ydata1[i], juce::dontSendNotification);
+                ySlider->setValue (getFilter()->Ycc[i], juce::dontSendNotification);
+                xSlider->setValue (getFilter()->Xcc[i], juce::dontSendNotification);
+                xoSlider->setValue (getFilter()->Xoff[i], juce::dontSendNotification);
+                triggerSlider->setValue (getFilter()->trigger[i], juce::dontSendNotification);
+                roundnessSlider->setValue (getFilter()->roundness[i], juce::dontSendNotification);
+                iconSizeSlider->setValue (getFilter()->iconsize[i], juce::dontSendNotification);
                 bool centered = getFilter()->centeredText[i];
 
                 m.clear();
@@ -652,9 +656,9 @@ void midiPadsEditor::buttonStateChanged (Button* buttonThatWasClicked) //mousedo
                 sub3.clear();
                 icons.clear();
                 icons.addItem (99999, "Load...");
-                Array<File> iconFiles;
+                juce::Array<juce::File> iconFiles;
                 int j = 0;
-                for (auto&& entry : RangedDirectoryIterator (File (getFilter()->iconPath), true))
+                for (auto&& entry : juce::RangedDirectoryIterator (juce::File (getFilter()->iconPath), true))
                 {
                     if (entry.getFile().hasFileExtension ("svg")
                         || entry.getFile().hasFileExtension ("png")
@@ -683,14 +687,14 @@ void midiPadsEditor::buttonStateChanged (Button* buttonThatWasClicked) //mousedo
                 m.addCustomItem (-1, *iconSizeSlider, 64, 16, false);
                 m.addSeparator();
 
-                m.addItem (2, String ("Note"), true, ! iscc);
-                m.addItem (3, String ("CC"), true, iscc);
-                m.addItem (4, String ("Use Y-Position"), true, usey);
-                m.addItem (7, String ("Send Y-CC with Note"), true, useycc);
-                m.addItem (5, String ("Use X-Position"), true, usex);
-                m.addItem (8, String ("X is Pitch Bend"), usex, usexpb);
-                m.addItem (6, String ("Send Off Values"), true, useoff);
-                m.addItem (9, String ("Toggle Mode"), true, toggle);
+                m.addItem (2, juce::String ("Note"), true, ! iscc);
+                m.addItem (3, juce::String ("CC"), true, iscc);
+                m.addItem (4, juce::String ("Use Y-Position"), true, usey);
+                m.addItem (7, juce::String ("Send Y-CC with Note"), true, useycc);
+                m.addItem (5, juce::String ("Use X-Position"), true, usex);
+                m.addItem (8, juce::String ("X is Pitch Bend"), usex, usexpb);
+                m.addItem (6, juce::String ("Send Off Values"), true, useoff);
+                m.addItem (9, juce::String ("Toggle Mode"), true, toggle);
                 sub2.addItem (-1, "Note #:", false);
                 sub2.addCustomItem (-1, *nSlider, 64, 16, false);
                 sub2.addItem (-1, "Y-CC #:", false);
@@ -723,22 +727,22 @@ void midiPadsEditor::buttonStateChanged (Button* buttonThatWasClicked) //mousedo
                         if (pad->setImageFromFile (iconFiles[result]))
                         {
                             //save the relative path
-                            pad->setIconPath (iconFiles[result].getRelativePathFrom (File (getFilter()->iconPath)));
+                            pad->setIconPath (iconFiles[result].getRelativePathFrom (juce::File (getFilter()->iconPath)));
                             getFilter()->icon[pad->getIndex()] = pad->getIconPath();
                         }
                     }
                     else if (result == 99999)
                     {
-                        FileChooser myChooser ("Load icon...",
-                                               File (getFilter()->iconPath),
-                                               "*.png;*.gif;*.svg;*.jpg");
+                        juce::FileChooser myChooser ("Load icon...",
+                                                     juce::File (getFilter()->iconPath),
+                                                     "*.png;*.gif;*.svg;*.jpg");
 
                         if (myChooser.browseForFileToOpen())
                         {
-                            File file (myChooser.getResult());
+                            juce::File file (myChooser.getResult());
                             if (pad->setImageFromFile (file))
                             {
-                                pad->setIconPath (file.getRelativePathFrom (File (getFilter()->iconPath)));
+                                pad->setIconPath (file.getRelativePathFrom (juce::File (getFilter()->iconPath)));
                                 getFilter()->icon[pad->getIndex()] = pad->getIconPath();
                             }
                         }
@@ -749,7 +753,7 @@ void midiPadsEditor::buttonStateChanged (Button* buttonThatWasClicked) //mousedo
                         {
                             getFilter()->Ytype[i] = 0;
                             midiPad[i]->setYInt (getFilter()->Ydata2[i]);
-                            midiPad[i]->setButtonText ("CC " + String (getFilter()->Ydata1[i]));
+                            midiPad[i]->setButtonText ("CC " + juce::String (getFilter()->Ydata1[i]));
                         }
                         else
                         {
@@ -758,7 +762,7 @@ void midiPadsEditor::buttonStateChanged (Button* buttonThatWasClicked) //mousedo
                                 midiPad[i]->setYInt (getFilter()->Yoff[i]);
                             else
                                 midiPad[i]->setYInt (getFilter()->Ydata2[i]);
-                            midiPad[i]->setButtonText (MidiMessage::getMidiNoteName (getFilter()->Ydata1[i], true, true, 3));
+                            midiPad[i]->setButtonText (juce::MidiMessage::getMidiNoteName (getFilter()->Ydata1[i], true, true, 3));
                         }
                     }
                     else if (result == 4)
@@ -873,9 +877,9 @@ void midiPadsEditor::buttonStateChanged (Button* buttonThatWasClicked) //mousedo
                     }
                     else if (result == 66)
                     {
-                        getFilter()->icon[i] = String();
+                        getFilter()->icon[i] = juce::String();
                         pad->setImages (0);
-                        pad->setIconPath (String());
+                        pad->setIconPath (juce::String());
                     }
                     else if (result == 88)
                         getFilter()->midilisten[i] = 1.0f;
@@ -919,7 +923,7 @@ void midiPadsEditor::sendMidi (int i, bool shiftclicked)
     if (getFilter()->togglestate[i])
     {
         getFilter()->togglestate[i] = false;
-        midiPad[i]->setToggleState (false, dontSendNotification);
+        midiPad[i]->setToggleState (false, juce::dontSendNotification);
         sendMidiOff (i);
         sending[i] = false;
         return;
@@ -929,19 +933,19 @@ void midiPadsEditor::sendMidi (int i, bool shiftclicked)
         for (int n = 0; n < numPads; n++)
         {
             getFilter()->togglestate[n] = false;
-            midiPad[n]->setToggleState (false, dontSendNotification);
+            midiPad[n]->setToggleState (false, juce::dontSendNotification);
         }
     }
     if (getFilter()->toggle[i] || shiftclicked)
     {
         dontsend                    = true;
         getFilter()->togglestate[i] = true;
-        midiPad[i]->setToggleState (true, dontSendNotification);
+        midiPad[i]->setToggleState (true, juce::dontSendNotification);
     }
     midiPad[i]->isPlaying = true;
     if (! getFilter()->triggered[i])
     {
-        Point<int> xy = midiPad[i]->getMouseXYRelative();
+        juce::Point<int> xy = midiPad[i]->getMouseXYRelative();
         //measure y from the bottom, make into range 0..1
         float fy = 1.0f - (((float) (xy.getY())) / ((float) (midiPad[i]->getHeight())));
         float fx = (((float) (xy.getX())) / ((float) (midiPad[i]->getWidth())));
@@ -981,13 +985,13 @@ void midiPadsEditor::sendMidi (int i, bool shiftclicked)
     sending[i] = false;
 }
 
-void midiPadsEditor::buttonClicked (Button* buttonThatWasClicked) //mouseup
+void midiPadsEditor::buttonClicked (juce::Button* buttonThatWasClicked) //mouseup
 {
     if (buttonThatWasClicked == menuButton)
     {
-        Array<File> layoutFiles, presetFiles;
-        File (getFilter()->layoutPath).findChildFiles (layoutFiles, File::findFiles, true, "*.mpadl");
-        File (getFilter()->presetPath).findChildFiles (presetFiles, File::findFiles, true, "*.mpads");
+        juce::Array<juce::File> layoutFiles, presetFiles;
+        juce::File (getFilter()->layoutPath).findChildFiles (layoutFiles, juce::File::findFiles, true, "*.mpadl");
+        juce::File (getFilter()->presetPath).findChildFiles (presetFiles, juce::File::findFiles, true, "*.mpads");
         //main menu
         bool sendoffvalue  = true;
         bool useyvalue     = true;
@@ -1027,35 +1031,35 @@ void midiPadsEditor::buttonClicked (Button* buttonThatWasClicked) //mouseup
         presets.clear();
         fileMenu.clear();
 
-        m.addItem (1001, String ("Full Screen"), true, fullscreen);
-        m.addItem (33, String ("Edit Mode"), true, editmode);
+        m.addItem (1001, juce::String ("Full Screen"), true, fullscreen);
+        m.addItem (33, juce::String ("Edit Mode"), true, editmode);
         m.addSeparator();
         for (int i = 0; i < layoutFiles.size(); i++)
             layout.addItem (100000 + i, layoutFiles[i].getFileNameWithoutExtension());
 #ifdef _DEBUG
-        layout.addItem (18, String ("1 Pad"), true);
-        layout.addItem (17, String ("4 Pads"), true);
-        layout.addItem (19, String ("4 Sliders"), true);
-        layout.addItem (10, String ("10 Pads"), true);
-        layout.addItem (14, String ("2 Pads, 12 Sliders"), true);
-        layout.addItem (20, String ("16 Pads"), true);
-        layout.addItem (21, String ("16 Sliders"), true);
-        layout.addItem (22, String ("64 Pads"), true);
-        layout.addItem (23, String ("8 Ch Mixer"), true);
-        layout.addItem (24, String ("Hexagons"), true);
-        layout.addItem (28, String ("2 XY, 5 Sliders, 21 Buttons"));
-        layout.addItem (52, String ("2 XY, 49 Buttons"), true);
-        layout.addItem (46, String ("12 Sliders, 2 XY, 25 Buttons"));
-        layout.addItem (48, String ("6 Mixer Blocks"), true);
-        layout.addItem (64, String ("8 Mixer Blocks w/sends"), true);
-        layout.addItem (55, String ("1 XY, 6 Sliders, 48 Buttons"), true);
+        layout.addItem (18, juce::String ("1 Pad"), true);
+        layout.addItem (17, juce::String ("4 Pads"), true);
+        layout.addItem (19, juce::String ("4 Sliders"), true);
+        layout.addItem (10, juce::String ("10 Pads"), true);
+        layout.addItem (14, juce::String ("2 Pads, 12 Sliders"), true);
+        layout.addItem (20, juce::String ("16 Pads"), true);
+        layout.addItem (21, juce::String ("16 Sliders"), true);
+        layout.addItem (22, juce::String ("64 Pads"), true);
+        layout.addItem (23, juce::String ("8 Ch Mixer"), true);
+        layout.addItem (24, juce::String ("Hexagons"), true);
+        layout.addItem (28, juce::String ("2 XY, 5 Sliders, 21 Buttons"));
+        layout.addItem (52, juce::String ("2 XY, 49 Buttons"), true);
+        layout.addItem (46, juce::String ("12 Sliders, 2 XY, 25 Buttons"));
+        layout.addItem (48, juce::String ("6 Mixer Blocks"), true);
+        layout.addItem (64, juce::String ("8 Mixer Blocks w/sends"), true);
+        layout.addItem (55, juce::String ("1 XY, 6 Sliders, 48 Buttons"), true);
 #endif
-        layout.addItem (9998, String ("Load..."), true);
-        layout.addItem (9999, String ("Save..."), true);
+        layout.addItem (9998, juce::String ("Load..."), true);
+        layout.addItem (9999, juce::String ("Save..."), true);
         m.addSubMenu ("Layout", layout);
         m.addItem (111, "Clear all icons");
-        m.addItem (7, String ("Show Dots"), true, showalldots);
-        m.addItem (77, String ("Show Values"), true, showallvalues);
+        m.addItem (7, juce::String ("Show Dots"), true, showalldots);
+        m.addItem (77, juce::String ("Show Values"), true, showallvalues);
         m.addItem (33333, "Centered Text", true, centeredNames);
 
         m.addItem (-1, "Pad Roundness:", false);
@@ -1064,16 +1068,16 @@ void midiPadsEditor::buttonClicked (Button* buttonThatWasClicked) //mouseup
         m.addCustomItem (-1, *globalIconSizeSlider, 64, 16, false);
         m.addSeparator();
 
-        m.addItem (1, String ("Send off values"), true, sendoffvalue);
-        m.addItem (2, String ("Use Midi Triggering"), true, triggering);
-        m.addItem (3, String ("Use Input Velocity"), triggering, useinvel);
+        m.addItem (1, juce::String ("Send off values"), true, sendoffvalue);
+        m.addItem (2, juce::String ("Use Midi Triggering"), true, triggering);
+        m.addItem (3, juce::String ("Use Input Velocity"), triggering, useinvel);
         //m.addItem (222, String("Piezo Mode"), triggering, noteontrig);
-        m.addItem (4, String ("Use Y-Position"), true, useyvalue);
-        m.addItem (5, String ("Use X-Position"), true, usexvalue);
-        m.addItem (6, String ("Send Aftertouch"), true, useaft);
-        m.addItem (8, String ("Mono Mode"), true, monomode);
-        m.addItem (9, String ("Use mouseup anywhere"), true, usemouseup);
-        m.addItem (50, String ("Midi Thru"), true, thru);
+        m.addItem (4, juce::String ("Use Y-Position"), true, useyvalue);
+        m.addItem (5, juce::String ("Use X-Position"), true, usexvalue);
+        m.addItem (6, juce::String ("Send Aftertouch"), true, useaft);
+        m.addItem (8, juce::String ("Mono Mode"), true, monomode);
+        m.addItem (9, juce::String ("Use mouseup anywhere"), true, usemouseup);
+        m.addItem (50, juce::String ("Midi Thru"), true, thru);
         m.addSeparator();
         m.addItem (-1, "In Channel:", false);
         m.addCustomItem (-1, *icSlider, 64, 16, false);
@@ -1083,12 +1087,12 @@ void midiPadsEditor::buttonClicked (Button* buttonThatWasClicked) //mouseup
         for (int i = 0; i < presetFiles.size(); i++)
             presets.addItem (200000 + i, presetFiles[i].getFileNameWithoutExtension());
         m.addSubMenu ("Presets", presets);
-        fileMenu.addItem (5473, String ("Save Bank..."));
-        fileMenu.addItem (54731, String ("Save Patch..."));
-        fileMenu.addItem (9999, String ("Save Layout..."));
-        fileMenu.addItem (1042, String ("Load Bank/Patch..."));
+        fileMenu.addItem (5473, juce::String ("Save Bank..."));
+        fileMenu.addItem (54731, juce::String ("Save Patch..."));
+        fileMenu.addItem (9999, juce::String ("Save Layout..."));
+        fileMenu.addItem (1042, juce::String ("Load Bank/Patch..."));
         m.addSubMenu ("Save/Load", fileMenu);
-        m.addItem (-1, String ("- midiPads ") + String (JucePlugin_VersionString) + String (" -"), false);
+        m.addItem (-1, juce::String ("- midiPads ") + juce::String (JucePlugin_VersionString) + juce::String (" -"), false);
 
         int result = m.showAt (menuButton);
         if (result > 0)
@@ -1120,14 +1124,14 @@ void midiPadsEditor::buttonClicked (Button* buttonThatWasClicked) //mouseup
             }
             else if (result == 9999)
             {
-                FileChooser myChooser ("Save layout...",
-                                       File (getFilter()->layoutPath + File::getSeparatorString()
-                                             + getFilter()->getProgramName (getFilter()->getCurrentProgram())
-                                             + ".mpadl"),
-                                       "*.mpadl");
+                juce::FileChooser myChooser ("Save layout...",
+                                             juce::File (getFilter()->layoutPath + juce::File::getSeparatorString()
+                                                         + getFilter()->getProgramName (getFilter()->getCurrentProgram())
+                                                         + ".mpadl"),
+                                             "*.mpadl");
                 if (myChooser.browseForFileToSave (true))
                 {
-                    File file (myChooser.getResult());
+                    juce::File file (myChooser.getResult());
                     //getFilter()->patchPath = file.getParentDirectory().getFullPathName();
                     if (! file.hasFileExtension ("mpadl"))
                         file = file.withFileExtension ("mpadl");
@@ -1137,26 +1141,26 @@ void midiPadsEditor::buttonClicked (Button* buttonThatWasClicked) //mouseup
             }
             else if (result == 9998)
             {
-                FileChooser myChooser ("Load layout...",
-                                       File (getFilter()->layoutPath),
-                                       "*.mpadl");
+                juce::FileChooser myChooser ("Load layout...",
+                                             juce::File (getFilter()->layoutPath),
+                                             "*.mpadl");
 
                 if (myChooser.browseForFileToOpen())
                 {
-                    File file (myChooser.getResult());
+                    juce::File file (myChooser.getResult());
                     getFilter()->loadXmlLayout (file);
                     resized();
                 }
             }
             else if (result == 5473)
             {
-                FileChooser myChooser ("Save bank...",
-                                       File (getFilter()->bankPath + File::getSeparatorString() + "midiPads.mpadb"),
-                                       "*.mpadb");
+                juce::FileChooser myChooser ("Save bank...",
+                                             juce::File (getFilter()->bankPath + juce::File::getSeparatorString() + "midiPads.mpadb"),
+                                             "*.mpadb");
 
                 if (myChooser.browseForFileToSave (true))
                 {
-                    File file (myChooser.getResult());
+                    juce::File file (myChooser.getResult());
                     //getFilter()->patchPath = file.getParentDirectory().getFullPathName();
                     if (! file.hasFileExtension ("mpadb"))
                         file = file.withFileExtension ("mpadb");
@@ -1166,16 +1170,16 @@ void midiPadsEditor::buttonClicked (Button* buttonThatWasClicked) //mouseup
             }
             else if (result == 54731)
             {
-                FileChooser myChooser ("Save patch...",
-                                       File (getFilter()->presetPath
-                                             + File::getSeparatorString()
-                                             + getFilter()->getProgramName (getFilter()->getCurrentProgram())
-                                             + ".mpads"),
-                                       "*.mpads");
+                juce::FileChooser myChooser ("Save patch...",
+                                             juce::File (getFilter()->presetPath
+                                                         + juce::File::getSeparatorString()
+                                                         + getFilter()->getProgramName (getFilter()->getCurrentProgram())
+                                                         + ".mpads"),
+                                             "*.mpads");
 
                 if (myChooser.browseForFileToSave (true))
                 {
-                    File file (myChooser.getResult());
+                    juce::File file (myChooser.getResult());
                     //getFilter()->patchPath = file.getParentDirectory().getFullPathName();
                     if (! file.hasFileExtension ("mpads"))
                         file = file.withFileExtension ("mpads");
@@ -1185,13 +1189,13 @@ void midiPadsEditor::buttonClicked (Button* buttonThatWasClicked) //mouseup
             }
             else if (result == 1042)
             {
-                FileChooser myChooser ("Load bank/patch...",
-                                       File (getFilter()->pluginPath),
-                                       "*.mpads;*.mpadb;*.mpadl;*.fxb;*.fxp");
+                juce::FileChooser myChooser ("Load bank/patch...",
+                                             juce::File (getFilter()->pluginPath),
+                                             "*.mpads;*.mpadb;*.mpadl;*.fxb;*.fxp");
 
                 if (myChooser.browseForFileToOpen())
                 {
-                    File file (myChooser.getResult());
+                    juce::File file (myChooser.getResult());
                     if (file.hasFileExtension ("mpadb"))
                         getFilter()->loadXmlBank (file);
                     else if (file.hasFileExtension ("mpads"))
@@ -1239,13 +1243,13 @@ void midiPadsEditor::buttonClicked (Button* buttonThatWasClicked) //mouseup
                 if (! fullscreen)
                 {
                     container->addToDesktop (0);
-                    Desktop::getInstance().setKioskModeComponent (container, false);
+                    juce::Desktop::getInstance().setKioskModeComponent (container, false);
                     fullscreen = true;
                     resized();
                 }
                 else
                 {
-                    Desktop::getInstance().setKioskModeComponent (0);
+                    juce::Desktop::getInstance().setKioskModeComponent (0);
                     this->addChildComponent (container);
                     fullscreen = false;
                     resized();
@@ -1524,9 +1528,9 @@ void midiPadsEditor::buttonClicked (Button* buttonThatWasClicked) //mouseup
             {
                 for (int i = 0; i < numPads; i++)
                 {
-                    getFilter()->icon[i] = String();
+                    getFilter()->icon[i] = juce::String();
                     midiPad[i]->setImages (0);
-                    midiPad[i]->setIconPath (String());
+                    midiPad[i]->setIconPath (juce::String());
                 }
             }
             else if (result == 33)
@@ -1554,7 +1558,7 @@ void midiPadsEditor::buttonClicked (Button* buttonThatWasClicked) //mouseup
             }
         }
     }
-    else if (! ModifierKeys::getCurrentModifiers().isAltDown())
+    else if (! juce::ModifierKeys::getCurrentModifiers().isAltDown())
     {
         if (! dontsend)
         {
@@ -1599,11 +1603,11 @@ void midiPadsEditor::sendMidiOff (int i)
     }
 }
 
-void midiPadsEditor::sliderValueChanged (Slider* sliderThatWasMoved)
+void midiPadsEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
 {
     if (sliderThatWasMoved == hueSlider)
     {
-        color              = Colour ((float) hueSlider->getValue(), (float) saturationSlider->getValue(), (float) brigtnessSlider->getValue(), 1.0f);
+        color              = juce::Colour ((float) hueSlider->getValue(), (float) saturationSlider->getValue(), (float) brigtnessSlider->getValue(), 1.0f);
         container->bgcolor = color;
         color2             = color.contrasting ((float) padOpacitySlider->getValue());
         getFilter()->bghue = (float) (hueSlider->getValue());
@@ -1611,7 +1615,7 @@ void midiPadsEditor::sliderValueChanged (Slider* sliderThatWasMoved)
     }
     else if (sliderThatWasMoved == saturationSlider)
     {
-        color              = Colour ((float) hueSlider->getValue(), (float) saturationSlider->getValue(), (float) brigtnessSlider->getValue(), 1.0f);
+        color              = juce::Colour ((float) hueSlider->getValue(), (float) saturationSlider->getValue(), (float) brigtnessSlider->getValue(), 1.0f);
         container->bgcolor = color;
         color2             = color.contrasting ((float) padOpacitySlider->getValue());
         getFilter()->bgsat = (float) (saturationSlider->getValue());
@@ -1619,7 +1623,7 @@ void midiPadsEditor::sliderValueChanged (Slider* sliderThatWasMoved)
     }
     else if (sliderThatWasMoved == brigtnessSlider)
     {
-        color              = Colour ((float) hueSlider->getValue(), (float) saturationSlider->getValue(), (float) brigtnessSlider->getValue(), 1.0f);
+        color              = juce::Colour ((float) hueSlider->getValue(), (float) saturationSlider->getValue(), (float) brigtnessSlider->getValue(), 1.0f);
         container->bgcolor = color;
         color2             = color.contrasting ((float) padOpacitySlider->getValue());
         getFilter()->bgbri = (float) brigtnessSlider->getValue();
@@ -1727,7 +1731,7 @@ void midiPadsEditor::sliderValueChanged (Slider* sliderThatWasMoved)
     }
 }
 
-void midiPadsEditor::textEditorTextChanged (TextEditor& editor)
+void midiPadsEditor::textEditorTextChanged (juce::TextEditor& editor)
 {
     if (&editor == textEditor)
     {
@@ -1736,7 +1740,7 @@ void midiPadsEditor::textEditorTextChanged (TextEditor& editor)
     }
 }
 
-void midiPadsEditor::textEditorReturnKeyPressed (TextEditor& editor)
+void midiPadsEditor::textEditorReturnKeyPressed (juce::TextEditor& editor)
 {
     if (&editor == textEditor)
     {
@@ -1746,7 +1750,7 @@ void midiPadsEditor::textEditorReturnKeyPressed (TextEditor& editor)
     }
 }
 
-void midiPadsEditor::textEditorEscapeKeyPressed (TextEditor& editor)
+void midiPadsEditor::textEditorEscapeKeyPressed (juce::TextEditor& editor)
 {
     if (&editor == textEditor)
     {
@@ -1755,7 +1759,7 @@ void midiPadsEditor::textEditorEscapeKeyPressed (TextEditor& editor)
     }
 }
 
-void midiPadsEditor::textEditorFocusLost (TextEditor& editor)
+void midiPadsEditor::textEditorFocusLost (juce::TextEditor& editor)
 {
     if (&editor == textEditor)
     {
@@ -1766,7 +1770,7 @@ void midiPadsEditor::textEditorFocusLost (TextEditor& editor)
 }
 
 //==============================================================================
-void midiPadsEditor::changeListenerCallback (ChangeBroadcaster* source)
+void midiPadsEditor::changeListenerCallback (juce::ChangeBroadcaster* source)
 {
     if (source == getFilter())
     {
@@ -1787,7 +1791,7 @@ void midiPadsEditor::changeListenerCallback (ChangeBroadcaster* source)
     }
     else if (source == colourSelector1)
     {
-        ColourSelector* cs = (ColourSelector*) source;
+        auto* cs = (juce::ColourSelector*) source;
         midiPad[lastPadMenu]->setColour (cs->getCurrentColour().withAlpha (getFilter()->contrast));
         getFilter()->padcolor[lastPadMenu] = cs->getCurrentColour();
     }
@@ -1802,7 +1806,7 @@ void midiPadsEditor::padTriggered()
         memcpy (triggered, getFilter()->triggered, sizeof (triggered));
         getFilter()->getCallbackLock().exit();
         for (int i = 0; i < numPads; i++)
-            midiPad[i]->setState (triggered[i] ? Button::buttonDown : Button::buttonNormal);
+            midiPad[i]->setState (triggered[i] ? juce::Button::buttonDown : juce::Button::buttonNormal);
     }
     else
     {
@@ -1832,9 +1836,9 @@ void midiPadsEditor::dotMoved (int pad)
     getFilter()->dotmoved[pad] = false;
 }
 
-bool midiPadsEditor::isInterestedInFileDrag (const StringArray& files)
+bool midiPadsEditor::isInterestedInFileDrag (const juce::StringArray& files)
 {
-    File file = File (files.joinIntoString (String(), 0, 1));
+    juce::File file = juce::File (files.joinIntoString (juce::String(), 0, 1));
     if (file.hasFileExtension ("png") || file.hasFileExtension ("gif") || file.hasFileExtension ("jpg") || file.hasFileExtension ("svg") || file.hasFileExtension ("mpads") || file.hasFileExtension ("mpadb") || file.hasFileExtension ("fxb") || file.hasFileExtension ("fxp"))
         return true;
     return false;
@@ -1844,8 +1848,8 @@ void midiPadsEditor::filesDropped (const juce::StringArray& filenames, int mouse
 {
     if (isInterestedInFileDrag (filenames))
     {
-        String filename = filenames.joinIntoString (String(), 0, 1);
-        File file       = File (filename);
+        juce::String filename = filenames.joinIntoString (juce::String(), 0, 1);
+        juce::File file       = juce::File (filename);
         if (file.hasFileExtension ("mpads"))
         {
             getFilter()->loadXmlPatch (getFilter()->getCurrentProgram(), file);
@@ -1880,7 +1884,7 @@ void midiPadsEditor::filesDropped (const juce::StringArray& filenames, int mouse
                 if (pad->setImageFromFile (file))
                 {
                     //save the relative path
-                    pad->setIconPath (file.getRelativePathFrom (File (getFilter()->iconPath)));
+                    pad->setIconPath (file.getRelativePathFrom (juce::File (getFilter()->iconPath)));
                     getFilter()->icon[pad->getIndex()] = pad->getIconPath();
                 }
             }
@@ -1905,9 +1909,9 @@ void midiPadsEditor::updateParametersFromFilter()
     bool usex[numPads];
     bool usey[numPads];
     bool useoff[numPads];
-    String t[numPads];
-    String icon[numPads];
-    Colour padcolor[numPads];
+    juce::String t[numPads];
+    juce::String icon[numPads];
+    juce::Colour padcolor[numPads];
     bool toggle[numPads];
     bool tstate[numPads];
     float roundness[numPads];
@@ -1967,15 +1971,15 @@ void midiPadsEditor::updateParametersFromFilter()
         if (icon[i].isEmpty())
         {
             midiPad[i]->setImages (0);
-            midiPad[i]->setIconPath (String());
+            midiPad[i]->setIconPath (juce::String());
         }
         else
         {
-            String fullpath = icon[i];
-            if (! File::getCurrentWorkingDirectory().getChildFile (fullpath).existsAsFile())
-                fullpath = getFilter()->iconPath + File::getSeparatorString() + icon[i];
+            juce::String fullpath = icon[i];
+            if (! juce::File::getCurrentWorkingDirectory().getChildFile (fullpath).existsAsFile())
+                fullpath = getFilter()->iconPath + juce::File::getSeparatorString() + icon[i];
             //Drawable* image = Drawable::createFromImageFile(File(fullpath));
-            if (! midiPad[i]->setImageFromFile (File (fullpath)))
+            if (! midiPad[i]->setImageFromFile (juce::File (fullpath)))
                 midiPad[i]->setImages (0);
             midiPad[i]->setIconPath (icon[i]);
         }
@@ -1986,7 +1990,7 @@ void midiPadsEditor::updateParametersFromFilter()
         midiPad[i]->setColour (padcolor[i].withAlpha (contrast));
         midiPad[i]->roundness = roundness[i];
         midiPad[i]->imageSize = iconsize[i];
-        midiPad[i]->setToggleState (tstate[i], dontSendNotification);
+        midiPad[i]->setToggleState (tstate[i], juce::dontSendNotification);
         midiPad[i]->setText (t[i]);
         midiPad[i]->setCenteredText (centered[i]);
 
@@ -2027,21 +2031,21 @@ void midiPadsEditor::updateParametersFromFilter()
             }
         }
         if (newMidiType[i] == 1)
-            midiPad[i]->setButtonText ("CC " + String (newMidiData[i]));
+            midiPad[i]->setButtonText ("CC " + juce::String (newMidiData[i]));
         else
-            midiPad[i]->setButtonText (MidiMessage::getMidiNoteName (newMidiData[i], true, true, 3));
+            midiPad[i]->setButtonText (juce::MidiMessage::getMidiNoteName (newMidiData[i], true, true, 3));
     }
 
-    color              = Colour (hue, sat, bri, 1.0f);
+    color              = juce::Colour (hue, sat, bri, 1.0f);
     container->bgcolor = color;
-    color2             = Colour (color.contrasting (contrast));
+    color2             = juce::Colour (color.contrasting (contrast));
 
-    hueSlider->setValue (hue, dontSendNotification);
-    saturationSlider->setValue (sat, dontSendNotification);
-    brigtnessSlider->setValue (bri, dontSendNotification);
-    padOpacitySlider->setValue (contrast, dontSendNotification);
-    globalRoundnessSlider->setValue (roundness[0], dontSendNotification);
-    globalIconSizeSlider->setValue (iconsize[0], dontSendNotification);
+    hueSlider->setValue (hue, juce::dontSendNotification);
+    saturationSlider->setValue (sat, juce::dontSendNotification);
+    brigtnessSlider->setValue (bri, juce::dontSendNotification);
+    padOpacitySlider->setValue (contrast, juce::dontSendNotification);
+    globalRoundnessSlider->setValue (roundness[0], juce::dontSendNotification);
+    globalIconSizeSlider->setValue (iconsize[0], juce::dontSendNotification);
 
     if (! editmode)
     {
@@ -2060,10 +2064,10 @@ void midiPadsEditor::updateParametersFromFilter()
         padOpacitySlider->setVisible (true);
     }
 
-    velocitySlider->setValue (newVelocity * 2.0, dontSendNotification);
-    valueSlider->setValue (newCCValue * 2.0, dontSendNotification);
-    icSlider->setValue ((float) (1 + (int) (newInCh * 15.1)), dontSendNotification);
-    cSlider->setValue ((float) (1 + (int) (newOutCh * 15.1)), dontSendNotification);
+    velocitySlider->setValue (newVelocity * 2.0, juce::dontSendNotification);
+    valueSlider->setValue (newCCValue * 2.0, juce::dontSendNotification);
+    icSlider->setValue ((float) (1 + (int) (newInCh * 15.1)), juce::dontSendNotification);
+    cSlider->setValue ((float) (1 + (int) (newOutCh * 15.1)), juce::dontSendNotification);
 
     if (getWidth() != filter->lastUIWidth || getHeight() != filter->lastUIHeight)
         setSize (filter->lastUIWidth, filter->lastUIHeight);

--- a/pizjuce/midiPads/midiPadsEditor.h
+++ b/pizjuce/midiPads/midiPadsEditor.h
@@ -1,88 +1,88 @@
 #ifndef MIDIPADSPLUGINEDITOR_H
 #define MIDIPADSPLUGINEDITOR_H
 
-#include "juce_audio_processors/juce_audio_processors.h"
-#include "juce_gui_basics/juce_gui_basics.h"
-#include "juce_gui_extra/juce_gui_extra.h"
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <juce_gui_extra/juce_gui_extra.h>
 
 #include "MidiPad.h"
 #include "midiPads.h"
 
-class fullScreenContainer : public Component
+class fullScreenContainer : public juce::Component
 {
 public:
-    fullScreenContainer() { bgcolor = Colours::white; }
+    fullScreenContainer() { bgcolor = juce::Colours::white; }
     ~fullScreenContainer() override{};
-    Colour bgcolor;
+    juce::Colour bgcolor;
 
 private:
-    void paint (Graphics& g) override { g.fillAll (bgcolor); }
+    void paint (juce::Graphics& g) override { g.fillAll (bgcolor); }
 };
 
-class midiPadsEditor : public AudioProcessorEditor,
-                       public ChangeListener,
-                       public Button::Listener,
-                       public Slider::Listener,
-                       public TextEditor::Listener,
-                       public FileDragAndDropTarget
+class midiPadsEditor : public juce::AudioProcessorEditor,
+                       public juce::ChangeListener,
+                       public juce::Button::Listener,
+                       public juce::Slider::Listener,
+                       public juce::TextEditor::Listener,
+                       public juce::FileDragAndDropTarget
 {
 public:
     midiPadsEditor (midiPads* const ownerFilter);
     ~midiPadsEditor() override;
 
     //==============================================================================
-    void changeListenerCallback (ChangeBroadcaster* source) override;
-    void buttonClicked (Button*) override;
-    void buttonStateChanged (Button*) override;
-    void sliderValueChanged (Slider*) override;
-    void mouseDown (const MouseEvent& e) override;
-    void mouseDrag (const MouseEvent& e) override;
-    void mouseUp (const MouseEvent& e) override;
-    void mouseDoubleClick (const MouseEvent& e) override;
-    void textEditorTextChanged (TextEditor&) override;
-    void textEditorReturnKeyPressed (TextEditor&) override;
-    void textEditorEscapeKeyPressed (TextEditor&) override;
-    void textEditorFocusLost (TextEditor&) override;
-    void filesDropped (const StringArray& files, int x, int y) override;
-    bool isInterestedInFileDrag (const StringArray& files) override;
-    void paint (Graphics&) override;
+    void changeListenerCallback (juce::ChangeBroadcaster* source) override;
+    void buttonClicked (juce::Button*) override;
+    void buttonStateChanged (juce::Button*) override;
+    void sliderValueChanged (juce::Slider*) override;
+    void mouseDown (const juce::MouseEvent& e) override;
+    void mouseDrag (const juce::MouseEvent& e) override;
+    void mouseUp (const juce::MouseEvent& e) override;
+    void mouseDoubleClick (const juce::MouseEvent& e) override;
+    void textEditorTextChanged (juce::TextEditor&) override;
+    void textEditorReturnKeyPressed (juce::TextEditor&) override;
+    void textEditorEscapeKeyPressed (juce::TextEditor&) override;
+    void textEditorFocusLost (juce::TextEditor&) override;
+    void filesDropped (const juce::StringArray& files, int x, int y) override;
+    bool isInterestedInFileDrag (const juce::StringArray& files) override;
+    void paint (juce::Graphics&) override;
     void resized() override;
 
-    Colour color, color2;
+    juce::Colour color, color2;
 
 private:
     //==============================================================================
     MidiPad* midiPad[numPads];
 
-    ColourSelector* colourSelector1;
-    Slider* vSlider;
-    Slider* nSlider;
-    Slider* ySlider;
-    Slider* oSlider;
-    Slider* triggerSlider;
-    Slider* xSlider;
-    Slider* xoSlider;
-    Slider* roundnessSlider;
-    Slider* iconSizeSlider;
-    Slider* cSlider;
-    Slider* icSlider;
-    Slider* hueSlider;
-    Slider* saturationSlider;
-    Slider* brigtnessSlider;
-    Slider* padOpacitySlider;
-    Slider* globalRoundnessSlider;
-    Slider* globalIconSizeSlider;
-    Slider* velocitySlider;
-    Slider* valueSlider;
-    TextEditor* textEditor;
-    TextButton* menuButton;
+    juce::ColourSelector* colourSelector1;
+    juce::Slider* vSlider;
+    juce::Slider* nSlider;
+    juce::Slider* ySlider;
+    juce::Slider* oSlider;
+    juce::Slider* triggerSlider;
+    juce::Slider* xSlider;
+    juce::Slider* xoSlider;
+    juce::Slider* roundnessSlider;
+    juce::Slider* iconSizeSlider;
+    juce::Slider* cSlider;
+    juce::Slider* icSlider;
+    juce::Slider* hueSlider;
+    juce::Slider* saturationSlider;
+    juce::Slider* brigtnessSlider;
+    juce::Slider* padOpacitySlider;
+    juce::Slider* globalRoundnessSlider;
+    juce::Slider* globalIconSizeSlider;
+    juce::Slider* velocitySlider;
+    juce::Slider* valueSlider;
+    juce::TextEditor* textEditor;
+    juce::TextButton* menuButton;
     fullScreenContainer* container;
     Component* padEditor;
-    ResizableCornerComponent* resizer;
-    ComponentBoundsConstrainer resizeLimits;
-    TooltipWindow tooltipWindow;
+    juce::ResizableCornerComponent* resizer;
+    juce::ComponentBoundsConstrainer resizeLimits;
+    juce::TooltipWindow tooltipWindow;
 
-    PopupMenu m, sub1, sub2, sub3, icons, layout, presets, fileMenu;
+    juce::PopupMenu m, sub1, sub2, sub3, icons, layout, presets, fileMenu;
 
     void updateParametersFromFilter();
     void padTriggered();
@@ -101,7 +101,7 @@ private:
     bool automateHost;
     bool dragging;
     bool resizing;
-    Point<int> dragstart;
+    juce::Point<int> dragstart;
     int lastTouchedPad;
     int lastPadMenu;
 

--- a/pizjuce/midiStep/MidiLoop.h
+++ b/pizjuce/midiStep/MidiLoop.h
@@ -1,9 +1,7 @@
 #ifndef PIZ_MIDI_LOOP_HEADER
 #define PIZ_MIDI_LOOP_HEADER
 
-#include "juce_audio_basics/juce_audio_basics.h"
-
-using namespace juce;
+#include <juce_audio_basics/juce_audio_basics.h>
 
 enum playmodes
 {
@@ -15,7 +13,7 @@ enum playmodes
     numPlayModes
 };
 
-class Loop : public MidiMessageSequence
+class Loop : public juce::MidiMessageSequence
 {
 public:
     Loop()
@@ -103,7 +101,7 @@ public:
         return false;
     }
 
-    void playAllNotesAtCurrentTime (MidiBuffer& buffer, int sample_number, int velocity)
+    void playAllNotesAtCurrentTime (juce::MidiBuffer& buffer, int sample_number, int velocity)
     {
         if (findNextNote())
         {
@@ -120,11 +118,11 @@ public:
         }
     }
 
-    void sendCurrentNoteToBuffer (MidiBuffer& buffer, int sample_number, int velocity)
+    void sendCurrentNoteToBuffer (juce::MidiBuffer& buffer, int sample_number, int velocity)
     {
-        MidiMessage m                                      = this->getEventPointer (currentIndex)->message;
-        playingNote[m.getNoteNumber()][m.getChannel() - 1] = jlimit (0, 127, m.getNoteNumber() + transpose);
-        m.setNoteNumber (jlimit (0, 127, m.getNoteNumber() + transpose));
+        juce::MidiMessage m                                = this->getEventPointer (currentIndex)->message;
+        playingNote[m.getNoteNumber()][m.getChannel() - 1] = juce::jlimit (0, 127, m.getNoteNumber() + transpose);
+        m.setNoteNumber (juce::jlimit (0, 127, m.getNoteNumber() + transpose));
         m.setVelocity ((((float) velocity * midiScaler * velocitySensitivity) + (1.f - velocitySensitivity)));
         if (outChannel > 0)
             m.setChannel (outChannel);
@@ -156,7 +154,7 @@ public:
         }
     }
 
-    void sendNoteOffMessagesToBuffer (MidiBuffer& buffer, int sample_number)
+    void sendNoteOffMessagesToBuffer (juce::MidiBuffer& buffer, int sample_number)
     {
         for (int ch = 0; ch < 16; ch++)
         {
@@ -165,14 +163,14 @@ public:
                 if (isNotePlaying (i, ch))
                 {
                     int channel = outChannel > 0 ? outChannel - 1 : ch;
-                    buffer.addEvent (MidiMessage (MIDI_NOTEOFF + channel, playingNote[i][ch], 0), sample_number);
+                    buffer.addEvent (juce::MidiMessage (MIDI_NOTEOFF + channel, playingNote[i][ch], 0), sample_number);
                     playingNote[i][ch] = NOT_PLAYING;
                 }
             }
         }
     }
 
-    MidiMessage getCurrentMessage()
+    juce::MidiMessage getCurrentMessage()
     {
         if (currentIndex >= this->getNumEvents())
             currentIndex = 0;

--- a/pizjuce/midiStep/PianoRoll.h
+++ b/pizjuce/midiStep/PianoRoll.h
@@ -3,7 +3,7 @@
 
 #include "step.h"
 
-class PianoRoll : public Component
+class PianoRoll : public juce::Component
 {
 public:
     PianoRoll (MidiStep* plugin_);
@@ -20,13 +20,13 @@ public:
     float pixelsPerPpq;
     float getNoteHeight();
 
-    void mouseDown (const MouseEvent& e) override;
-    void mouseDrag (const MouseEvent& e) override;
-    void mouseUp (const MouseEvent& e) override;
-    void mouseMove (const MouseEvent& e) override;
-    void mouseDoubleClick (const MouseEvent& e) override;
+    void mouseDown (const juce::MouseEvent& e) override;
+    void mouseDrag (const juce::MouseEvent& e) override;
+    void mouseUp (const juce::MouseEvent& e) override;
+    void mouseMove (const juce::MouseEvent& e) override;
+    void mouseDoubleClick (const juce::MouseEvent& e) override;
 
-    void paint (Graphics& g) override;
+    void paint (juce::Graphics& g) override;
     void resized() override;
 
 private:
@@ -42,7 +42,7 @@ private:
     float xinc;
     float yinc;
     double lastDragTime;
-    uint8 draggingNoteChannel;
+    juce::uint8 draggingNoteChannel;
     int draggingNoteNumber;
     int draggingNoteVelocity;
     double draggingNoteLength;

--- a/pizjuce/midiStep/step.cpp
+++ b/pizjuce/midiStep/step.cpp
@@ -1,6 +1,8 @@
 #include "step.h"
 #include "stepgui.h"
 
+using juce::roundToInt;
+
 //==============================================================================
 /*
     This function must be implemented to create the actual plugin object that
@@ -49,21 +51,21 @@ MidiStep::MidiStep()
     for (int i = 0; i < numLoops; i++)
         loop.add (new Loop());
 
-    loopDir = ((File::getSpecialLocation (File::currentExecutableFile)).getParentDirectory()).getFullPathName()
-            + File::getSeparatorString() + "midiStep";
-    String defaultBank = loopDir + File::getSeparatorString() + "default.fxb";
-    programs           = new JuceProgram[getNumPrograms()];
-    if (File (defaultBank).exists())
+    loopDir = ((juce::File::getSpecialLocation (juce::File::currentExecutableFile)).getParentDirectory()).getFullPathName()
+            + juce::File::getSeparatorString() + "midiStep";
+    juce::String defaultBank = loopDir + juce::File::getSeparatorString() + "default.fxb";
+    programs                 = new JuceProgram[getNumPrograms()];
+    if (juce::File (defaultBank).exists())
     {
-        MemoryBlock bank = MemoryBlock (0, true);
-        File (defaultBank).loadFileAsData (bank);
+        juce::MemoryBlock bank = juce::MemoryBlock (0, true);
+        juce::File (defaultBank).loadFileAsData (bank);
         bank.removeSection (0, 0xA0);
         setStateInformation (bank.getData(), (int) bank.getSize());
     }
     else
         (loadDefaultFxb());
 
-    if (File (loopDir).findChildFiles (midiFiles, File::findFiles, true, "*.mid"))
+    if (juce::File (loopDir).findChildFiles (midiFiles, juce::File::findFiles, true, "*.mid"))
     {
         //for (int i=0;i<midiFiles.size();i++)
         //{
@@ -109,7 +111,7 @@ void MidiStep::setParameter (int index, float newValue)
     }
 }
 
-const String MidiStep::getParameterName (int index)
+const juce::String MidiStep::getParameterName (int index)
 {
     if (index == kRecord)
         return "Record";
@@ -121,7 +123,7 @@ const String MidiStep::getParameterName (int index)
         return "Thru";
     else
     {
-        String loopnum = String ((index - kNumGlobalParams) % 16 + 1);
+        juce::String loopnum = juce::String ((index - kNumGlobalParams) % 16 + 1);
         if (index < kChannel)
             return "RecArm" + loopnum;
         if (index < kTriggerKey)
@@ -133,76 +135,76 @@ const String MidiStep::getParameterName (int index)
         if (index < kNumParams)
             return "OutChannel" + loopnum;
     }
-    return String();
+    return juce::String();
 }
 
-const String MidiStep::getParameterText (int index)
+const juce::String MidiStep::getParameterText (int index)
 {
     if (index == kRecord)
     {
-        return param[kRecord] < 0.5f ? String ("Off") : String ("On");
+        return param[kRecord] < 0.5f ? juce::String ("Off") : juce::String ("On");
     }
     if (index == kRecActive)
     {
-        return param[kRecActive] < 0.5f ? String ("Off") : String ("On");
+        return param[kRecActive] < 0.5f ? juce::String ("Off") : juce::String ("On");
     }
     if (index == kActiveLoop)
     {
         if (roundToInt (param[kActiveLoop] * 16.0f) == 0)
-            return String ("Any");
+            return juce::String ("Any");
         else
-            return String (roundToInt (param[kActiveLoop] * 16.0f));
+            return juce::String (roundToInt (param[kActiveLoop] * 16.0f));
     }
     if (index == kThru)
     {
-        return param[kThru] < 0.5f ? String ("Off") : String ("On");
+        return param[kThru] < 0.5f ? juce::String ("Off") : juce::String ("On");
     }
     else
     {
         if (index < kChannel)
         { //rec arm
-            return param[index] < 0.5f ? String ("Off") : String ("On");
+            return param[index] < 0.5f ? juce::String ("Off") : juce::String ("On");
         }
         if (index < kTriggerKey)
         { //in channel
             if (roundToInt (param[index] * 16.0f) == 0)
-                return String ("Any");
+                return juce::String ("Any");
             else
-                return String (roundToInt (param[index] * 16.0f));
+                return juce::String (roundToInt (param[index] * 16.0f));
         }
         if (index < kTranspose)
         { //trigger key
             if (floatToMidi (param[index], true) < 0)
-                return String ("Learn...");
-            return String (floatToMidi (param[index], true));
+                return juce::String ("Learn...");
+            return juce::String (floatToMidi (param[index], true));
         }
         if (index < kOutChannel)
         { //transpose
-            return String (roundToInt (param[index] * 96.f) - 48);
+            return juce::String (roundToInt (param[index] * 96.f) - 48);
         }
         if (index < kNumParams)
         { //out channel
             if (roundToInt (param[index] * 16.0f) == 0)
-                return String ("No Change");
+                return juce::String ("No Change");
             else
-                return String (roundToInt (param[index] * 16.0f));
+                return juce::String (roundToInt (param[index] * 16.0f));
         }
     }
-    return String();
+    return juce::String();
 }
 
-const String MidiStep::getInputChannelName (const int channelIndex) const
+const juce::String MidiStep::getInputChannelName (const int channelIndex) const
 {
     if (channelIndex < getNumInputChannels())
-        return String (JucePlugin_Name) + String (" ") + String (channelIndex + 1);
-    return String();
+        return juce::String (JucePlugin_Name) + juce::String (" ") + juce::String (channelIndex + 1);
+    return juce::String();
 }
 
-const String MidiStep::getOutputChannelName (const int channelIndex) const
+const juce::String MidiStep::getOutputChannelName (const int channelIndex) const
 {
     if (channelIndex < getNumOutputChannels())
-        return String (JucePlugin_Name) + String (" ") + String (channelIndex + 1);
-    return String();
+        return juce::String (JucePlugin_Name) + juce::String (" ") + juce::String (channelIndex + 1);
+    return juce::String();
 }
 
 bool MidiStep::isInputChannelStereoPair (int index) const
@@ -239,17 +241,17 @@ void MidiStep::setCurrentProgram (int index)
     sendChangeMessage();
 }
 
-void MidiStep::changeProgramName (int index, const String& newName)
+void MidiStep::changeProgramName (int index, const juce::String& newName)
 {
     if (index < getNumPrograms())
         programs[index].name = newName;
 }
 
-const String MidiStep::getProgramName (int index)
+const juce::String MidiStep::getProgramName (int index)
 {
     if (index < getNumPrograms())
         return programs[index].name;
-    return String();
+    return juce::String();
 }
 
 int MidiStep::getCurrentProgram()
@@ -269,8 +271,8 @@ void MidiStep::releaseResources()
     // spare memory, etc.
 }
 
-void MidiStep::processBlock (AudioSampleBuffer& buffer,
-                             MidiBuffer& midiMessages)
+void MidiStep::processBlock (juce::AudioSampleBuffer& buffer,
+                             juce::MidiBuffer& midiMessages)
 {
     const int sampleFrames = buffer.getNumSamples();
     for (int i = getNumInputChannels(); i < getNumOutputChannels(); ++i)
@@ -278,7 +280,7 @@ void MidiStep::processBlock (AudioSampleBuffer& buffer,
         buffer.clear (i, 0, sampleFrames);
     }
 
-    AudioPlayHead::CurrentPositionInfo pos;
+    juce::AudioPlayHead::CurrentPositionInfo pos;
     if (getPlayHead() != 0 && getPlayHead()->getCurrentPosition (pos))
     {
         if (memcmp (&pos, &lastPosInfo, sizeof (pos)) != 0)
@@ -300,7 +302,7 @@ void MidiStep::processBlock (AudioSampleBuffer& buffer,
     //}
 
     //const int channel = floatToChannel(param[kChannel]);
-    MidiBuffer output;
+    juce::MidiBuffer output;
 
     for (int i = 0; i < numLoops; i++)
     {
@@ -412,13 +414,13 @@ void MidiStep::processBlock (AudioSampleBuffer& buffer,
 }
 
 //==============================================================================
-AudioProcessorEditor* MidiStep::createEditor()
+juce::AudioProcessorEditor* MidiStep::createEditor()
 {
     return new StepEditor (this);
 }
 
 //==============================================================================
-void MidiStep::getStateInformation (MemoryBlock& destData)
+void MidiStep::getStateInformation (juce::MemoryBlock& destData)
 {
     // make sure the non-parameter settings are copied to the current program
     programs[curProgram].lastUIHeight = lastUIHeight;
@@ -427,13 +429,13 @@ void MidiStep::getStateInformation (MemoryBlock& destData)
     //save patterns
     for (int i = 0; i < numLoops; i++)
     {
-        MemoryBlock midiData (512, true);
-        MemoryOutputStream m (midiData, false);
+        juce::MemoryBlock midiData (512, true);
+        juce::MemoryOutputStream m (midiData, false);
 
-        MidiFile midifile;
+        juce::MidiFile midifile;
         midifile.setTicksPerQuarterNote (960);
 
-        MidiMessageSequence midi (*loop[i]);
+        juce::MidiMessageSequence midi (*loop[i]);
         midifile.addTrack (midi);
         midifile.writeTo (m);
         size_t dataSize = midiData.getSize();
@@ -441,18 +443,18 @@ void MidiStep::getStateInformation (MemoryBlock& destData)
         destData.append (midiData.getData(), dataSize);
     }
 
-    MemoryBlock xmlData (512);
+    juce::MemoryBlock xmlData (512);
 
-    XmlElement xmlState ("midiStepSettings");
+    juce::XmlElement xmlState ("midiStepSettings");
     xmlState.setAttribute ("pluginVersion", 2);
     xmlState.setAttribute ("program", getCurrentProgram());
     for (int p = 0; p < getNumPrograms(); p++)
     {
-        String prefix = "P" + String (p) + "_";
+        juce::String prefix = "P" + juce::String (p) + "_";
         xmlState.setAttribute (prefix + "progname", programs[p].name);
         for (int i = 0; i < kNumParams; i++)
         {
-            xmlState.setAttribute (prefix + String (i), programs[p].param[i]);
+            xmlState.setAttribute (prefix + juce::String (i), programs[p].param[i]);
         }
         xmlState.setAttribute (prefix + "uiWidth", programs[p].lastUIWidth);
         xmlState.setAttribute (prefix + "uiHeight", programs[p].lastUIHeight);
@@ -463,16 +465,16 @@ void MidiStep::getStateInformation (MemoryBlock& destData)
 
 void MidiStep::setStateInformation (const void* data, int sizeInBytes)
 {
-    uint8* datab      = (uint8*) data;
-    int totalMidiSize = 0;
+    juce::uint8* datab = (juce::uint8*) data;
+    int totalMidiSize  = 0;
     for (int i = 0; i < numLoops; i++)
     {
         loop[i]->clear();
         int midiSize = *((int*) datab);
         datab += sizeof (int);
         totalMidiSize += sizeof (midiSize);
-        MemoryInputStream m (datab, midiSize, true);
-        MidiFile midifile;
+        juce::MemoryInputStream m (datab, midiSize, true);
+        juce::MidiFile midifile;
         if (midifile.readFrom (m))
         {
             loop[i]->addSequence (*midifile.getTrack (midifile.getNumTracks() - 1), 0, 0, midifile.getLastTimestamp() + 1);
@@ -492,10 +494,10 @@ void MidiStep::setStateInformation (const void* data, int sizeInBytes)
         {
             for (int p = 0; p < getNumPrograms(); p++)
             {
-                String prefix = "P" + String (p) + "_";
+                juce::String prefix = "P" + juce::String (p) + "_";
                 for (int i = 0; i < kNumParams; i++)
                 {
-                    programs[p].param[i] = (float) xmlState->getDoubleAttribute (prefix + String (i), programs[p].param[i]);
+                    programs[p].param[i] = (float) xmlState->getDoubleAttribute (prefix + juce::String (i), programs[p].param[i]);
                 }
                 programs[p].lastUIWidth  = xmlState->getIntAttribute (prefix + "uiWidth", programs[p].lastUIWidth);
                 programs[p].lastUIHeight = xmlState->getIntAttribute (prefix + "uiHeight", programs[p].lastUIHeight);
@@ -508,14 +510,14 @@ void MidiStep::setStateInformation (const void* data, int sizeInBytes)
 }
 
 //==============================================================================
-bool MidiStep::writeMidiFile (int index, File& file)
+bool MidiStep::writeMidiFile (int index, juce::File& file)
 {
-    MidiFile midifile;
+    juce::MidiFile midifile;
     midifile.setTicksPerQuarterNote (960);
 
-    MidiMessageSequence midi (*loop[index]);
-    uint8 tn[]            = { 0xFF, 0x03, 4, 'l', 'o', 'o', 'p' };
-    MidiMessage trackname = MidiMessage (tn, 7, 0);
+    juce::MidiMessageSequence midi (*loop[index]);
+    juce::uint8 tn[]            = { 0xFF, 0x03, 4, 'l', 'o', 'o', 'p' };
+    juce::MidiMessage trackname = juce::MidiMessage (tn, 7, 0);
     midi.addEvent (trackname);
 
     midifile.addTrack (midi);
@@ -525,19 +527,19 @@ bool MidiStep::writeMidiFile (int index, File& file)
             return false;
     if (file.create())
     {
-        FileOutputStream fo (file);
+        juce::FileOutputStream fo (file);
         if (midifile.writeTo (fo))
             return true;
     }
     return false;
 }
 
-bool MidiStep::readMidiFile (int index, File& mid)
+bool MidiStep::readMidiFile (int index, juce::File& mid)
 {
     if (mid.exists())
     {
-        MidiFile midifile;
-        FileInputStream fi (mid);
+        juce::MidiFile midifile;
+        juce::FileInputStream fi (mid);
         if (midifile.readFrom (fi))
         {
             loop[index]->clear();

--- a/pizjuce/midiStep/step.h
+++ b/pizjuce/midiStep/step.h
@@ -34,12 +34,12 @@ private:
     float param[kNumParams];
 
     int lastUIWidth, lastUIHeight;
-    String name;
+    juce::String name;
 };
 
 //==============================================================================
 class MidiStep : public PizAudioProcessor,
-                 public ChangeBroadcaster
+                 public juce::ChangeBroadcaster
 {
 public:
     //==============================================================================
@@ -50,15 +50,15 @@ public:
     void prepareToPlay (double sampleRate, int samplesPerBlock) override;
     void releaseResources() override;
 
-    void processBlock (AudioSampleBuffer& buffer,
-                       MidiBuffer& midiMessages) override;
+    void processBlock (juce::AudioSampleBuffer& buffer,
+                       juce::MidiBuffer& midiMessages) override;
 
     //==============================================================================
-    AudioProcessorEditor* createEditor() override;
+    juce::AudioProcessorEditor* createEditor() override;
 
     //==============================================================================
     double getTailLengthSeconds() const override { return 0; }
-    const String getName() const override { return JucePlugin_Name; }
+    const juce::String getName() const override { return JucePlugin_Name; }
     bool hasEditor() const override { return true; }
     bool acceptsMidi() const override
     {
@@ -82,11 +82,11 @@ public:
     float getParameter (int index) override;
     void setParameter (int index, float newValue) override;
 
-    const String getParameterName (int index) override;
-    const String getParameterText (int index) override;
+    const juce::String getParameterName (int index) override;
+    const juce::String getParameterText (int index) override;
 
-    const String getInputChannelName (int channelIndex) const override;
-    const String getOutputChannelName (int channelIndex) const override;
+    const juce::String getInputChannelName (int channelIndex) const override;
+    const juce::String getOutputChannelName (int channelIndex) const override;
     bool isInputChannelStereoPair (int index) const override;
     bool isOutputChannelStereoPair (int index) const override;
 
@@ -95,37 +95,37 @@ public:
     int getNumPrograms() override { return 1; }
     int getCurrentProgram() override;
     void setCurrentProgram (int index) override;
-    const String getProgramName (int index) override;
-    void changeProgramName (int index, const String& newName) override;
+    const juce::String getProgramName (int index) override;
+    void changeProgramName (int index, const juce::String& newName) override;
 
     //==============================================================================
     //void getCurrentProgramStateInformation (MemoryBlock& destData);
     //void setCurrentProgramStateInformation (const void* data, int sizeInBytes);
-    void getStateInformation (MemoryBlock& destData) override;
+    void getStateInformation (juce::MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
 
     //==============================================================================
-    AudioPlayHead::CurrentPositionInfo lastPosInfo;
+    juce::AudioPlayHead::CurrentPositionInfo lastPosInfo;
     int lastUIWidth, lastUIHeight;
-    String loopDir;
+    juce::String loopDir;
     int activeLoop;
     Loop* getActiveLoop() { return loop[activeLoop]; }
-    bool writeMidiFile (int index, File& file);
-    bool readMidiFile (int index, File& mid);
-    MidiKeyboardState keyboardState;
+    bool writeMidiFile (int index, juce::File& file);
+    bool readMidiFile (int index, juce::File& mid);
+    juce::MidiKeyboardState keyboardState;
 
-    //==============================================================================
-    juce_UseDebuggingNewOperator
-
-        private : float param[kNumParams];
+private:
+    float param[kNumParams];
     JuceProgram* programs;
     int curProgram;
     bool init;
 
-    OwnedArray<Loop> loop;
-    uint64 samples;
-    Array<File> midiFiles;
+    juce::OwnedArray<Loop> loop;
+    juce::uint64 samples;
+    juce::Array<juce::File> midiFiles;
     bool wasRecording;
+
+    JUCE_LEAK_DETECTOR (MidiStep)
 };
 
 #endif

--- a/pizjuce/midiStep/stepgui.cpp
+++ b/pizjuce/midiStep/stepgui.cpp
@@ -23,6 +23,8 @@
 #include "stepgui.h"
 
 //[MiscUserDefs] You can add your own user definitions and misc code here...
+using juce::jlimit;
+using juce::roundToInt;
 //[/MiscUserDefs]
 
 //==============================================================================
@@ -37,7 +39,7 @@ StepEditor::StepEditor (MidiStep* const ownerFilter)
     addAndMakeVisible (activeLoopLabel.get());
     activeLoopLabel->setColour (juce::GroupComponent::outlineColourId, juce::Colour (0x66000000));
 
-    resizer.reset (new ResizableCornerComponent (this, &resizeLimits));
+    resizer.reset (new juce::ResizableCornerComponent (this, &resizeLimits));
     addAndMakeVisible (resizer.get());
 
     viewport.reset (new PianoPort ("new viewport"));
@@ -665,7 +667,7 @@ void StepEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     {
         //[UserButtonCode_recordButton] -- add your button handler code here..
         getFilter()->setParameterNotifyingHost (kRecord, recordButton->getToggleState() ? 0.f : 1.f);
-        recordButton->setToggleState (! recordButton->getToggleState(), dontSendNotification);
+        recordButton->setToggleState (! recordButton->getToggleState(), juce::dontSendNotification);
         //[/UserButtonCode_recordButton]
     }
     else if (buttonThatWasClicked == recArmButton1.get())
@@ -767,13 +769,13 @@ void StepEditor::buttonClicked (juce::Button* buttonThatWasClicked)
     else if (buttonThatWasClicked == saveButton.get())
     {
         //[UserButtonCode_saveButton] -- add your button handler code here..
-        FileChooser myChooser ("Export MIDI...",
-                               File (getFilter()->loopDir + File::getSeparatorString() + "Untitled.mid"),
-                               "*.mid");
+        juce::FileChooser myChooser ("Export MIDI...",
+                                     juce::File (getFilter()->loopDir + juce::File::getSeparatorString() + "Untitled.mid"),
+                                     "*.mid");
 
         if (myChooser.browseForFileToSave (true))
         {
-            File midiFile (myChooser.getResult());
+            juce::File midiFile (myChooser.getResult());
             if (! midiFile.hasFileExtension ("mid"))
                 midiFile = midiFile.withFileExtension ("mid");
 
@@ -851,7 +853,7 @@ void StepEditor::sliderValueChanged (juce::Slider* sliderThatWasMoved)
 }
 
 //[MiscUserCode] You can add your own definitions of your custom methods or any other code here...
-TextButton* StepEditor::getButtonByIndex (int i)
+juce::TextButton* StepEditor::getButtonByIndex (int i)
 {
     switch (i)
     {
@@ -892,44 +894,44 @@ TextButton* StepEditor::getButtonByIndex (int i)
     }
 }
 
-void StepEditor::recArmButtonClicked (Button* buttonThatWasClicked)
+void StepEditor::recArmButtonClicked (juce::Button* buttonThatWasClicked)
 {
     int index = buttonThatWasClicked->getButtonText().getIntValue() - 1;
-    if (ModifierKeys::getCurrentModifiers().isCommandDown())
+    if (juce::ModifierKeys::getCurrentModifiers().isCommandDown())
     {
-        buttonThatWasClicked->setToggleState (! buttonThatWasClicked->getToggleState(), dontSendNotification);
+        buttonThatWasClicked->setToggleState (! buttonThatWasClicked->getToggleState(), juce::dontSendNotification);
         getFilter()->setParameterNotifyingHost (kRecArm + index, buttonThatWasClicked->getToggleState() ? 1.f : 0.f);
     }
     else
     {
         getFilter()->setParameterNotifyingHost (kActiveLoop, (float) index / (float) (numLoops - 1));
         pianoRoll->setSequence (getFilter()->getActiveLoop());
-        activeLoopLabel->setText (String (getFilter()->activeLoop + 1));
+        activeLoopLabel->setText (juce::String (getFilter()->activeLoop + 1));
         for (int i = 0; i < numLoops; i++)
         {
-            getButtonByIndex (i)->setToggleState (i == index ? true : false, dontSendNotification);
+            getButtonByIndex (i)->setToggleState (i == index ? true : false, juce::dontSendNotification);
             if (toggleButton->getToggleState())
                 getFilter()->setParameterNotifyingHost (kRecArm + i, i == index ? 1.f : 0.f);
         }
     }
 }
 
-bool StepEditor::isInterestedInFileDrag (const StringArray& files)
+bool StepEditor::isInterestedInFileDrag (const juce::StringArray& files)
 {
-    File file = File (files[0]);
+    juce::File file = juce::File (files[0]);
     if (file.hasFileExtension ("mid"))
         return true;
     return false;
 }
 
-void StepEditor::filesDropped (const StringArray& filenames, int mouseX, int mouseY)
+void StepEditor::filesDropped (const juce::StringArray& filenames, int mouseX, int mouseY)
 {
-    File file (filenames[0]);
+    juce::File file (filenames[0]);
     if (getFilter()->readMidiFile (getFilter()->activeLoop, file))
         updateParameters (true);
 }
 
-void StepEditor::mouseWheelMove (const MouseEvent& e, float wheelIncrementX, float wheelIncrementY)
+void StepEditor::mouseWheelMove (const juce::MouseEvent& e, float wheelIncrementX, float wheelIncrementY)
 {
     if (e.eventComponent == viewport.get())
     {
@@ -959,7 +961,7 @@ void StepEditor::timerCallback()
     }
 }
 
-void StepEditor::changeListenerCallback (ChangeBroadcaster* source)
+void StepEditor::changeListenerCallback (juce::ChangeBroadcaster* source)
 {
     if (source == getFilter())
         updateParameters();
@@ -982,21 +984,21 @@ void StepEditor::updateParameters (bool updateLoop)
 
     for (int i = 0; i < numLoops; i++)
     {
-        getButtonByIndex (i)->setColour (TextButton::textColourOnId, i == activeLoop ? Colours::red : Colours::black);
-        getButtonByIndex (i)->setToggleState (param[kRecArm + i] >= 0.5f, dontSendNotification);
+        getButtonByIndex (i)->setColour (juce::TextButton::textColourOnId, i == activeLoop ? juce::Colours::red : juce::Colours::black);
+        getButtonByIndex (i)->setToggleState (param[kRecArm + i] >= 0.5f, juce::dontSendNotification);
     }
-    thruButton->setToggleState (param[kThru] >= 0.5f, dontSendNotification);
-    toggleButton->setToggleState (param[kRecActive] >= 0.5f, dontSendNotification);
-    recordButton->setToggleState (param[kRecord] >= 0.5f, dontSendNotification);
-    keySlider->setValue (floatToMidi (param[kTriggerKey + activeLoop], true), dontSendNotification);
-    transposeSlider->setValue (param[kTranspose + activeLoop] * 96.f - 48.f, dontSendNotification);
-    recChannelSlider->setValue (floatToChannel (param[kChannel + activeLoop]), dontSendNotification);
-    outChannelSlider->setValue (floatToChannel (param[kOutChannel + activeLoop]), dontSendNotification);
+    thruButton->setToggleState (param[kThru] >= 0.5f, juce::dontSendNotification);
+    toggleButton->setToggleState (param[kRecActive] >= 0.5f, juce::dontSendNotification);
+    recordButton->setToggleState (param[kRecord] >= 0.5f, juce::dontSendNotification);
+    keySlider->setValue (floatToMidi (param[kTriggerKey + activeLoop], true), juce::dontSendNotification);
+    transposeSlider->setValue (param[kTranspose + activeLoop] * 96.f - 48.f, juce::dontSendNotification);
+    recChannelSlider->setValue (floatToChannel (param[kChannel + activeLoop]), juce::dontSendNotification);
+    outChannelSlider->setValue (floatToChannel (param[kOutChannel + activeLoop]), juce::dontSendNotification);
     if (updateLoop || lastActiveLoop != activeLoop)
     {
         lastActiveLoop = activeLoop;
         pianoRoll->setSequence (getFilter()->getActiveLoop());
-        activeLoopLabel->setText (String (activeLoop + 1));
+        activeLoopLabel->setText (juce::String (activeLoop + 1));
     }
     else
         repaint();

--- a/pizjuce/midiStep/stepgui.h
+++ b/pizjuce/midiStep/stepgui.h
@@ -20,18 +20,18 @@
 #pragma once
 
 //[Headers]     -- You can add your own extra header files here --
-#include "juce_audio_processors/juce_audio_processors.h"
-#include "juce_events/juce_events.h"
-#include "juce_gui_basics/juce_gui_basics.h"
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_events/juce_events.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
 #include "../_common/ChannelSlider.h"
 #include "PianoRoll.h"
 #include "step.h"
-class PianoPort : public Viewport
+class PianoPort : public juce::Viewport
 {
 public:
-    PianoPort (String name) : Viewport (name){};
-    void mouseWheelMove (const MouseEvent& e, const MouseWheelDetails& d) override
+    PianoPort (juce::String name) : Viewport (name){};
+    void mouseWheelMove (const juce::MouseEvent& e, const juce::MouseWheelDetails& d) override
     {
         this->getParentComponent()->mouseWheelMove (e, d);
     }
@@ -62,12 +62,12 @@ public:
 
     //==============================================================================
     //[UserMethods]     -- You can add your own custom methods in this section.
-    bool isInterestedInFileDrag (const StringArray& files) override;
-    void filesDropped (const StringArray& filenames, int mouseX, int mouseY) override;
+    bool isInterestedInFileDrag (const juce::StringArray& files) override;
+    void filesDropped (const juce::StringArray& filenames, int mouseX, int mouseY) override;
     void timerCallback() override;
     void zoomIn (int centerPixel);
     void zoomOut (int centerPixel);
-    void mouseWheelMove (const MouseEvent& e, float wheelIncrementX, float wheelIncrementY);
+    void mouseWheelMove (const juce::MouseEvent& e, float wheelIncrementX, float wheelIncrementY);
     //[/UserMethods]
 
     void paint (juce::Graphics& g) override;
@@ -78,18 +78,18 @@ public:
 private:
     //[UserVariables]   -- You can add your own custom variables in this section.
     MidiStep* getFilter() const throw() { return (MidiStep*) getAudioProcessor(); }
-    void changeListenerCallback (ChangeBroadcaster* source) override;
+    void changeListenerCallback (juce::ChangeBroadcaster* source) override;
     void updateParameters (bool updateLoop = false);
-    ComponentBoundsConstrainer resizeLimits;
+    juce::ComponentBoundsConstrainer resizeLimits;
     PianoRoll* pianoRoll;
-    TextButton* getButtonByIndex (int i);
-    void recArmButtonClicked (Button* buttonThatWasClicked);
+    juce::TextButton* getButtonByIndex (int i);
+    void recArmButtonClicked (juce::Button* buttonThatWasClicked);
     int lastActiveLoop;
     //[/UserVariables]
 
     //==============================================================================
     std::unique_ptr<juce::GroupComponent> activeLoopLabel;
-    std::unique_ptr<ResizableCornerComponent> resizer;
+    std::unique_ptr<juce::ResizableCornerComponent> resizer;
     std::unique_ptr<PianoPort> viewport;
     std::unique_ptr<juce::TextButton> recordButton;
     std::unique_ptr<ChannelSlider> outChannelSlider;


### PR DESCRIPTION
While trying and failing to solve the current main issues of MiddyMorphy, I thought it might be better to at least make the code base a little bit more consistent as a start.

Feel free to make me revert some of it: 
- remove juce namespace usage and add juce:: where needed accordingly (avoids mixed usage with and without prefix)
- reduce public and private sections in header files and move constructor and destructor to beginning
- solve some clang-tidy hints (esp. nullptr and shadowed vars)
- remove autogenerated comments (feel free to enlighten me in case you know and use it, but I'd rather not promote a tool that adds so much clutter..)
- remove some legacy commented out code and other comments